### PR TITLE
Support train-from-scratch for G2 families

### DIFF
--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -59,7 +59,7 @@ def _create_explicit_task_train_model(
 ):
     """Build a known architecture when training must not load a checkpoint.
 
-    Scratch training covers every G0/G1 family. The older transfer path below
+    Scratch training covers every G0/G1/G2 family. The older transfer path below
     remains limited to families that need a task-specific architecture before
     loading their published checkpoint.
     """
@@ -69,7 +69,7 @@ def _create_explicit_task_train_model(
         from libreyolo.models.registry import group_of
 
         model_cls = get_model_class(family)
-        if model_cls is not None and group_of(family) in {"g0", "g1"}:
+        if model_cls is not None and group_of(family) in {"g0", "g1", "g2"}:
             size = model_cls.detect_size_from_filename(Path(model_path).name)
             if size is None:
                 return None
@@ -79,11 +79,16 @@ def _create_explicit_task_train_model(
                 else model_cls.detect_task_from_filename(Path(model_path).name)
                 or model_cls.DEFAULT_TASK
             )
+            scratch_kwargs = {}
+            variant = model_cls.detect_variant_from_filename(Path(model_path).name)
+            if variant is not None:
+                scratch_kwargs["weight_variant"] = variant
             return model_cls._from_scratch(
                 size=size,
                 task=train_task,
                 device=device,
                 seed=seed,
+                **scratch_kwargs,
             )
 
     if family not in {"yolo9", "rfdetr", "dfine"} or resume:
@@ -465,7 +470,7 @@ def train_cmd(
     if train_pretrained is False and resume_val:
         from libreyolo.models.registry import group_of
 
-        if group_of(family) in {"g0", "g1"}:
+        if group_of(family) in {"g0", "g1", "g2"}:
             exit_with_error(
                 out,
                 "config_unsupported",

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -169,9 +169,10 @@ def _iter_model_classes():
             seen.add(cls)
             yield cls
 
-    rfcls = try_ensure_rfdetr()
-    if rfcls is not None and rfcls not in seen:
-        yield rfcls
+    try_ensure_rfdetr()
+    for cls in BaseModel._registry:
+        if cls not in seen:
+            yield cls
 
 
 def get_model_class(family: str | None):

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -96,7 +96,7 @@ def _wrap_train_with_cfg(train_fn: Callable) -> Callable:
         if merged.get("pretrained") is False:
             from ..registry import group_of
 
-            if group_of(self.FAMILY) in {"g0", "g1"}:
+            if group_of(self.FAMILY) in {"g0", "g1", "g2"}:
                 bound = sig.bind_partial(self, *args, **merged)
                 bound.apply_defaults()
                 extras = next(

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -69,6 +69,7 @@ class _DINOv2ModelWrapper(nn.Module):
         config: str,
         nb_classes: int,
         device: str = "cpu",
+        load_dinov2_weights: bool = True,
     ) -> None:
         super().__init__()
         # Lazy import so the outer module-level import stays rfdetr-free.
@@ -78,7 +79,10 @@ class _DINOv2ModelWrapper(nn.Module):
         # the dense-head path (uses the segmenter freeze layout).
         self.model: nn.Module | None = None
         self.segmenter = RFDETRSemanticSegmenter(
-            config=config, nb_classes=nb_classes, device=device
+            config=config,
+            nb_classes=nb_classes,
+            device=device,
+            load_dinov2_weights=load_dinov2_weights,
         )
         self.nb_classes = nb_classes
         self.resolution = self.segmenter.resolution
@@ -119,6 +123,7 @@ class _DINOv2ClassifierWrapper(nn.Module):
         config: str,
         nb_classes: int,
         device: str = "cpu",
+        load_dinov2_weights: bool = True,
     ) -> None:
         super().__init__()
         # Lazy import so the outer module-level import stays rfdetr-free.
@@ -128,7 +133,10 @@ class _DINOv2ClassifierWrapper(nn.Module):
         # the linear-head path (uses the classifier freeze layout).
         self.model: nn.Module | None = None
         self.classifier = RFDETRClassifier(
-            config=config, nb_classes=nb_classes, device=device
+            config=config,
+            nb_classes=nb_classes,
+            device=device,
+            load_dinov2_weights=load_dinov2_weights,
         )
         self.nb_classes = nb_classes
         self.resolution = self.classifier.resolution
@@ -156,7 +164,12 @@ class _DINOv2ClassifierWrapper(nn.Module):
 class _DINOv2EmbedderWrapper(nn.Module):
     """DINOv2 backbone-only wrapper returning the final CLS token."""
 
-    def __init__(self, config: str, device: str = "cpu") -> None:
+    def __init__(
+        self,
+        config: str,
+        device: str = "cpu",
+        load_dinov2_weights: bool = True,
+    ) -> None:
         super().__init__()
         from ..rfdetr.nn import RFDETRClassifier
 
@@ -165,6 +178,7 @@ class _DINOv2EmbedderWrapper(nn.Module):
             nb_classes=1,
             device=device,
             dropout=0.0,
+            load_dinov2_weights=load_dinov2_weights,
         )
         # Retain only the encoder. The classifier backbone's projector is not
         # used for CLS extraction; keeping its random parameters would waste
@@ -407,21 +421,25 @@ class LibreDINOv2(BaseModel):
     # =========================================================================
 
     def _init_model(self) -> nn.Module:
+        load_dinov2_weights = not self._is_scratch_build()
         if self.task == "classify":
             return _DINOv2ClassifierWrapper(
                 config=self.size,
                 nb_classes=self._model_num_classes,
                 device=str(self.device),
+                load_dinov2_weights=load_dinov2_weights,
             )
         if self.task == "embed":
             return _DINOv2EmbedderWrapper(
                 config=self.size,
                 device=str(self.device),
+                load_dinov2_weights=load_dinov2_weights,
             )
         return _DINOv2ModelWrapper(
             config=self.size,
             nb_classes=self._model_num_classes,
             device=str(self.device),
+            load_dinov2_weights=load_dinov2_weights,
         )
 
     def _rebuild_for_new_classes(self, new_nc: int) -> None:

--- a/libreyolo/models/domedetr/model.py
+++ b/libreyolo/models/domedetr/model.py
@@ -212,6 +212,7 @@ class LibreDOMEDETR(BaseModel):
             nb_classes=self.nb_classes,
             variant=getattr(self, "weight_variant", DEFAULT_VARIANT),
             eval_spatial_size=(self.input_size, self.input_size),
+            train_from_scratch=self._is_scratch_build(),
         )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:

--- a/libreyolo/models/domedetr/nn.py
+++ b/libreyolo/models/domedetr/nn.py
@@ -82,6 +82,7 @@ class LibreDOMEDETRModel(nn.Module):
         variant: str = DEFAULT_VARIANT,
         eval_spatial_size: tuple[int, int] | None = EVAL_SPATIAL_SIZE,
         activation: str = "relu",
+        train_from_scratch: bool = False,
     ):
         super().__init__()
         if config not in SIZE_CONFIGS:
@@ -99,9 +100,9 @@ class LibreDOMEDETRModel(nn.Module):
             name=cfg["backbone"],
             use_lab=cfg["use_lab"],
             return_idx=(0, 1, 2, 3),
-            freeze_stem_only=True,
+            freeze_stem_only=not train_from_scratch,
             freeze_at=-1,
-            freeze_norm=cfg["freeze_norm"],
+            freeze_norm=False if train_from_scratch else cfg["freeze_norm"],
             pretrained=False,
         )
         self.encoder = DomeHybridEncoder(

--- a/libreyolo/models/lingbotvision/model.py
+++ b/libreyolo/models/lingbotvision/model.py
@@ -336,11 +336,15 @@ class LibreLingBotVision(BaseModel):
         loggers=None,
         **kwargs,
     ) -> Dict:
-        """Train the dense head on a semantic dataset (backbone frozen by
-        default — the report's linear-probing recipe). Pass
-        ``freeze_backbone=False`` to fine-tune the whole network.
+        """Train on a semantic dataset.
+
+        Fine-tuning keeps the report's linear-probe default. Scratch training
+        trains the random backbone unless ``freeze_backbone`` is explicit.
         """
         from .trainer import LingBotVisionTrainer
+
+        if self._is_scratch_build():
+            kwargs.setdefault("freeze_backbone", False)
 
         train_kwargs = dict(
             data=data,

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -406,6 +406,7 @@ class RFDETRClassifier(nn.Module):
         nb_classes: int = 1000,
         device: str = "cpu",
         dropout: float = 0.2,
+        load_dinov2_weights: bool = True,
     ):
         super().__init__()
         if config not in RFDETR_CONFIGS:
@@ -421,7 +422,7 @@ class RFDETRClassifier(nn.Module):
         self.num_windows = self._NUM_WINDOWS
         self.resolution = 224
 
-        joiner = self._build_backbone(cfg, device)
+        joiner = self._build_backbone(cfg, device, load_dinov2_weights)
         # joiner = Sequential(Backbone, PositionEmbedding); classification only
         # needs the Backbone (DINOv2 encoder + projector) — drop the position
         # encoding so its parameters are not carried around unused.
@@ -431,7 +432,12 @@ class RFDETRClassifier(nn.Module):
         self.drop = nn.Dropout(p=dropout)
         self.linear = nn.Linear(self.hidden_dim, nb_classes)
 
-    def _build_backbone(self, cfg: RFDETRSizeConfig, device: str):
+    def _build_backbone(
+        self,
+        cfg: RFDETRSizeConfig,
+        device: str,
+        load_dinov2_weights: bool,
+    ):
         kwargs = dict(
             encoder=cfg.encoder,
             vit_encoder_num_layers=12,
@@ -455,6 +461,8 @@ class RFDETRClassifier(nn.Module):
             num_windows=self._NUM_WINDOWS,
             positional_encoding_size=self._POS_ENC_SIZE,
         )
+        if not load_dinov2_weights:
+            return build_backbone(load_dinov2_weights=False, **kwargs)
         try:
             return build_backbone(load_dinov2_weights=True, **kwargs)
         except Exception as exc:  # pragma: no cover - offline / hub failure
@@ -515,6 +523,7 @@ class RFDETRSemanticSegmenter(nn.Module):
         nb_classes: int = 19,
         device: str = "cpu",
         dropout: float = 0.1,
+        load_dinov2_weights: bool = True,
     ):
         super().__init__()
         if config not in RFDETR_CONFIGS:
@@ -529,7 +538,7 @@ class RFDETRSemanticSegmenter(nn.Module):
         self.num_windows = self._NUM_WINDOWS
         self.resolution = self._POS_ENC_SIZE * self._PATCH_SIZE  # 518
 
-        joiner = self._build_backbone(cfg, device)
+        joiner = self._build_backbone(cfg, device, load_dinov2_weights)
         # joiner = Sequential(Backbone, PositionEmbedding); the dense decoder
         # only needs the Backbone (DINOv2 encoder + projector).
         self.backbone = joiner[0]
@@ -551,7 +560,12 @@ class RFDETRSemanticSegmenter(nn.Module):
         self.register_buffer("pixel_mean", mean, persistent=False)
         self.register_buffer("pixel_std", std, persistent=False)
 
-    def _build_backbone(self, cfg: RFDETRSizeConfig, device: str):
+    def _build_backbone(
+        self,
+        cfg: RFDETRSizeConfig,
+        device: str,
+        load_dinov2_weights: bool,
+    ):
         kwargs = dict(
             encoder=cfg.encoder,
             vit_encoder_num_layers=12,
@@ -575,6 +589,8 @@ class RFDETRSemanticSegmenter(nn.Module):
             num_windows=self._NUM_WINDOWS,
             positional_encoding_size=self._POS_ENC_SIZE,
         )
+        if not load_dinov2_weights:
+            return build_backbone(load_dinov2_weights=False, **kwargs)
         try:
             return build_backbone(load_dinov2_weights=True, **kwargs)
         except Exception as exc:  # pragma: no cover - offline / hub failure

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -111,7 +111,16 @@ def _build_init_kw(model_instance: Any) -> dict:
         "_class": cls.__name__,
         "device": "auto",
     }
-    for attr in ("size", "nb_classes", "reg_max", "task", "num_masks", "proto_channels", "num_keypoints"):
+    for attr in (
+        "size",
+        "nb_classes",
+        "reg_max",
+        "task",
+        "num_masks",
+        "proto_channels",
+        "num_keypoints",
+        "weight_variant",
+    ):
         if (attr in supported or supports_kwargs) and hasattr(model_instance, attr):
             kw[attr] = getattr(model_instance, attr)
     if supports_kwargs and getattr(model_instance, "_training_from_scratch", False):

--- a/tests/e2e/test_profile_training_families.py
+++ b/tests/e2e/test_profile_training_families.py
@@ -210,6 +210,15 @@ CASES = [
         "classify_dataset",
         {"imgsz": 224},
     ),
+    (
+        "domedetr",
+        "LibreDOMEDETR",
+        "s",
+        None,
+        {"weight_variant": "aitod"},
+        "detect_dataset",
+        {"imgsz": 320, "multi_scale": False},
+    ),
 ]
 
 
@@ -353,7 +362,11 @@ def test_profile_emits_report(
         profile_steps=2,
         profile_open=False,
         eval_interval=100,
-        **({"pretrained": False} if group_of(family) in {"g0", "g1"} else {}),
+        **(
+            {"pretrained": False}
+            if group_of(family) in {"g0", "g1", "g2"}
+            else {}
+        ),
         **extra,
     )
 

--- a/tests/unit/test_train_from_scratch.py
+++ b/tests/unit/test_train_from_scratch.py
@@ -1,4 +1,4 @@
-"""G0/G1 train-from-scratch contracts."""
+"""G0/G1/G2 train-from-scratch contracts."""
 
 from __future__ import annotations
 
@@ -18,20 +18,34 @@ from libreyolo.models.registry import families_in
 
 pytestmark = pytest.mark.unit
 
-SCRATCH_FAMILIES = families_in("g0") + families_in("g1")
+SCRATCH_FAMILIES = families_in("g0") + families_in("g1") + families_in("g2")
 CLI_CASES = (
-    ("yolo9-t", "yolo9", "t"),
-    ("rfdetr-n", "rfdetr", "n"),
-    ("yolo9_e2e-t", "yolo9_e2e", "t"),
-    ("yolo9_p2-t", "yolo9_p2", "t"),
-    ("ec-s", "ec", "s"),
-    ("rtdetr-r18", "rtdetr", "r18"),
-    ("rtdetrv2-r18", "rtdetrv2", "r18"),
-    ("rtdetrv4-s", "rtdetrv4", "s"),
-    ("dfine-n", "dfine", "n"),
-    ("deim-n", "deim", "n"),
-    ("deimv2-atto", "deimv2", "atto"),
-    ("yolonas-s", "yolonas", "s"),
+    ("yolo9-t", "yolo9", "t", "detect"),
+    ("rfdetr-n", "rfdetr", "n", "detect"),
+    ("yolo9_e2e-t", "yolo9_e2e", "t", "detect"),
+    ("yolo9_p2-t", "yolo9_p2", "t", "detect"),
+    ("ec-s", "ec", "s", "detect"),
+    ("rtdetr-r18", "rtdetr", "r18", "detect"),
+    ("rtdetrv2-r18", "rtdetrv2", "r18", "detect"),
+    ("rtdetrv4-s", "rtdetrv4", "s", "detect"),
+    ("dfine-n", "dfine", "n", "detect"),
+    ("deim-n", "deim", "n", "detect"),
+    ("deimv2-atto", "deimv2", "atto", "detect"),
+    ("yolonas-s", "yolonas", "s", "detect"),
+    ("yolox-t", "yolox", "t", "detect"),
+    ("yolo7-b", "yolo7", "b", "detect"),
+    ("rtmdet-t", "rtmdet", "t", "detect"),
+    ("picodet-s", "picodet", "s", "detect"),
+    ("fomo-s", "fomo", "s", "point"),
+    ("segformer-b0", "segformer", "b0", "semantic"),
+    ("lingbotvision-s", "lingbotvision", "s", "semantic"),
+    ("dinov2-s", "dinov2", "s", "semantic"),
+    ("nafnet-s", "nafnet", "s", "restore"),
+    ("resnet-18", "resnet", "18", "classify"),
+    ("convnext-t", "convnext", "t", "classify"),
+    ("mobilenetv4-s", "mobilenetv4", "s", "classify"),
+    ("efficientnetv2-b0", "efficientnetv2", "b0", "classify"),
+    ("domedetr-s", "domedetr", "s", "detect"),
 )
 
 
@@ -68,14 +82,14 @@ def test_pretrained_false_rejects_resume_before_reset(family):
         model.train("unused.yaml", pretrained=False, resume=True)
 
 
-def test_scratch_handling_does_not_change_g2_behavior():
+def test_scratch_handling_does_not_change_g3_behavior():
     captured = {}
 
     class Wrapper:
-        FAMILY = "yolox"
+        FAMILY = "detr"
 
         def _reset_for_scratch(self, **_kwargs):
-            pytest.fail("G2 behavior must remain unchanged")
+            pytest.fail("G3 behavior must remain unchanged")
 
     def train(_self, data, **kwargs):
         captured.update(data=data, kwargs=kwargs)
@@ -132,6 +146,20 @@ def test_ddp_workers_rebuild_with_the_scratch_policy():
     model._training_from_scratch = True
 
     assert _build_init_kw(model)["_scratch_init"] is True
+
+
+def test_ddp_workers_preserve_checkpoint_variant():
+    from libreyolo.training.ddp_spawn import _build_init_kw
+
+    class Wrapper:
+        def __init__(self, size, **kwargs):
+            pass
+
+    model = Wrapper.__new__(Wrapper)
+    model.size = "s"
+    model.weight_variant = "visdrone"
+
+    assert _build_init_kw(model)["weight_variant"] == "visdrone"
 
 
 def test_yolo9_scratch_reset_is_seeded_and_discards_loaded_state():
@@ -233,6 +261,71 @@ def test_rfdetr_ddp_scratch_worker_loads_temporary_state(monkeypatch):
     assert model._training_from_scratch is True
 
 
+@pytest.mark.parametrize("task", ["semantic", "classify"])
+def test_dinov2_scratch_reset_skips_pretrained_backbone(monkeypatch, task):
+    import libreyolo.models.rfdetr.nn as rfdetr_nn
+    from libreyolo.models.dinov2.model import LibreDINOv2
+
+    backbone_loads = []
+
+    def build_backbone(*, load_dinov2_weights, **_kwargs):
+        backbone_loads.append(load_dinov2_weights)
+        return nn.Sequential(nn.Identity(), nn.Identity())
+
+    monkeypatch.setattr(rfdetr_nn, "build_backbone", build_backbone)
+    model = LibreDINOv2(
+        None,
+        size="n",
+        nb_classes=3,
+        device="cpu",
+        task=task,
+    )
+    model._reset_for_scratch(seed=7)
+
+    assert backbone_loads == [True, False]
+    assert all(parameter.requires_grad for parameter in model.model.parameters())
+
+
+@pytest.mark.parametrize(
+    "scratch,freeze,expected",
+    [
+        (False, None, None),
+        (True, None, False),
+        (True, True, True),
+    ],
+    ids=["finetune-default", "scratch-default", "scratch-explicit-freeze"],
+)
+def test_lingbotvision_scratch_default_trains_backbone(
+    monkeypatch, scratch, freeze, expected
+):
+    import libreyolo.models.lingbotvision.trainer as trainer_module
+    from libreyolo.models.lingbotvision.model import LibreLingBotVision
+
+    captured = {}
+
+    class Trainer:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def train(self):
+            return {}
+
+    monkeypatch.setattr(trainer_module, "LingBotVisionTrainer", Trainer)
+    model = LibreLingBotVision.__new__(LibreLingBotVision)
+    model.model = nn.Identity()
+    model.size = "s"
+    model.nb_classes = 3
+    model.input_size = 512
+    model.device = torch.device("cpu")
+    model._training_from_scratch = scratch
+    model._restore_after_training = lambda _result: None
+
+    kwargs = {} if freeze is None else {"freeze_backbone": freeze}
+    model.train("unused.yaml", device="cpu", **kwargs)
+
+    assert captured.get("freeze_backbone") is expected
+
+
 @pytest.mark.parametrize(
     "module_name,class_name,decoder_name",
     [
@@ -270,12 +363,37 @@ def test_hgnet_scratch_build_only_disables_finetune_freezes(
     ) == expected
 
 
+@pytest.mark.parametrize("scratch", [False, True], ids=["finetune", "scratch"])
+def test_domedetr_scratch_policy_reaches_hgnet(monkeypatch, scratch):
+    import libreyolo.models.domedetr.nn as module
+
+    captured = {}
+    monkeypatch.setattr(
+        module,
+        "HGNetv2",
+        lambda **kwargs: captured.update(kwargs) or nn.Identity(),
+    )
+    monkeypatch.setattr(module, "DomeHybridEncoder", lambda **_kwargs: nn.Identity())
+    monkeypatch.setattr(module, "DomeTransformer", lambda **_kwargs: nn.Identity())
+
+    module.LibreDOMEDETRModel(config="l", train_from_scratch=scratch)
+
+    cfg = module.SIZE_CONFIGS["l"]
+    expected = (False, -1, False) if scratch else (True, -1, cfg["freeze_norm"])
+    assert (
+        captured["freeze_stem_only"],
+        captured["freeze_at"],
+        captured["freeze_norm"],
+    ) == expected
+
+
 @pytest.mark.parametrize(
     "module_name,class_name,model_name",
     [
         ("libreyolo.models.dfine.model", "LibreDFINE", "LibreDFINEModel"),
         ("libreyolo.models.deim.model", "LibreDEIM", "LibreDEIMModel"),
         ("libreyolo.models.rtdetrv4.model", "LibreRTDETRv4", "LibreDFINEModel"),
+        ("libreyolo.models.domedetr.model", "LibreDOMEDETR", "LibreDOMEDETRModel"),
     ],
 )
 def test_hgnet_wrappers_preserve_scratch_policy_on_rebuild(
@@ -302,12 +420,12 @@ def test_hgnet_wrappers_preserve_scratch_policy_on_rebuild(
 
 
 @pytest.mark.parametrize(
-    "alias,family,size",
+    "alias,family,size,task",
     CLI_CASES,
     ids=[case[1] for case in CLI_CASES],
 )
 def test_cli_known_alias_builds_scratch_without_loading_weights(
-    monkeypatch, tmp_path, alias, family, size
+    monkeypatch, alias, family, size, task
 ):
     import libreyolo.cli.commands.train as train_module
 
@@ -318,12 +436,12 @@ def test_cli_known_alias_builds_scratch_without_loading_weights(
 
         def train(self, data, **kwargs):
             captured["train"] = {"data": data, "kwargs": kwargs}
-            return {"output_dir": str(tmp_path / "run")}
+            return {"output_dir": "unused-run"}
 
     ScratchModel.FAMILY = family
 
     class ScratchClass:
-        DEFAULT_TASK = "detect"
+        DEFAULT_TASK = task
 
         @classmethod
         def detect_size_from_filename(cls, _filename):
@@ -331,6 +449,10 @@ def test_cli_known_alias_builds_scratch_without_loading_weights(
 
         @classmethod
         def detect_task_from_filename(cls, _filename):
+            return None
+
+        @classmethod
+        def detect_variant_from_filename(cls, _filename):
             return None
 
         @classmethod
@@ -355,7 +477,7 @@ def test_cli_known_alias_builds_scratch_without_loading_weights(
             "pretrained=false",
             "epochs=1",
             "seed=29",
-            f"project={tmp_path}",
+            "project=unused-project",
             "exist_ok=true",
             "--json",
         ],
@@ -365,9 +487,56 @@ def test_cli_known_alias_builds_scratch_without_loading_weights(
     assert json.loads(result.stdout)["model_family"] == family
     assert captured["init"] == {
         "size": size,
-        "task": "detect",
+        "task": task,
         "device": "auto",
         "seed": 29,
     }
     assert captured["train"]["data"] == "unused.yaml"
     assert "pretrained" not in captured["train"]["kwargs"]
+
+
+def test_cli_scratch_build_preserves_filename_variant(monkeypatch):
+    import libreyolo.cli.commands.train as train_module
+
+    captured = {}
+
+    class ScratchClass:
+        DEFAULT_TASK = "detect"
+
+        @classmethod
+        def detect_size_from_filename(cls, _filename):
+            return "s"
+
+        @classmethod
+        def detect_task_from_filename(cls, _filename):
+            return None
+
+        @classmethod
+        def detect_variant_from_filename(cls, _filename):
+            return "visdrone"
+
+        @classmethod
+        def _from_scratch(cls, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    monkeypatch.setattr(train_module, "get_model_class", lambda _family: ScratchClass)
+
+    model = train_module._create_explicit_task_train_model(
+        family="domedetr",
+        model_path="LibreDOMEDETRs-visdrone.pt",
+        task=None,
+        resume=False,
+        device="cpu",
+        pretrained=False,
+        seed=31,
+    )
+
+    assert model is not None
+    assert captured == {
+        "size": "s",
+        "task": "detect",
+        "device": "cpu",
+        "seed": 31,
+        "weight_variant": "visdrone",
+    }


### PR DESCRIPTION
Closes #730.

- Extends `pretrained=False` API and CLI scratch initialization to all G2 trainable families.
- Skips DINOv2 pretrained-backbone loading for scratch builds, trains LingBotVision's random backbone by default, and preserves DomeDETR variants through CLI and DDP reconstruction.
- Changes shared behavior only for G2 calls with `pretrained=False`; G3 and normal fine-tuning paths remain unchanged.
- Not verified: multi-GPU DDP and long-run convergence.

## Code provenance

All changes are original LibreYOLO integration and test code written for this PR using existing repository interfaces. No third-party code was copied, adapted, or derived.

## Verification

- Ruff checks passed.
- Focused suite: 181 passed, 5 skipped.
- All 14 G2 families completed real GPU scratch forward/backward training; registry enrollment passed.
- Greptile completed with no comments on this feature diff.
- The full serial Windows unit run stopped after 1,032 passes on the existing YOLO2/NCNN blocked-export mismatch.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends scratch initialization across G2 model families while preserving family-specific variants and distributed reconstruction.
- Adds G2 scratch construction to the CLI and shared model training wrapper.
- Avoids pretrained DINOv2 backbone initialization during scratch builds.
- Carries Dome-DETR variants and scratch state through CLI and DDP reconstruction.
- Adds focused scratch-training and family-enrollment coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/cli/commands/train.py | Extends explicit scratch construction and resume validation to G2 families while forwarding filename-derived variants. |
| libreyolo/models/base/model.py | Enables the shared scratch-reset lifecycle for G2 model wrappers. |
| libreyolo/models/dinov2/model.py | Propagates scratch state so DINOv2 wrappers can skip pretrained backbone loading. |
| libreyolo/models/domedetr/model.py | Passes scratch lifecycle state into Dome-DETR model construction. |
| libreyolo/models/domedetr/nn.py | Adjusts Dome-DETR initialization behavior for train-from-scratch construction. |
| libreyolo/models/lingbotvision/model.py | Updates LingBotVision backbone initialization semantics for scratch training. |
| libreyolo/models/rfdetr/nn.py | Makes DINOv2 pretrained-backbone loading configurable for scratch builds. |
| libreyolo/training/ddp_spawn.py | Preserves family-specific construction metadata when spawning distributed workers. |
| tests/unit/test_train_from_scratch.py | Expands focused coverage for G2 scratch initialization and reconstruction behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  CLI["CLI train pretrained=false"] --> Resolve["Resolve family, size, task, and variant"]
  Resolve --> Scratch["_from_scratch()"]
  Scratch --> Family["Initialize G2 family without pretrained weights"]
  Family --> Train["Run family trainer"]
  Train --> DDP["Reconstruct equivalent model in DDP workers"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix lazy model registration lookup"](https://github.com/libreyolo/libreyolo/commit/3951425066a7e7e02ac0061765cae7fd8fd56555) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51455768)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
</details>

<!-- /greptile_comment -->