### PR TITLE
Support torch-free ONNX inference (pip install --no-deps)

### DIFF
--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -3,94 +3,105 @@
 from importlib.metadata import version, PackageNotFoundError
 from pathlib import Path as _Path
 
-# Core API — always available
-from .models import (
-    LibreYOLO,
-    LibreYOLOX,
-    LibreYOLO9,
-    LibreYOLO9E2E,
-    LibreYOLO9P2,
-    LibreYOLONAS,
-    LibreDFINE,
-    LibreDOMEDETR,
-    LibreDEIM,
-    LibreDEIMv2,
-    LibreDETR,
-    LibreDeformableDETR,
-    LibreDINODETR,
-    LibreLWDETR,
-    LibreMaskRCNN,
-    LibreFCOS,
-    LibreFasterRCNN,
-    LibreRetinaNet,
-    LibreSSD,
-    LibreCenterNet,
-    LibreEfficientDet,
-    LibreEC,
-    LibrePICODET,
-    LibreRTDETR,
-    LibreRTDETRv2,
-    LibreRTDETRv4,
-    LibreRTMDet,
-    LibreYOLO3,
-    LibreYOLO4,
-    LibreYOLO2,
-    LibreYOLO1,
-    LibreYOLO7,
-    LibreHRNet,
-    LibreL2CS,
-    LibreFOMO,
-    LibreMiDaS,
-    LibreDepthAnythingV2,
-    LibreZipDepth,
-    LibreMoGe2,
-    LibreTEED,
-    LibreDexiNed,
-    LibreDepthAnything3,
-    LibreNAFNet,
-    LibreBiRefNet,
-    LibreFeyNobg,
-    LibreRealESRGAN,
-    LibreSwinIR,
-    LibreFCN,
-    LibreEoMT,
-    LibreDeepLabv3,
-    LibrePIDNet,
-    LibreSegformer,
-    LibreLingBotVision,
-    LibreViT,
-    LibreMobileNetV4,
-    LibreConvNeXt,
-    LibreDeiT,
-    LibreSwin,
-    LibreEfficientNetV2,
-    LibreVGG,
-    LibreResNet,
-    LibreAlexNet,
-    LibreCLIP,
-    LibreSigLIP2,
-    LibrePPOCR,
+# Core API — resolved lazily through ``__getattr__`` so that ``import
+# libreyolo`` does not pull torch. The ONNX inference path (backends/onnx.py +
+# BaseBackend._build_result) is numpy-native, which lets a ``pip install
+# --no-deps libreyolo`` deployment run inference without the torch wheel.
+# See https://github.com/LibreYOLO/libreyolo/discussions/711.
+#
+# Laziness lives ONLY at this level. ``models/__init__.py`` stays eager and
+# atomic: it builds the can_load() registry as an import side effect and its
+# import ORDER is load-bearing (first match wins, so e.g. LibreYOLO9P2 must
+# register before LibreYOLO9). Touching any model name here imports that whole
+# module in one go, so the registry is never observed half-populated. Do not
+# make the per-family imports in models/__init__.py lazy.
+_MODEL_EXPORTS = (
+    "LibreYOLO",
+    "LibreYOLOX",
+    "LibreYOLO9",
+    "LibreYOLO9E2E",
+    "LibreYOLO9P2",
+    "LibreYOLONAS",
+    "LibreDFINE",
+    "LibreDOMEDETR",
+    "LibreDEIM",
+    "LibreDEIMv2",
+    "LibreDETR",
+    "LibreDeformableDETR",
+    "LibreDINODETR",
+    "LibreLWDETR",
+    "LibreMaskRCNN",
+    "LibreFCOS",
+    "LibreFasterRCNN",
+    "LibreRetinaNet",
+    "LibreSSD",
+    "LibreCenterNet",
+    "LibreEfficientDet",
+    "LibreEC",
+    "LibrePICODET",
+    "LibreRTDETR",
+    "LibreRTDETRv2",
+    "LibreRTDETRv4",
+    "LibreRTMDet",
+    "LibreYOLO3",
+    "LibreYOLO4",
+    "LibreYOLO2",
+    "LibreYOLO1",
+    "LibreYOLO7",
+    "LibreHRNet",
+    "LibreL2CS",
+    "LibreFOMO",
+    "LibreMiDaS",
+    "LibreDepthAnythingV2",
+    "LibreZipDepth",
+    "LibreMoGe2",
+    "LibreTEED",
+    "LibreDexiNed",
+    "LibreDepthAnything3",
+    "LibreNAFNet",
+    "LibreBiRefNet",
+    "LibreFeyNobg",
+    "LibreRealESRGAN",
+    "LibreSwinIR",
+    "LibreFCN",
+    "LibreEoMT",
+    "LibreDeepLabv3",
+    "LibrePIDNet",
+    "LibreSegformer",
+    "LibreLingBotVision",
+    "LibreViT",
+    "LibreMobileNetV4",
+    "LibreConvNeXt",
+    "LibreDeiT",
+    "LibreSwin",
+    "LibreEfficientNetV2",
+    "LibreVGG",
+    "LibreResNet",
+    "LibreAlexNet",
+    "LibreCLIP",
+    "LibreSigLIP2",
+    "LibrePPOCR",
 )
-from .utils.results import (
-    Results,
-    Boxes,
-    Masks,
-    Keypoints,
-    Points,
-    Probs,
-    OBB,
-    Gaze,
-    SemanticMask,
-    PanopticSegmentation,
-    DepthMap,
-    EdgeMap,
-    NormalMap,
-    RestoredImage,
-    Matte,
-    Meshes,
-    OCRRegions,
-    Embeddings,
-    Identities,
+_RESULTS_EXPORTS = (
+    "Results",
+    "Boxes",
+    "Masks",
+    "Keypoints",
+    "Points",
+    "Probs",
+    "OBB",
+    "Gaze",
+    "SemanticMask",
+    "PanopticSegmentation",
+    "DepthMap",
+    "EdgeMap",
+    "NormalMap",
+    "RestoredImage",
+    "Matte",
+    "Meshes",
+    "OCRRegions",
+    "Embeddings",
+    "Identities",
 )
 
 SAMPLE_IMAGE = str(_Path(__file__).parent / "assets" / "parkour.jpg")
@@ -127,6 +138,18 @@ def __getattr__(name):
         # (``LibreRFDETR``); recursing into ``__getattr__`` directly would
         # skip the eager case.
         return getattr(sys.modules[__name__], new_name)
+
+    # Core model / results exports. Resolving any of these imports the whole
+    # ``models`` package in one atomic step, preserving can_load() registry
+    # order (see the _MODEL_EXPORTS comment above).
+    if name in _MODEL_EXPORTS or name in _RESULTS_EXPORTS:
+        import importlib
+
+        module_path = ".models" if name in _MODEL_EXPORTS else ".utils.results"
+        attr = getattr(importlib.import_module(module_path, package=__name__), name)
+        # Cache into module globals so repeat access skips __getattr__ entirely.
+        globals()[name] = attr
+        return attr
 
     _lazy = {
         "LibreRFDETR": (".models.rfdetr.model", "LibreRFDETR"),
@@ -200,6 +223,13 @@ def __getattr__(name):
         mod = importlib.import_module(module_path, package=__name__)
         return getattr(mod, attr)
     raise AttributeError(f"module 'libreyolo' has no attribute '{name}'")
+
+
+def __dir__():
+    # Model/results names resolve lazily, so they are absent from globals()
+    # until first use. Advertise them anyway to keep tab-completion and
+    # introspection behaving as they did when the imports were eager.
+    return sorted(set(globals()) | set(__all__))
 
 
 __all__ = [

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -32,6 +32,7 @@ from ..postprocess.yolonas import (
     YOLO_NAS_POSE_RESIZE_SIZE,
     YOLO_NAS_RESIZE_SIZE,
 )
+from ..preprocess import as_batched_input, as_input
 from ..preprocess.yolo9 import preprocess_image
 from ..preprocess.yolonas import (
     preprocess_image as yolonas_preprocess_image,
@@ -966,7 +967,7 @@ class BaseBackend(ABC):
     @staticmethod
     def _preprocess_rfdetr(image, input_size, color_format, task=None):
         """RF-DETR preprocessing: direct resize + ImageNet normalization."""
-        from ..models.rfdetr.utils import (
+        from ..preprocess.rfdetr import (
             IMAGENET_MEAN,
             IMAGENET_STD,
             preprocess_numpy as rfdetr_preprocess_numpy,
@@ -992,7 +993,7 @@ class BaseBackend(ABC):
             return (img_tensor - mean) / std, original_img, original_size
 
         img_chw, _ = rfdetr_preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
         return img_tensor, original_img, original_size
 
     @staticmethod
@@ -1005,7 +1006,7 @@ class BaseBackend(ABC):
         original_img = img.copy()
 
         img_chw, _ = lwdetr_preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
 
         return img_tensor, original_img, original_size
 
@@ -1059,7 +1060,7 @@ class BaseBackend(ABC):
         original_img = img.copy()
 
         img_chw, _ = preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
         return img_tensor, original_img, original_size
 
     @staticmethod
@@ -1084,43 +1085,43 @@ class BaseBackend(ABC):
         original_img = img.copy()
 
         img_chw, _ = detr_preprocess_numpy(np.asarray(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
 
         return img_tensor, original_img, original_size
 
     @staticmethod
     def _preprocess_dfine(image, input_size, color_format):
         """D-FINE preprocessing: plain resize + RGB + /255, no ImageNet norm."""
-        from ..models.dfine.utils import preprocess_numpy as dfine_preprocess_numpy
+        from ..preprocess.dfine import preprocess_numpy as dfine_preprocess_numpy
 
         img = ImageLoader.load(image, color_format=color_format)
         original_size = img.size
         original_img = img.copy()
 
         img_chw, _ = dfine_preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
 
         return img_tensor, original_img, original_size
 
     @staticmethod
     def _preprocess_deim(image, input_size, color_format):
         """DEIM-D-FINE preprocessing: plain resize + RGB + /255."""
-        from ..models.deim.utils import preprocess_numpy as deim_preprocess_numpy
+        from ..preprocess.deim import preprocess_numpy as deim_preprocess_numpy
 
         img = ImageLoader.load(image, color_format=color_format)
         original_size = img.size
         original_img = img.copy()
 
         img_chw, _ = deim_preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
 
         return img_tensor, original_img, original_size
 
     @staticmethod
     def _preprocess_deimv2(image, input_size, color_format, model_size=None):
         """DEIMv2 preprocessing; DINO-backed sizes use ImageNet normalization."""
-        from ..models.deimv2.nn import DINO_SIZES
-        from ..models.deimv2.utils import preprocess_numpy as deimv2_preprocess_numpy
+        from ..preprocess.deimv2 import DINO_SIZES
+        from ..preprocess.deimv2 import preprocess_numpy as deimv2_preprocess_numpy
 
         img = ImageLoader.load(image, color_format=color_format)
         original_size = img.size
@@ -1129,23 +1130,21 @@ class BaseBackend(ABC):
         img_chw, _ = deimv2_preprocess_numpy(
             np.array(img), input_size, imagenet_norm=model_size in DINO_SIZES
         )
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
 
         return img_tensor, original_img, original_size
 
     @staticmethod
     def _preprocess_ec(image, input_size, color_format):
         """EC preprocessing: plain resize + RGB + /255 + ImageNet (mean, std)."""
-        from ..models.ec.postprocess import (
-            preprocess_numpy as ec_preprocess_numpy,
-        )
+        from ..preprocess.ec import preprocess_numpy as ec_preprocess_numpy
 
         img = ImageLoader.load(image, color_format=color_format)
         original_size = img.size
         original_img = img.copy()
 
         img_chw, _ = ec_preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
         return img_tensor, original_img, original_size
 
     @staticmethod
@@ -1158,7 +1157,7 @@ class BaseBackend(ABC):
         original_img = img.copy()
 
         img_chw, _ = picodet_preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
         return img_tensor, original_img, original_size
 
     @staticmethod
@@ -1178,20 +1177,20 @@ class BaseBackend(ABC):
         original_img = img.copy()
 
         img_chw, ratio = rtmdet_preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+        img_tensor = as_batched_input(img_chw)
         return img_tensor, original_img, original_size, ratio
 
     @staticmethod
     def _preprocess_rtdetr(image, input_size, color_format):
         """RT-DETR preprocessing: direct resize + normalize to [0,1]."""
-        from ..models.rtdetr.utils import preprocess_numpy as rtdetr_preprocess_numpy
+        from ..preprocess.rtdetr import preprocess_numpy as rtdetr_preprocess_numpy
 
         img = ImageLoader.load(image, color_format=color_format)
         original_size = img.size  # (W, H)
         original_img = img.copy()
 
         img_chw, _ = rtdetr_preprocess_numpy(np.array(img), input_size)
-        img_tensor = torch.from_numpy(img_chw)
+        img_tensor = as_input(img_chw)
         return img_tensor, original_img, original_size
 
     # =========================================================================

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -112,6 +112,20 @@ def _zeros_f32(shape):
     return np.zeros(shape, dtype=np.float32)
 
 
+def _zeros_bool(length):
+    """All-False mask, as a ``torch.Tensor`` if torch is installed."""
+    if _torch_installed():
+        return torch.zeros(length, dtype=torch.bool)
+    return np.zeros(length, dtype=bool)
+
+
+def _bool_array(data):
+    """Boolean mask stack, as a ``torch.Tensor`` if torch is installed."""
+    if _torch_installed():
+        return torch.from_numpy(data).bool()
+    return np.asarray(data, dtype=bool)
+
+
 def _to_blob(input_tensor) -> np.ndarray:
     """Return the runtime input as a contiguous numpy array.
 
@@ -3524,29 +3538,27 @@ class BaseBackend(ABC):
         obb_t = _f32(obb) if obb is not None else None
 
         if classes is not None and len(boxes_t) > 0:
-            cls_mask = torch.zeros(len(cls_t), dtype=torch.bool)
+            cls_mask = _zeros_bool(len(cls_t))
             for cid in classes:
                 cls_mask |= cls_t == cid
             boxes_t = boxes_t[cls_mask]
             conf_t = conf_t[cls_mask]
             cls_t = cls_t[cls_mask]
+            mask_np = _to_blob(cls_mask)
             if masks is not None:
-                masks = masks[cls_mask.numpy()]
+                masks = masks[mask_np]
             if obb_t is not None:
                 obb_t = obb_t[cls_mask]
             if keypoints is not None:
-                keypoints = keypoints[cls_mask.numpy()]
+                keypoints = keypoints[mask_np]
 
         masks_obj = None
         if masks is not None and len(masks) > 0:
-            masks_obj = Masks(torch.from_numpy(masks).bool(), orig_shape=orig_shape)
+            masks_obj = Masks(_bool_array(masks), orig_shape=orig_shape)
 
         keypoints_obj = None
         if keypoints is not None:
-            keypoints_obj = Keypoints(
-                torch.as_tensor(keypoints, dtype=torch.float32),
-                orig_shape,
-            )
+            keypoints_obj = Keypoints(_f32(keypoints), orig_shape)
 
         obb_obj = None
         if obb_t is not None:

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1,31 +1,43 @@
 """Base class for LibreYOLO inference backends."""
 
+# Annotations are deferred so that the ``-> torch.Tensor`` hints below do not
+# resolve torch at class-definition time; see the lazy torch import further
+# down.
+from __future__ import annotations
+
 import json
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
-import torch
-import torch.nn.functional as F
+from ..utils.lazy import lazy_module, module_available
+
 from PIL import Image
 
-from ..models.yolo9.utils import (
+# Constants and the yolo9 postprocess entry point live in the torch-free
+# ``postprocess`` package, so importing them here does not drag in
+# ``models/__init__.py`` (which eagerly builds every nn.Module to populate
+# the can_load registry) and keeps this module importable without torch.
+from ..postprocess.yolo9 import (
     _YOLO9_MAX_NMS_CANDIDATES,
     postprocess as yolo9_postprocess,
-    preprocess_image,
 )
-from ..models.yolonas.utils import (
+from ..postprocess.yolonas import (
     YOLO_NAS_PRE_NMS_TOP_K,
     YOLO_NAS_POSE_RESIZE_SIZE,
     YOLO_NAS_RESIZE_SIZE,
+)
+from ..preprocess.yolo9 import preprocess_image
+from ..preprocess.yolonas import (
     preprocess_image as yolonas_preprocess_image,
     preprocess_pose_image as yolonas_preprocess_pose_image,
 )
-from ..models.yolox.utils import preprocess_image as yolox_preprocess_image
+from ..preprocess.yolox import preprocess_image as yolox_preprocess_image
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.drawing import (
     draw_boxes,
@@ -68,6 +80,56 @@ from ..utils.video import (
     collect_video_results,
     run_video_inference,
 )
+
+
+@lru_cache(maxsize=1)
+def _torch_installed() -> bool:
+    """Whether torch is importable.
+
+    Cached: the answer cannot change within a process, and this is consulted
+    once per built result.
+    """
+    return module_available("torch")
+
+
+def _f32(data):
+    """float32 ``torch.Tensor`` when torch is installed, ``ndarray`` otherwise.
+
+    Results containers hold ``TensorLike`` (tensor *or* ndarray) and never
+    require a tensor, which is what lets a torch-free ONNX deployment build a
+    Results object. With torch installed the tensor branch is taken and
+    behaviour is byte-for-byte unchanged.
+    """
+    if _torch_installed():
+        return torch.tensor(data, dtype=torch.float32)
+    return np.asarray(data, dtype=np.float32)
+
+
+def _zeros_f32(shape):
+    """Empty-detection counterpart to :func:`_f32`."""
+    if _torch_installed():
+        return torch.zeros(shape, dtype=torch.float32)
+    return np.zeros(shape, dtype=np.float32)
+
+
+def _to_blob(input_tensor) -> np.ndarray:
+    """Return the runtime input as a contiguous numpy array.
+
+    Preprocessing yields a torch tensor when torch is installed and an ndarray
+    otherwise (see ``libreyolo.preprocess.as_batched_input``). Every non-torch
+    runtime (ONNX, OpenVINO, ncnn, ...) wants numpy either way, so normalise
+    here instead of at each call site.
+    """
+    if isinstance(input_tensor, np.ndarray):
+        return input_tensor
+    return input_tensor.detach().cpu().numpy()
+
+
+
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
+F = lazy_module("torch.nn.functional")
 
 logger = logging.getLogger(__name__)
 
@@ -3393,17 +3455,14 @@ class BaseBackend(ABC):
         if len(boxes) == 0:
             keypoints_obj = None
             if keypoints is not None:
-                keypoints_obj = Keypoints(
-                    torch.as_tensor(keypoints, dtype=torch.float32),
-                    orig_shape,
-                )
+                keypoints_obj = Keypoints(_f32(keypoints), orig_shape)
             return Results(
                 boxes=Boxes(
-                    torch.zeros((0, 4), dtype=torch.float32),
-                    torch.zeros((0,), dtype=torch.float32),
-                    torch.zeros((0,), dtype=torch.float32),
+                    _zeros_f32((0, 4)),
+                    _zeros_f32((0,)),
+                    _zeros_f32((0,)),
                 ),
-                obb=OBB(torch.zeros((0, 7), dtype=torch.float32), orig_shape)
+                obb=OBB(_zeros_f32((0, 7)), orig_shape)
                 if self.task == "obb"
                 else None,
                 keypoints=keypoints_obj,
@@ -3459,10 +3518,10 @@ class BaseBackend(ABC):
             if keypoints is not None:
                 keypoints = keypoints[top_indices]
 
-        boxes_t = torch.tensor(boxes, dtype=torch.float32)
-        conf_t = torch.tensor(max_scores, dtype=torch.float32)
-        cls_t = torch.tensor(class_ids, dtype=torch.float32)
-        obb_t = torch.tensor(obb, dtype=torch.float32) if obb is not None else None
+        boxes_t = _f32(boxes)
+        conf_t = _f32(max_scores)
+        cls_t = _f32(class_ids)
+        obb_t = _f32(obb) if obb is not None else None
 
         if classes is not None and len(boxes_t) > 0:
             cls_mask = torch.zeros(len(cls_t), dtype=torch.bool)
@@ -3699,7 +3758,7 @@ class BaseBackend(ABC):
         return effective
 
     def _forward(self, input_tensor: torch.Tensor):
-        blob = input_tensor.detach().cpu().numpy()
+        blob = _to_blob(input_tensor)
         try:
             outputs = self._run_inference(blob)
         except Exception:
@@ -3978,7 +4037,7 @@ class BaseBackend(ABC):
             image, effective_imgsz, color_format
         )
 
-        blob = input_tensor.numpy()
+        blob = _to_blob(input_tensor)
 
         all_outputs = self._run_inference(blob)
 
@@ -4312,7 +4371,7 @@ class BaseBackend(ABC):
             for t in tensors
         )
         if stackable and not getattr(self, "_batched_inference_failed", False):
-            blob = np.concatenate([t.numpy() for t in tensors], axis=0)
+            blob = np.concatenate([_to_blob(t) for t in tensors], axis=0)
             try:
                 all_outputs = self._run_inference(blob)
             except Exception as e:
@@ -4635,7 +4694,7 @@ class BaseBackend(ABC):
             input_tensor, original_img, original_size, ratio = self._preprocess(
                 pil_img, effective_imgsz, "rgb"
             )
-            blob = input_tensor.numpy()
+            blob = _to_blob(input_tensor)
             all_outputs = self._run_inference(blob)
             orig_w, orig_h = original_size
             orig_shape = (orig_h, orig_w)

--- a/libreyolo/models/deim/utils.py
+++ b/libreyolo/models/deim/utils.py
@@ -15,6 +15,9 @@ from PIL import Image
 
 from ...postprocess.deim import postprocess  # noqa: F401  (backward-compatible re-export)
 from ...utils.image_loader import ImageInput, ImageLoader
+from ...preprocess.deim import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    preprocess_numpy,
+)
 
 
 def unwrap_deim_checkpoint(checkpoint: Mapping | Any):
@@ -40,21 +43,6 @@ def unwrap_deim_checkpoint(checkpoint: Mapping | Any):
     return checkpoint
 
 
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray,
-    input_size: int = 640,
-) -> Tuple[np.ndarray, float]:
-    """Preprocess an RGB HWC uint8 array to DEIM input layout.
-
-    Plain square resize to ``(input_size, input_size)``, no letterbox, no
-    ImageNet normalization — just ``uint8 / 255``. Ratio is always 1.0
-    because there's no padding.
-    """
-    img_resized = Image.fromarray(img_rgb_hwc).resize(
-        (input_size, input_size), Image.Resampling.BILINEAR
-    )
-    arr = np.array(img_resized, dtype=np.float32) / 255.0
-    return arr.transpose(2, 0, 1), 1.0
 
 
 def preprocess_image(

--- a/libreyolo/models/deimv2/nn.py
+++ b/libreyolo/models/deimv2/nn.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 
 from libreyolo.models.deim.backbone import HGNetv2
 
+from ...preprocess.deimv2 import DINO_SIZES  # noqa: F401  (moved; re-exported)
 from .engine.backbone.dinov3_adapter import DINOv3STAs
 from .engine.deim.deim_decoder import DEIMTransformer
 from .engine.deim.hybrid_encoder import HybridEncoder
@@ -17,7 +18,6 @@ from .engine.deim.lite_encoder import LiteEncoder
 
 
 SIZE_ALIASES = {"a": "atto", "f": "femto", "p": "pico"}
-DINO_SIZES = {"s", "m", "l", "x"}
 
 
 SIZE_CONFIGS: dict[str, dict[str, Any]] = {

--- a/libreyolo/models/deimv2/utils.py
+++ b/libreyolo/models/deimv2/utils.py
@@ -11,9 +11,12 @@ from PIL import Image
 from ...postprocess.deim import postprocess
 from ...utils.image_loader import ImageInput, ImageLoader
 from ..deim.utils import unwrap_deim_checkpoint
+from ...preprocess.deimv2 import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    IMAGENET_MEAN,
+    IMAGENET_STD,
+    preprocess_numpy,
+)
 
-IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32).reshape(3, 1, 1)
-IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32).reshape(3, 1, 1)
 
 __all__ = [
     "IMAGENET_MEAN",
@@ -25,19 +28,6 @@ __all__ = [
 ]
 
 
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray,
-    input_size: int = 640,
-    *,
-    imagenet_norm: bool = False,
-) -> Tuple[np.ndarray, float]:
-    img_resized = Image.fromarray(img_rgb_hwc).resize(
-        (input_size, input_size), Image.Resampling.BILINEAR
-    )
-    chw = (np.array(img_resized, dtype=np.float32) / 255.0).transpose(2, 0, 1)
-    if imagenet_norm:
-        chw = (chw - IMAGENET_MEAN) / IMAGENET_STD
-    return chw.astype(np.float32), 1.0
 
 
 def preprocess_image(

--- a/libreyolo/models/dfine/utils.py
+++ b/libreyolo/models/dfine/utils.py
@@ -14,6 +14,9 @@ from PIL import Image
 
 from ...postprocess.dfine import postprocess  # noqa: F401  (backward-compatible re-export)
 from ...utils.image_loader import ImageInput, ImageLoader
+from ...preprocess.dfine import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    preprocess_numpy,
+)
 
 
 def unwrap_dfine_checkpoint(checkpoint: Mapping | Any):
@@ -39,21 +42,6 @@ def unwrap_dfine_checkpoint(checkpoint: Mapping | Any):
     return checkpoint
 
 
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray,
-    input_size: int = 640,
-) -> Tuple[np.ndarray, float]:
-    """Preprocess an RGB HWC uint8 array to D-FINE input layout.
-
-    Plain square resize to ``(input_size, input_size)``, no letterbox, no
-    ImageNet normalization — just ``uint8 / 255``. Ratio is always 1.0
-    because there's no padding.
-    """
-    img_resized = Image.fromarray(img_rgb_hwc).resize(
-        (input_size, input_size), Image.Resampling.BILINEAR
-    )
-    arr = np.array(img_resized, dtype=np.float32) / 255.0
-    return arr.transpose(2, 0, 1), 1.0
 
 
 def preprocess_image(

--- a/libreyolo/models/ec/postprocess.py
+++ b/libreyolo/models/ec/postprocess.py
@@ -21,6 +21,11 @@ from ...postprocess.ec import (  # noqa: F401  (backward-compatible re-exports)
     postprocess_seg,
 )
 from ...utils.image_loader import ImageInput, ImageLoader
+from ...preprocess.ec import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    _IMAGENET_MEAN,
+    _IMAGENET_STD,
+    preprocess_numpy,
+)
 
 
 def unwrap_ec_checkpoint(checkpoint: Mapping | Any):
@@ -39,25 +44,8 @@ def unwrap_ec_checkpoint(checkpoint: Mapping | Any):
     return checkpoint
 
 
-_IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
-_IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
 
 
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray, input_size: int = 640
-) -> Tuple[np.ndarray, float]:
-    """EC preprocess: square resize + /255 + ImageNet (mean, std).
-
-    Mirrors upstream val transforms (`Resize -> ConvertPILImage(scale=True) ->
-    Normalize(IMAGENET)`). The ImageNet normalization is what distinguishes
-    EC's preprocess from D-FINE's; missing it costs ~2 mAP on COCO val.
-    """
-    img_resized = Image.fromarray(img_rgb_hwc).resize(
-        (input_size, input_size), Image.Resampling.BILINEAR
-    )
-    arr = np.array(img_resized, dtype=np.float32) / 255.0
-    arr = (arr - _IMAGENET_MEAN) / _IMAGENET_STD
-    return arr.transpose(2, 0, 1), 1.0
 
 
 def preprocess_image(

--- a/libreyolo/models/rfdetr/utils.py
+++ b/libreyolo/models/rfdetr/utils.py
@@ -7,37 +7,13 @@ Postprocessing lives in ``libreyolo.postprocess.rfdetr`` and is re-exported
 here for backward compatibility.
 """
 
-import numpy as np
-from typing import Tuple
-from PIL import Image
 
 from ...postprocess.rfdetr import postprocess  # noqa: F401  (backward-compatible re-export)
+from ...preprocess.rfdetr import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    IMAGENET_MEAN,
+    IMAGENET_STD,
+    preprocess_numpy,
+)
 
-IMAGENET_MEAN = [0.485, 0.456, 0.406]
-IMAGENET_STD = [0.229, 0.224, 0.225]
 
 
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray,
-    input_size: int = 560,
-) -> Tuple[np.ndarray, float]:
-    """
-    Preprocess RGB HWC uint8 image for RF-DETR inference.
-
-    Simple resize + ImageNet normalization.
-
-    Args:
-        img_rgb_hwc: Input image as RGB HWC uint8 numpy array.
-        input_size: Target size for the model.
-
-    Returns:
-        Tuple of (preprocessed CHW float32 array with ImageNet norm, ratio).
-    """
-    img_resized = Image.fromarray(img_rgb_hwc).resize(
-        (input_size, input_size), Image.Resampling.BILINEAR
-    )
-    arr = np.array(img_resized, dtype=np.float32) / 255.0
-    mean = np.array(IMAGENET_MEAN, dtype=np.float32)
-    std = np.array(IMAGENET_STD, dtype=np.float32)
-    arr = (arr - mean) / std
-    return arr.transpose(2, 0, 1), 1.0

--- a/libreyolo/models/rtdetr/utils.py
+++ b/libreyolo/models/rtdetr/utils.py
@@ -5,9 +5,7 @@ Provides preprocessing, postprocessing, and core attention functions.
 """
 
 import math
-from typing import Tuple
 
-import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -16,6 +14,9 @@ from ...kernels.attention.ms_deform_attn import (
     maybe_ms_deform_attn,
     ms_deform_attn_available,
     spatial_shapes_tensor,
+)
+from ...preprocess.rtdetr import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    preprocess_numpy,
 )
 
 
@@ -133,22 +134,3 @@ def deformable_attention_core_func(
 # =============================================================================
 
 
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray, input_size: int
-) -> Tuple[np.ndarray, Tuple[int, int]]:
-    """Resize and normalize image for RTDETR inference. Returns float32 NCHW array.
-
-    Args:
-        img_rgb_hwc: Input image in RGB format, HWC layout
-        input_size: Target input size (square)
-
-    Returns:
-        Tuple of (preprocessed image as float32 NCHW array, original size (h, w))
-    """
-    import cv2
-
-    h, w = img_rgb_hwc.shape[:2]
-    img = cv2.resize(img_rgb_hwc, (input_size, input_size))
-    img = img.astype(np.float32) / 255.0
-    img = img.transpose(2, 0, 1)[np.newaxis]  # HWC -> NCHW
-    return img, (h, w)

--- a/libreyolo/models/yolo9/utils.py
+++ b/libreyolo/models/yolo9/utils.py
@@ -6,12 +6,15 @@ in ``libreyolo.postprocess.yolo9`` and is re-exported here for backward
 compatibility.
 """
 
-import cv2
-import numpy as np
-import torch
-from typing import Tuple
-from PIL import Image
+from __future__ import annotations
 
+from ...utils.lazy import lazy_module
+
+
+from ...preprocess.yolo9 import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    preprocess_image,
+    preprocess_numpy,
+)
 from ...postprocess.yolo9 import (  # noqa: F401  (backward-compatible re-exports)
     ImageSize,
     _YOLO9_MAX_NMS_CANDIDATES,
@@ -25,60 +28,11 @@ from ...postprocess.yolo9 import (  # noqa: F401  (backward-compatible re-export
     _xywhr_to_xyxy,
     postprocess,
 )
-from ...utils.image_loader import ImageLoader, ImageInput
 
 
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray,
-    input_size: ImageSize = 640,
-) -> Tuple[np.ndarray, float]:
-    """
-    Preprocess RGB HWC uint8 image for YOLOv9 inference.
-
-    Letterbox resize + normalize to 0-1 range.
-
-    Args:
-        img_rgb_hwc: Input image as RGB HWC uint8 numpy array.
-        input_size: Target size for the model as int or (height, width).
-
-    Returns:
-        Tuple of (preprocessed CHW float32 array in RGB 0-1, ratio).
-    """
-    orig_h, orig_w = img_rgb_hwc.shape[:2]
-    input_h, input_w = _input_size_hw(input_size)
-    ratio = min(input_h / orig_h, input_w / orig_w)
-    new_h = max(int(orig_h * ratio), 1)
-    new_w = max(int(orig_w * ratio), 1)
-
-    resized = cv2.resize(img_rgb_hwc, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
-    padded = np.full((input_h, input_w, 3), 114, dtype=np.uint8)
-    padded[:new_h, :new_w] = resized
-
-    arr = np.ascontiguousarray(padded, dtype=np.float32) / 255.0
-    return arr.transpose(2, 0, 1), ratio
-
-
-def preprocess_image(
-    image: ImageInput, input_size: ImageSize = 640, color_format: str = "auto"
-) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int]]:
-    """
-    Preprocess image for YOLOv9 inference.
-
-    Args:
-        image: Input image (path, PIL, numpy, tensor, bytes, etc.)
-        input_size: Target size for resizing as int or (height, width).
-        color_format: Color format hint ("auto", "rgb", "bgr")
-
-    Returns:
-        Tuple of (preprocessed_tensor, original_image, original_size)
-    """
-    img = ImageLoader.load(image, color_format=color_format)
-    original_size = img.size  # (width, height)
-    original_img = img.copy()
-
-    img_chw, _ = preprocess_numpy(np.array(img), input_size)
-    img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
-    return img_tensor, original_img, original_size
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
 
 
 def decode_boxes(

--- a/libreyolo/models/yolonas/utils.py
+++ b/libreyolo/models/yolonas/utils.py
@@ -7,12 +7,17 @@ shares with the preprocess side).
 
 from __future__ import annotations
 
-from typing import Mapping, MutableMapping, Tuple
+from typing import Mapping, MutableMapping
 
-import numpy as np
-import torch
-from PIL import Image
+from ...utils.lazy import lazy_module
 
+
+from ...preprocess.yolonas import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    YOLO_NAS_POSE_PAD_VALUE,
+    preprocess_image,
+    preprocess_numpy,
+    preprocess_pose_image,
+)
 from ...postprocess.yolonas import (  # noqa: F401  (backward-compatible re-exports)
     YOLO_NAS_PRE_NMS_TOP_K,
     YOLO_NAS_POSE_RESIZE_SIZE,
@@ -23,9 +28,12 @@ from ...postprocess.yolonas import (  # noqa: F401  (backward-compatible re-expo
     postprocess,
     postprocess_pose,
 )
-from ...utils.image_loader import ImageInput, ImageLoader
 
-YOLO_NAS_POSE_PAD_VALUE = 127
+
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
+
 
 
 def unwrap_yolonas_checkpoint(
@@ -46,83 +54,3 @@ def unwrap_yolonas_checkpoint(
             return value
 
     return checkpoint
-
-
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray,
-    input_size: int = 640,
-    pad_value: int = 114,
-    resize_size: int = YOLO_NAS_RESIZE_SIZE,
-    padding_mode: str = "center",
-) -> Tuple[np.ndarray, float]:
-    """Resize longest side to ``resize_size``, center-pad to ``input_size``."""
-    orig_h, orig_w = img_rgb_hwc.shape[:2]
-    if isinstance(input_size, (list, tuple)):
-        input_h, input_w = int(input_size[0]), int(input_size[1])
-        if input_h != input_w:
-            # YOLO-NAS preprocessing resizes the longest side to a fixed
-            # ``resize_size`` before padding, so a rectangular canvas would
-            # either crop the image or leave most of it as padding. Reject
-            # until the resize recipe itself is made aspect-aware.
-            raise ValueError(
-                f"YOLO-NAS does not support rectangular input sizes, got "
-                f"({input_h}, {input_w}). Use a square imgsz."
-            )
-    else:
-        input_h = input_w = int(input_size)
-    resize_size = min(resize_size, input_h, input_w)
-    ratio = min(resize_size / orig_h, resize_size / orig_w)
-    new_w, new_h = int(round(orig_w * ratio)), int(round(orig_h * ratio))
-
-    img_resized = Image.fromarray(img_rgb_hwc).resize(
-        (new_w, new_h), Image.Resampling.BILINEAR
-    )
-
-    padded = Image.new(
-        "RGB", (input_w, input_h), (pad_value, pad_value, pad_value)
-    )
-    if padding_mode == "bottom_right":
-        offset_x = 0
-        offset_y = 0
-    else:
-        offset_x = (input_w - new_w) // 2
-        offset_y = (input_h - new_h) // 2
-    padded.paste(img_resized, (offset_x, offset_y))
-
-    arr = np.array(padded, dtype=np.float32) / 255.0
-    return arr.transpose(2, 0, 1), ratio
-
-
-def preprocess_image(
-    image: ImageInput,
-    input_size: int = 640,
-    color_format: str = "auto",
-) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
-    img = ImageLoader.load(image, color_format=color_format)
-    original_size = img.size
-    original_img = img.copy()
-
-    img_chw, ratio = preprocess_numpy(np.array(img), input_size=input_size)
-    img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
-    return img_tensor, original_img, original_size, ratio
-
-
-def preprocess_pose_image(
-    image: ImageInput,
-    input_size: int = 640,
-    color_format: str = "auto",
-) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
-    img = ImageLoader.load(image, color_format=color_format)
-    original_size = img.size
-    original_img = img.copy()
-    rgb = np.array(img)
-    bgr = rgb[:, :, ::-1]
-    img_chw, ratio = preprocess_numpy(
-        bgr,
-        input_size=input_size,
-        pad_value=YOLO_NAS_POSE_PAD_VALUE,
-        resize_size=YOLO_NAS_POSE_RESIZE_SIZE,
-        padding_mode="bottom_right",
-    )
-    img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
-    return img_tensor, original_img, original_size, ratio

--- a/libreyolo/models/yolox/utils.py
+++ b/libreyolo/models/yolox/utils.py
@@ -9,79 +9,22 @@ Postprocessing lives in ``libreyolo.postprocess.yolox`` and is re-exported
 here for backward compatibility.
 """
 
-import torch
-import numpy as np
-from typing import Tuple
-from PIL import Image
+from __future__ import annotations
 
+from ...utils.lazy import lazy_module
+
+
+from ...preprocess.yolox import (  # noqa: F401  (moved; re-exported for backward compatibility)
+    preprocess_image,
+    preprocess_numpy,
+)
 from ...postprocess.yolox import (  # noqa: F401  (backward-compatible re-exports)
     decode_outputs,
     make_grids,
     postprocess,
 )
-from ...utils.image_loader import ImageLoader, ImageInput
 
 
-def preprocess_numpy(
-    img_rgb_hwc: np.ndarray,
-    input_size: int = 640,
-) -> Tuple[np.ndarray, float]:
-    """
-    Preprocess RGB HWC uint8 image for YOLOX inference.
-
-    YOLOX-specific: letterbox + RGB to BGR + no normalization (0-255 range).
-
-    Args:
-        img_rgb_hwc: Input image as RGB HWC uint8 numpy array.
-        input_size: Target size for the model.
-
-    Returns:
-        Tuple of (preprocessed CHW float32 array in BGR 0-255, ratio).
-    """
-    orig_h, orig_w = img_rgb_hwc.shape[:2]
-    if isinstance(input_size, (list, tuple)):
-        input_h, input_w = int(input_size[0]), int(input_size[1])
-    else:
-        input_h = input_w = int(input_size)
-    ratio = min(input_w / orig_w, input_h / orig_h)
-    new_w, new_h = int(orig_w * ratio), int(orig_h * ratio)
-
-    img_resized = Image.fromarray(img_rgb_hwc).resize(
-        (new_w, new_h), Image.Resampling.BILINEAR
-    )
-
-    # Letterbox with gray padding at top-left
-    padded = Image.new("RGB", (input_w, input_h), (114, 114, 114))
-    padded.paste(img_resized, (0, 0))
-
-    # RGB to BGR, HWC to CHW, keep 0-255
-    arr = np.array(padded, dtype=np.float32)[:, :, ::-1].copy()
-    return arr.transpose(2, 0, 1), ratio
-
-
-def preprocess_image(
-    image: ImageInput, input_size: int = 640, color_format: str = "auto"
-) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
-    """
-    Preprocess image for YOLOX inference with letterboxing.
-
-    YOLOX-specific preprocessing:
-    - Letterbox resize maintaining aspect ratio
-    - Gray padding (114, 114, 114)
-    - NO normalization (keeps 0-255 range as float32)
-
-    Args:
-        image: Input image (path, PIL, numpy, tensor, bytes, etc.)
-        input_size: Target size for the model (default: 640)
-        color_format: Color format hint ("auto", "rgb", "bgr")
-
-    Returns:
-        Tuple of (preprocessed_tensor, original_image, original_size, ratio)
-    """
-    img = ImageLoader.load(image, color_format=color_format)
-    original_size = img.size  # (width, height)
-    original_img = img.copy()
-
-    img_chw, ratio = preprocess_numpy(np.array(img), input_size)
-    img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
-    return img_tensor, original_img, original_size, ratio
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")

--- a/libreyolo/postprocess/common.py
+++ b/libreyolo/postprocess/common.py
@@ -6,10 +6,17 @@ the YOLOX and RTMDet decode paths. Moved verbatim from
 compatibility).
 """
 
+from __future__ import annotations
+
 from typing import Tuple, Union
 
-import torch
-import torchvision.ops
+from ..utils.lazy import lazy_module
+
+
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
+torchvision = lazy_module("torchvision")
 
 
 def _input_size_hw(input_size: Union[int, Tuple[int, int]]) -> Tuple[int, int]:

--- a/libreyolo/postprocess/yolo9.py
+++ b/libreyolo/postprocess/yolo9.py
@@ -4,12 +4,17 @@ Moved verbatim from ``libreyolo/models/yolo9/utils.py``, which re-exports
 everything here for backward compatibility.
 """
 
+from __future__ import annotations
+
 import numpy as np
-import torch
-from torchvision.ops import batched_nms
+from ..utils.lazy import lazy_module
+
 from typing import Dict, Tuple, Union
 
-from ..data.obb import xywhr_iou
+
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
 
 
 _YOLO9_MAX_NMS_CANDIDATES = 30000
@@ -38,6 +43,11 @@ def _nms_keep_indices(
     iou_thres: float,
     max_det: int,
 ) -> torch.Tensor:
+    # Imported here rather than at module scope: this module must stay
+    # importable without torchvision for the torch-free ONNX path, which
+    # reaches NMS through _batched_nms_numpy in backends/base.py instead.
+    from torchvision.ops import batched_nms
+
     if boxes.numel() == 0:
         return torch.zeros(0, dtype=torch.long, device=boxes.device)
 
@@ -116,6 +126,12 @@ def _rotated_nms_keep_indices(
     iou_thres: float,
     max_det: int,
 ) -> torch.Tensor:
+    # Imported here rather than at module scope: ``libreyolo.data`` pulls the
+    # dataset stack (and torch) at import time, and this module sits on the
+    # torch-free ONNX import path. Rotated NMS is OBB-only, which that path
+    # does not reach.
+    from ..data.obb import xywhr_iou
+
     if xywhr.numel() == 0:
         return torch.zeros(0, dtype=torch.long, device=xywhr.device)
 

--- a/libreyolo/postprocess/yolonas.py
+++ b/libreyolo/postprocess/yolonas.py
@@ -13,10 +13,15 @@ from __future__ import annotations
 
 from typing import Tuple, Union
 
-import torch
-import torchvision.ops
+from ..utils.lazy import lazy_module
 
 from .common import _input_size_hw
+
+
+# torch/torchvision are resolved on first use so this module stays
+# importable in a torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
+torchvision = lazy_module("torchvision")
 
 YOLO_NAS_RESIZE_SIZE = 636
 YOLO_NAS_POSE_RESIZE_SIZE = 640

--- a/libreyolo/preprocess/__init__.py
+++ b/libreyolo/preprocess/__init__.py
@@ -1,0 +1,43 @@
+"""Torch-free input preprocessing.
+
+Mirrors ``libreyolo/postprocess/``: the family-specific numpy preprocessing
+recipes live here rather than under ``libreyolo/models/``, because importing
+anything under ``models/`` runs ``models/__init__.py``, which eagerly
+constructs every model class to populate the ``can_load()`` registry. Those
+classes are ``nn.Module`` subclasses and genuinely require torch, so a backend
+that only needs a letterbox recipe would drag the whole torch wheel in with it.
+
+Keeping these functions here is what lets ``backends/base.py`` (and therefore
+``backends/onnx.py``) import without torch, so a lightweight deployment can run
+ONNX inference with just numpy + onnxruntime.
+
+``libreyolo/models/<family>/utils.py`` re-exports everything here, so existing
+import paths keep working.
+
+See https://github.com/LibreYOLO/libreyolo/discussions/711.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..utils.lazy import lazy_module, module_available
+
+torch = lazy_module("torch")
+
+
+def as_batched_input(img_chw: np.ndarray):
+    """Add a batch dim, as a ``torch.Tensor`` if torch is installed.
+
+    With torch present this is exactly ``torch.from_numpy(chw).unsqueeze(0)``,
+    which is what every family preprocessor did before this module existed.
+    Without torch it returns the equivalent ``(1, C, H, W)`` ndarray, which the
+    ONNX backend feeds to onnxruntime directly (it converted the tensor back to
+    numpy anyway).
+    """
+    if module_available("torch"):
+        return torch.from_numpy(img_chw).unsqueeze(0)
+    return img_chw[None, ...]
+
+
+__all__ = ["as_batched_input"]

--- a/libreyolo/preprocess/__init__.py
+++ b/libreyolo/preprocess/__init__.py
@@ -26,6 +26,18 @@ from ..utils.lazy import lazy_module, module_available
 torch = lazy_module("torch")
 
 
+def as_input(img_nchw: np.ndarray):
+    """Wrap an already-batched array, as a ``torch.Tensor`` if torch is installed.
+
+    Counterpart to :func:`as_batched_input` for the recipes whose
+    ``preprocess_numpy`` already returns NCHW (RT-DETR), so no batch dim is
+    added here.
+    """
+    if module_available("torch"):
+        return torch.from_numpy(img_nchw)
+    return img_nchw
+
+
 def as_batched_input(img_chw: np.ndarray):
     """Add a batch dim, as a ``torch.Tensor`` if torch is installed.
 
@@ -40,4 +52,4 @@ def as_batched_input(img_chw: np.ndarray):
     return img_chw[None, ...]
 
 
-__all__ = ["as_batched_input"]
+__all__ = ["as_batched_input", "as_input"]

--- a/libreyolo/preprocess/deim.py
+++ b/libreyolo/preprocess/deim.py
@@ -1,0 +1,32 @@
+"""DEIM input preprocessing.
+
+Moved verbatim from ``libreyolo/models/deim/utils.py``, which re-exports it for backward
+compatibility. Lives outside ``models/`` so the ONNX backend can import it
+without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from PIL import Image
+
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: int = 640,
+) -> Tuple[np.ndarray, float]:
+    """Preprocess an RGB HWC uint8 array to DEIM input layout.
+
+    Plain square resize to ``(input_size, input_size)``, no letterbox, no
+    ImageNet normalization — just ``uint8 / 255``. Ratio is always 1.0
+    because there's no padding.
+    """
+    img_resized = Image.fromarray(img_rgb_hwc).resize(
+        (input_size, input_size), Image.Resampling.BILINEAR
+    )
+    arr = np.array(img_resized, dtype=np.float32) / 255.0
+    return arr.transpose(2, 0, 1), 1.0
+
+
+__all__ = ["preprocess_numpy"]

--- a/libreyolo/preprocess/deimv2.py
+++ b/libreyolo/preprocess/deimv2.py
@@ -1,0 +1,37 @@
+"""DEIMv2 input preprocessing.
+
+Moved verbatim from ``libreyolo/models/deimv2/utils.py``, which re-exports it for backward
+compatibility. Lives outside ``models/`` so the ONNX backend can import it
+without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from PIL import Image
+
+# Sizes whose DINO backbone expects ImageNet-normalised input. Lives here
+# rather than in models/deimv2/nn.py (which re-exports it) so the backend can
+# read it without importing the network definition, and therefore torch.
+DINO_SIZES = {"s", "m", "l", "x"}
+
+IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32).reshape(3, 1, 1)
+IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32).reshape(3, 1, 1)
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: int = 640,
+    *,
+    imagenet_norm: bool = False,
+) -> Tuple[np.ndarray, float]:
+    img_resized = Image.fromarray(img_rgb_hwc).resize(
+        (input_size, input_size), Image.Resampling.BILINEAR
+    )
+    chw = (np.array(img_resized, dtype=np.float32) / 255.0).transpose(2, 0, 1)
+    if imagenet_norm:
+        chw = (chw - IMAGENET_MEAN) / IMAGENET_STD
+    return chw.astype(np.float32), 1.0
+
+
+__all__ = ["DINO_SIZES", "IMAGENET_MEAN", "IMAGENET_STD", "preprocess_numpy"]

--- a/libreyolo/preprocess/dfine.py
+++ b/libreyolo/preprocess/dfine.py
@@ -1,0 +1,32 @@
+"""D-FINE input preprocessing.
+
+Moved verbatim from ``libreyolo/models/dfine/utils.py``, which re-exports it for backward
+compatibility. Lives outside ``models/`` so the ONNX backend can import it
+without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from PIL import Image
+
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: int = 640,
+) -> Tuple[np.ndarray, float]:
+    """Preprocess an RGB HWC uint8 array to D-FINE input layout.
+
+    Plain square resize to ``(input_size, input_size)``, no letterbox, no
+    ImageNet normalization — just ``uint8 / 255``. Ratio is always 1.0
+    because there's no padding.
+    """
+    img_resized = Image.fromarray(img_rgb_hwc).resize(
+        (input_size, input_size), Image.Resampling.BILINEAR
+    )
+    arr = np.array(img_resized, dtype=np.float32) / 255.0
+    return arr.transpose(2, 0, 1), 1.0
+
+
+__all__ = ["preprocess_numpy"]

--- a/libreyolo/preprocess/ec.py
+++ b/libreyolo/preprocess/ec.py
@@ -1,0 +1,34 @@
+"""EC input preprocessing.
+
+Moved verbatim from ``libreyolo/models/ec/postprocess.py``, which re-exports it for backward
+compatibility. Lives outside ``models/`` so the ONNX backend can import it
+without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from PIL import Image
+
+_IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+_IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray, input_size: int = 640
+) -> Tuple[np.ndarray, float]:
+    """EC preprocess: square resize + /255 + ImageNet (mean, std).
+
+    Mirrors upstream val transforms (`Resize -> ConvertPILImage(scale=True) ->
+    Normalize(IMAGENET)`). The ImageNet normalization is what distinguishes
+    EC's preprocess from D-FINE's; missing it costs ~2 mAP on COCO val.
+    """
+    img_resized = Image.fromarray(img_rgb_hwc).resize(
+        (input_size, input_size), Image.Resampling.BILINEAR
+    )
+    arr = np.array(img_resized, dtype=np.float32) / 255.0
+    arr = (arr - _IMAGENET_MEAN) / _IMAGENET_STD
+    return arr.transpose(2, 0, 1), 1.0
+
+
+__all__ = ["_IMAGENET_MEAN", "_IMAGENET_STD", "preprocess_numpy"]

--- a/libreyolo/preprocess/rfdetr.py
+++ b/libreyolo/preprocess/rfdetr.py
@@ -1,0 +1,43 @@
+"""RF-DETR input preprocessing.
+
+Moved verbatim from ``libreyolo/models/rfdetr/utils.py``, which re-exports it for backward
+compatibility. Lives outside ``models/`` so the ONNX backend can import it
+without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from PIL import Image
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: int = 560,
+) -> Tuple[np.ndarray, float]:
+    """
+    Preprocess RGB HWC uint8 image for RF-DETR inference.
+
+    Simple resize + ImageNet normalization.
+
+    Args:
+        img_rgb_hwc: Input image as RGB HWC uint8 numpy array.
+        input_size: Target size for the model.
+
+    Returns:
+        Tuple of (preprocessed CHW float32 array with ImageNet norm, ratio).
+    """
+    img_resized = Image.fromarray(img_rgb_hwc).resize(
+        (input_size, input_size), Image.Resampling.BILINEAR
+    )
+    arr = np.array(img_resized, dtype=np.float32) / 255.0
+    mean = np.array(IMAGENET_MEAN, dtype=np.float32)
+    std = np.array(IMAGENET_STD, dtype=np.float32)
+    arr = (arr - mean) / std
+    return arr.transpose(2, 0, 1), 1.0
+
+
+__all__ = ["IMAGENET_MEAN", "IMAGENET_STD", "preprocess_numpy"]

--- a/libreyolo/preprocess/rtdetr.py
+++ b/libreyolo/preprocess/rtdetr.py
@@ -1,0 +1,35 @@
+"""RT-DETR input preprocessing.
+
+Moved verbatim from ``libreyolo/models/rtdetr/utils.py``, which re-exports it for backward
+compatibility. Lives outside ``models/`` so the ONNX backend can import it
+without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray, input_size: int
+) -> Tuple[np.ndarray, Tuple[int, int]]:
+    """Resize and normalize image for RTDETR inference. Returns float32 NCHW array.
+
+    Args:
+        img_rgb_hwc: Input image in RGB format, HWC layout
+        input_size: Target input size (square)
+
+    Returns:
+        Tuple of (preprocessed image as float32 NCHW array, original size (h, w))
+    """
+    import cv2
+
+    h, w = img_rgb_hwc.shape[:2]
+    img = cv2.resize(img_rgb_hwc, (input_size, input_size))
+    img = img.astype(np.float32) / 255.0
+    img = img.transpose(2, 0, 1)[np.newaxis]  # HWC -> NCHW
+    return img, (h, w)
+
+
+__all__ = ["preprocess_numpy"]

--- a/libreyolo/preprocess/yolo9.py
+++ b/libreyolo/preprocess/yolo9.py
@@ -1,0 +1,72 @@
+"""YOLO9 input preprocessing.
+
+Moved verbatim from ``libreyolo/models/yolo9/utils.py``, which re-exports
+everything here for backward compatibility. Lives outside ``models/`` so the
+ONNX backend can import it without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import cv2
+import numpy as np
+
+from ..postprocess.yolo9 import ImageSize, _input_size_hw
+from ..utils.image_loader import ImageInput, ImageLoader
+from . import as_batched_input
+
+
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: ImageSize = 640,
+) -> Tuple[np.ndarray, float]:
+    """
+    Preprocess RGB HWC uint8 image for YOLOv9 inference.
+
+    Letterbox resize + normalize to 0-1 range.
+
+    Args:
+        img_rgb_hwc: Input image as RGB HWC uint8 numpy array.
+        input_size: Target size for the model as int or (height, width).
+
+    Returns:
+        Tuple of (preprocessed CHW float32 array in RGB 0-1, ratio).
+    """
+    orig_h, orig_w = img_rgb_hwc.shape[:2]
+    input_h, input_w = _input_size_hw(input_size)
+    ratio = min(input_h / orig_h, input_w / orig_w)
+    new_h = max(int(orig_h * ratio), 1)
+    new_w = max(int(orig_w * ratio), 1)
+
+    resized = cv2.resize(img_rgb_hwc, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+    padded = np.full((input_h, input_w, 3), 114, dtype=np.uint8)
+    padded[:new_h, :new_w] = resized
+
+    arr = np.ascontiguousarray(padded, dtype=np.float32) / 255.0
+    return arr.transpose(2, 0, 1), ratio
+
+
+def preprocess_image(
+    image: ImageInput, input_size: ImageSize = 640, color_format: str = "auto"
+):
+    """
+    Preprocess image for YOLOv9 inference.
+
+    Args:
+        image: Input image (path, PIL, numpy, tensor, bytes, etc.)
+        input_size: Target size for resizing as int or (height, width).
+        color_format: Color format hint ("auto", "rgb", "bgr")
+
+    Returns:
+        Tuple of (preprocessed_tensor, original_image, original_size)
+    """
+    img = ImageLoader.load(image, color_format=color_format)
+    original_size = img.size  # (width, height)
+    original_img = img.copy()
+
+    img_chw, _ = preprocess_numpy(np.array(img), input_size)
+    return as_batched_input(img_chw), original_img, original_size
+
+
+__all__ = ["preprocess_numpy", "preprocess_image"]

--- a/libreyolo/preprocess/yolonas.py
+++ b/libreyolo/preprocess/yolonas.py
@@ -1,0 +1,106 @@
+"""YOLO-NAS input preprocessing.
+
+Moved verbatim from ``libreyolo/models/yolonas/utils.py``, which re-exports
+everything here for backward compatibility. Lives outside ``models/`` so the
+ONNX backend can import it without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from PIL import Image
+
+from ..postprocess.yolonas import (
+    YOLO_NAS_POSE_RESIZE_SIZE,
+    YOLO_NAS_RESIZE_SIZE,
+)
+from ..utils.image_loader import ImageInput, ImageLoader
+from . import as_batched_input
+
+YOLO_NAS_POSE_PAD_VALUE = 127
+
+
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: int = 640,
+    pad_value: int = 114,
+    resize_size: int = YOLO_NAS_RESIZE_SIZE,
+    padding_mode: str = "center",
+) -> Tuple[np.ndarray, float]:
+    """Resize longest side to ``resize_size``, center-pad to ``input_size``."""
+    orig_h, orig_w = img_rgb_hwc.shape[:2]
+    if isinstance(input_size, (list, tuple)):
+        input_h, input_w = int(input_size[0]), int(input_size[1])
+        if input_h != input_w:
+            # YOLO-NAS preprocessing resizes the longest side to a fixed
+            # ``resize_size`` before padding, so a rectangular canvas would
+            # either crop the image or leave most of it as padding. Reject
+            # until the resize recipe itself is made aspect-aware.
+            raise ValueError(
+                f"YOLO-NAS does not support rectangular input sizes, got "
+                f"({input_h}, {input_w}). Use a square imgsz."
+            )
+    else:
+        input_h = input_w = int(input_size)
+    resize_size = min(resize_size, input_h, input_w)
+    ratio = min(resize_size / orig_h, resize_size / orig_w)
+    new_w, new_h = int(round(orig_w * ratio)), int(round(orig_h * ratio))
+
+    img_resized = Image.fromarray(img_rgb_hwc).resize(
+        (new_w, new_h), Image.Resampling.BILINEAR
+    )
+
+    padded = Image.new("RGB", (input_w, input_h), (pad_value, pad_value, pad_value))
+    if padding_mode == "bottom_right":
+        offset_x = 0
+        offset_y = 0
+    else:
+        offset_x = (input_w - new_w) // 2
+        offset_y = (input_h - new_h) // 2
+    padded.paste(img_resized, (offset_x, offset_y))
+
+    arr = np.array(padded, dtype=np.float32) / 255.0
+    return arr.transpose(2, 0, 1), ratio
+
+
+def preprocess_image(
+    image: ImageInput,
+    input_size: int = 640,
+    color_format: str = "auto",
+):
+    img = ImageLoader.load(image, color_format=color_format)
+    original_size = img.size
+    original_img = img.copy()
+
+    img_chw, ratio = preprocess_numpy(np.array(img), input_size=input_size)
+    return as_batched_input(img_chw), original_img, original_size, ratio
+
+
+def preprocess_pose_image(
+    image: ImageInput,
+    input_size: int = 640,
+    color_format: str = "auto",
+):
+    img = ImageLoader.load(image, color_format=color_format)
+    original_size = img.size
+    original_img = img.copy()
+    rgb = np.array(img)
+    bgr = rgb[:, :, ::-1]
+    img_chw, ratio = preprocess_numpy(
+        bgr,
+        input_size=input_size,
+        pad_value=YOLO_NAS_POSE_PAD_VALUE,
+        resize_size=YOLO_NAS_POSE_RESIZE_SIZE,
+        padding_mode="bottom_right",
+    )
+    return as_batched_input(img_chw), original_img, original_size, ratio
+
+
+__all__ = [
+    "YOLO_NAS_POSE_PAD_VALUE",
+    "preprocess_numpy",
+    "preprocess_image",
+    "preprocess_pose_image",
+]

--- a/libreyolo/preprocess/yolox.py
+++ b/libreyolo/preprocess/yolox.py
@@ -1,0 +1,83 @@
+"""YOLOX input preprocessing.
+
+Moved verbatim from ``libreyolo/models/yolox/utils.py``, which re-exports
+everything here for backward compatibility. Lives outside ``models/`` so the
+ONNX backend can import it without pulling torch; see the package docstring.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from PIL import Image
+
+from ..utils.image_loader import ImageInput, ImageLoader
+from . import as_batched_input
+
+
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: int = 640,
+) -> Tuple[np.ndarray, float]:
+    """
+    Preprocess RGB HWC uint8 image for YOLOX inference.
+
+    YOLOX-specific: letterbox + RGB to BGR + no normalization (0-255 range).
+
+    Args:
+        img_rgb_hwc: Input image as RGB HWC uint8 numpy array.
+        input_size: Target size for the model.
+
+    Returns:
+        Tuple of (preprocessed CHW float32 array in BGR 0-255, ratio).
+    """
+    orig_h, orig_w = img_rgb_hwc.shape[:2]
+    if isinstance(input_size, (list, tuple)):
+        input_h, input_w = int(input_size[0]), int(input_size[1])
+    else:
+        input_h = input_w = int(input_size)
+    ratio = min(input_w / orig_w, input_h / orig_h)
+    new_w, new_h = int(orig_w * ratio), int(orig_h * ratio)
+
+    img_resized = Image.fromarray(img_rgb_hwc).resize(
+        (new_w, new_h), Image.Resampling.BILINEAR
+    )
+
+    # Letterbox with gray padding at top-left
+    padded = Image.new("RGB", (input_w, input_h), (114, 114, 114))
+    padded.paste(img_resized, (0, 0))
+
+    # RGB to BGR, HWC to CHW, keep 0-255
+    arr = np.array(padded, dtype=np.float32)[:, :, ::-1].copy()
+    return arr.transpose(2, 0, 1), ratio
+
+
+def preprocess_image(
+    image: ImageInput, input_size: int = 640, color_format: str = "auto"
+):
+    """
+    Preprocess image for YOLOX inference with letterboxing.
+
+    YOLOX-specific preprocessing:
+    - Letterbox resize maintaining aspect ratio
+    - Gray padding (114, 114, 114)
+    - NO normalization (keeps 0-255 range as float32)
+
+    Args:
+        image: Input image (path, PIL, numpy, tensor, bytes, etc.)
+        input_size: Target size for the model (default: 640)
+        color_format: Color format hint ("auto", "rgb", "bgr")
+
+    Returns:
+        Tuple of (preprocessed_tensor, original_image, original_size, ratio)
+    """
+    img = ImageLoader.load(image, color_format=color_format)
+    original_size = img.size  # (width, height)
+    original_img = img.copy()
+
+    img_chw, ratio = preprocess_numpy(np.array(img), input_size)
+    return as_batched_input(img_chw), original_img, original_size, ratio
+
+
+__all__ = ["preprocess_numpy", "preprocess_image"]

--- a/libreyolo/utils/general.py
+++ b/libreyolo/utils/general.py
@@ -1,13 +1,21 @@
 """Shared general utility functions."""
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 from urllib.parse import urlparse
 
-import torch
+from .lazy import lazy_module
+
 
 from ..postprocess.common import postprocess_detections  # noqa: F401  (moved; re-exported for backward compatibility)
+
+
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
 
 logger = logging.getLogger(__name__)
 

--- a/libreyolo/utils/image_loader.py
+++ b/libreyolo/utils/image_loader.py
@@ -1,18 +1,33 @@
 """Unified image loader for all image input formats."""
 
+from __future__ import annotations
+
 import io
 from pathlib import Path
-from typing import List, Union
+from typing import TYPE_CHECKING, Any, List, Union
 
 import numpy as np
-import torch
+from .lazy import lazy_module
+
 from PIL import Image
 
 
-# Type alias for all supported image inputs
-ImageInput = Union[
-    str, Path, Image.Image, np.ndarray, torch.Tensor, bytes, "io.BytesIO"
-]
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
+
+
+# Type alias for all supported image inputs. Built at import time, so it must
+# not dereference the lazy torch proxy; annotations in this module are strings
+# via ``from __future__ import annotations`` and never evaluate it at runtime.
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch as _torch
+
+    ImageInput = Union[
+        str, Path, Image.Image, np.ndarray, _torch.Tensor, bytes, "io.BytesIO"
+    ]
+else:
+    ImageInput = Any
 
 # Supported image file extensions for directory scanning
 SUPPORTED_EXTENSIONS = {

--- a/libreyolo/utils/lazy.py
+++ b/libreyolo/utils/lazy.py
@@ -1,0 +1,74 @@
+"""Deferred module imports.
+
+LibreYOLO supports a lightweight ONNX-only deployment that has no torch wheel
+installed (``pip install --no-deps libreyolo`` plus numpy/onnxruntime). The
+ONNX inference path is numpy-native end to end, but the modules it lives in
+also hold torch-based code for the default path. ``LazyModule`` lets those
+modules keep writing ``torch.foo(...)`` normally while deferring the actual
+import until the first torch-backed attribute is touched.
+
+See https://github.com/LibreYOLO/libreyolo/discussions/711.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+
+class LazyModule(ModuleType):
+    """Stand-in for a module that is imported on first attribute access.
+
+    Behaves like the real module for every practical purpose (``torch.Tensor``,
+    ``isinstance(x, torch.Tensor)``, ``torch.cuda.is_available()``), but a
+    module that merely *imports* it pays nothing. The underlying module is
+    resolved once and cached, so steady-state access is two dict lookups.
+
+    Raises ``ModuleNotFoundError`` at first use if the module really is absent,
+    which is the same error the caller would have seen from a normal import.
+    """
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.__dict__["_lazy_target"] = name
+
+    def __getattr__(self, attr: str):
+        # Only invoked for names absent from __dict__, so the bookkeeping keys
+        # below never recurse.
+        target = self.__dict__.get("_lazy_target")
+        if target is None or attr.startswith("_lazy_"):
+            raise AttributeError(attr)
+        module = self.__dict__.get("_lazy_module")
+        if module is None:
+            module = importlib.import_module(target)
+            self.__dict__["_lazy_module"] = module
+        return getattr(module, attr)
+
+    def __dir__(self):
+        try:
+            return dir(importlib.import_module(self.__dict__["_lazy_target"]))
+        except ImportError:
+            return []
+
+
+def module_available(name: str) -> bool:
+    """Whether ``name`` can be imported, without keeping it loaded on failure."""
+    try:
+        importlib.import_module(name)
+    except ImportError:
+        return False
+    return True
+
+
+def lazy_module(name: str) -> ModuleType:
+    """Return a :class:`LazyModule` proxy for ``name``.
+
+    If the module is already imported, hand back the real thing so callers
+    never pay proxy overhead in the common (torch-installed) case.
+    """
+    import sys
+
+    existing = sys.modules.get(name)
+    if existing is not None:
+        return existing  # type: ignore[return-value]
+    return LazyModule(name)

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -5,13 +5,26 @@ from __future__ import annotations
 import json
 import math
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import torch
+from .lazy import lazy_module
 
 
-TensorLike = Union[torch.Tensor, np.ndarray]
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch as _torch
+
+    TensorLike = Union[_torch.Tensor, np.ndarray]
+else:
+    # Evaluated at import time, so it must not touch the lazy torch proxy.
+    # Annotations elsewhere in this module are strings (see __future__ import),
+    # so nothing dereferences this alias at runtime.
+    TensorLike = Any
 
 
 def _move(data: TensorLike | None, *args, **kwargs):

--- a/libreyolo/utils/serialization.py
+++ b/libreyolo/utils/serialization.py
@@ -8,9 +8,16 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
-import torch
-
 from ..tasks import normalize_task
+from .lazy import lazy_module
+
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711): warn_on_metadata_schema_version
+# and the metadata helpers here sit on backends/onnx.py's import path, while
+# only the ``.pt`` loaders below actually need torch. Kept as a module
+# attribute rather than a function-local import so ``serialization.torch``
+# stays patchable.
+torch = lazy_module("torch")
 
 
 SCHEMA_VERSION = "1.0"

--- a/tests/unit/test_import_without_torch.py
+++ b/tests/unit/test_import_without_torch.py
@@ -198,7 +198,7 @@ def test_onnx_predict_matches_torch_path_end_to_end(tmp_path, classes):
 
     from libreyolo.models.yolo9.model import LibreYOLO9
 
-    model = LibreYOLO9(model_path=None, size="t", nb_classes=4, device="cpu")
+    model = LibreYOLO9({}, size="t", nb_classes=4, device="cpu")
     onnx_path = Path(model.export(format="onnx", imgsz=128)).resolve()
 
     body = f"""
@@ -270,7 +270,9 @@ def test_g0_g1_families_predict_without_torch(family, size, imgsz):
 
     from libreyolo.cli.config import get_model_class
 
-    model = get_model_class(family)(model_path=None, size=size, device="cpu")
+    # `{}` (empty state dict), not None: None makes RF-DETR fetch its DINOv2
+    # backbone over HTTP, and the PR gate blocks external network access.
+    model = get_model_class(family)({}, size=size, device="cpu")
     onnx_path = Path(model.export(format="onnx", imgsz=imgsz)).resolve()
 
     body = f"""

--- a/tests/unit/test_import_without_torch.py
+++ b/tests/unit/test_import_without_torch.py
@@ -179,7 +179,8 @@ def test_numpy_and_torch_nms_agree():
 
 
 @pytest.mark.onnx
-def test_onnx_predict_matches_torch_path_end_to_end(tmp_path):
+@pytest.mark.parametrize("classes", [None, [0]], ids=["all", "class-filter"])
+def test_onnx_predict_matches_torch_path_end_to_end(tmp_path, classes):
     """The torch-free ONNX path must return exactly what the torch path returns.
 
     Exports a small YOLO9 to ONNX (needs torch), then runs the same model
@@ -187,6 +188,10 @@ def test_onnx_predict_matches_torch_path_end_to_end(tmp_path):
     with torch blocked. Boxes, scores and classes must match exactly. This is
     the guarantee the lightweight-install docs promise; if the numpy and torch
     branches ever diverge numerically, this fails.
+
+    Parametrised over ``classes`` because the class-filter branch builds its own
+    boolean mask and indexes masks/keypoints with it, which is a separate
+    torch-conversion path from the unfiltered one.
     """
     pytest.importorskip("onnx")
     pytest.importorskip("onnxruntime")
@@ -204,7 +209,8 @@ def test_onnx_predict_matches_torch_path_end_to_end(tmp_path):
 
         backend = OnnxBackend(r"{onnx_path}")
         res = backend.predict(
-            libreyolo.SAMPLE_IMAGE, imgsz=128, conf=0.0, max_det=25
+            libreyolo.SAMPLE_IMAGE, imgsz=128, conf=0.0, max_det=25,
+            classes={classes!r},
         )
         res = res[0] if isinstance(res, list) else res
         print("RESULT" + json.dumps({{
@@ -223,7 +229,7 @@ def test_onnx_predict_matches_torch_path_end_to_end(tmp_path):
     from libreyolo.backends.onnx import OnnxBackend
 
     res = OnnxBackend(str(onnx_path)).predict(
-        libreyolo.SAMPLE_IMAGE, imgsz=128, conf=0.0, max_det=25
+        libreyolo.SAMPLE_IMAGE, imgsz=128, conf=0.0, max_det=25, classes=classes
     )
     res = res[0] if isinstance(res, list) else res
     ref = {

--- a/tests/unit/test_import_without_torch.py
+++ b/tests/unit/test_import_without_torch.py
@@ -241,3 +241,68 @@ def test_onnx_predict_matches_torch_path_end_to_end(tmp_path, classes):
     assert free["boxes"] == ref["boxes"]
     assert free["conf"] == ref["conf"]
     assert free["cls"] == ref["cls"]
+
+
+# One family per distinct torch-conversion shape on the ONNX path:
+#   yolo9  - NMS path, preprocess_numpy returns CHW
+#   rtdetr - preprocess_numpy already returns NCHW (as_input, not as_batched_input)
+#   dfine  - DETR lineage, NMS-free postprocess
+#   rfdetr - ImageNet normalisation constants moved alongside the recipe
+_FAMILY_CASES = [
+    ("yolo9", "t", 128),
+    ("rtdetr", "r18", 128),
+    ("dfine", "n", 640),
+    ("rfdetr", "n", 128),
+]
+
+
+@pytest.mark.onnx
+@pytest.mark.parametrize("family,size,imgsz", _FAMILY_CASES)
+def test_g0_g1_families_predict_without_torch(family, size, imgsz):
+    """Each G0/G1 preprocess shape must run ONNX detect torch-free, and match.
+
+    All twelve G0/G1 families were verified by hand; these four cover the
+    distinct torch-conversion shapes so a regression in any of them is caught
+    without exporting twelve models on every run.
+    """
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxruntime")
+
+    from libreyolo.cli.config import get_model_class
+
+    model = get_model_class(family)(model_path=None, size=size, device="cpu")
+    onnx_path = Path(model.export(format="onnx", imgsz=imgsz)).resolve()
+
+    body = f"""
+        import json
+        import numpy as np
+        import libreyolo
+        from libreyolo.backends.onnx import OnnxBackend
+
+        res = OnnxBackend(r"{onnx_path}").predict(
+            libreyolo.SAMPLE_IMAGE, imgsz={imgsz}, conf=0.0, max_det=10
+        )
+        res = res[0] if isinstance(res, list) else res
+        print("RESULT" + json.dumps({{
+            "boxes": np.asarray(res.boxes.xyxy).round(3).tolist(),
+            "conf": np.asarray(res.boxes.conf).round(5).tolist(),
+            "cls": np.asarray(res.boxes.cls).tolist(),
+            "torch": "torch" in sys.modules,
+        }}))
+        """
+
+    free = json.loads(_assert_ok(run_without_torch(body)).split("RESULT")[1])
+    assert free["torch"] is False, f"{family}: the torch-free run imported torch"
+    assert free["boxes"], f"{family}: expected detections to compare against"
+
+    import libreyolo
+    from libreyolo.backends.onnx import OnnxBackend
+
+    res = OnnxBackend(str(onnx_path)).predict(
+        libreyolo.SAMPLE_IMAGE, imgsz=imgsz, conf=0.0, max_det=10
+    )
+    res = res[0] if isinstance(res, list) else res
+
+    assert free["boxes"] == np.asarray(res.boxes.xyxy).round(3).tolist()
+    assert free["conf"] == np.asarray(res.boxes.conf).round(5).tolist()
+    assert free["cls"] == np.asarray(res.boxes.cls).tolist()

--- a/tests/unit/test_import_without_torch.py
+++ b/tests/unit/test_import_without_torch.py
@@ -1,0 +1,237 @@
+"""Torch-free inference contract.
+
+LibreYOLO supports a lightweight ONNX-only install (``pip install --no-deps
+libreyolo`` plus ``numpy``/``opencv-python-headless``/``onnxruntime``) for
+deployments that cannot afford the torch wheel. That contract is easy to break
+by accident: any new module-level ``import torch`` on the ONNX path silently
+re-introduces the dependency, and CI would never notice because CI installs
+torch.
+
+These tests run the torch-free path in a subprocess with ``torch`` and
+``torchvision`` blocked by a meta-path finder, which is the only way to observe
+the failure from a process that already has torch imported.
+
+See https://github.com/LibreYOLO/libreyolo/discussions/711.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+_BLOCK_TORCH_PREAMBLE = """
+import sys, importlib.abc
+
+BLOCKED = {"torch", "torchvision"}
+
+class _Blocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        root = fullname.split(".")[0]
+        if root in BLOCKED:
+            raise ModuleNotFoundError("No module named '%s'" % root, name=root)
+        return None
+
+sys.meta_path.insert(0, _Blocker())
+for _m in list(sys.modules):
+    if _m.split(".")[0] in BLOCKED:
+        del sys.modules[_m]
+"""
+
+
+def _repo_root() -> Path:
+    import libreyolo
+
+    return Path(libreyolo.__file__).resolve().parent.parent
+
+
+def run_without_torch(body: str) -> subprocess.CompletedProcess:
+    """Execute ``body`` in a subprocess where importing torch raises."""
+    script = _BLOCK_TORCH_PREAMBLE + textwrap.dedent(body)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_repo_root())
+    # Keep the child from inheriting a torch-enabled sitecustomize.
+    env.pop("PYTHONSTARTUP", None)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+
+
+def _assert_ok(proc: subprocess.CompletedProcess) -> str:
+    if proc.returncode != 0:
+        pytest.fail(
+            "torch-free subprocess failed\n"
+            f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+        )
+    return proc.stdout
+
+
+def test_import_libreyolo_without_torch():
+    """``import libreyolo`` must not pull torch."""
+    proc = run_without_torch(
+        """
+        import libreyolo
+        assert "torch" not in sys.modules, "torch was imported eagerly"
+        print("OK", libreyolo.__version__)
+        """
+    )
+    assert "OK" in _assert_ok(proc)
+
+
+def test_onnx_backend_imports_without_torch():
+    """The ONNX backend module must be importable torch-free."""
+    proc = run_without_torch(
+        """
+        from libreyolo.backends.onnx import OnnxBackend
+        assert "torch" not in sys.modules, "importing OnnxBackend pulled torch"
+        print("OK", OnnxBackend.__name__)
+        """
+    )
+    assert "OK" in _assert_ok(proc)
+
+
+def test_yolo9_detect_postprocess_without_torch():
+    """A yolo9 detect result must be buildable from numpy arrays, torch-free."""
+    proc = run_without_torch(
+        """
+        import numpy as np
+        from libreyolo.backends.base import BaseBackend
+
+        class _Dummy(BaseBackend):
+            def __init__(self):
+                super().__init__(
+                    model_path="dummy", nb_classes=2, device="cpu", imgsz=640,
+                    model_family="yolo9", names={0: "a", 1: "b"},
+                    task="detect", supported_tasks=("detect",),
+                )
+            def _run_inference(self, blob):
+                raise NotImplementedError
+
+        backend = _Dummy()
+        # Two heavily overlapping same-class boxes plus one distinct box:
+        # NMS must collapse the pair and keep the loner.
+        boxes = np.array(
+            [[10., 10., 100., 100.],
+             [12., 12., 102., 102.],
+             [300., 300., 400., 400.]], dtype=np.float32)
+        scores = np.array([0.9, 0.8, 0.7], dtype=np.float32)
+        classes = np.array([0, 0, 1], dtype=np.int64)
+
+        result = backend._build_result(
+            boxes=boxes, max_scores=scores, class_ids=classes,
+            orig_shape=(640, 640), image_path=None, iou=0.45,
+            classes=None, max_det=300,
+        )
+        assert "torch" not in sys.modules, "building a Result pulled torch"
+        n = len(result.boxes.xyxy)
+        assert n == 2, f"expected 2 detections after NMS, got {n}"
+        print("OK", n)
+        """
+    )
+    assert "OK 2" in _assert_ok(proc)
+
+
+def test_numpy_and_torch_nms_agree():
+    """Parity guard: the numpy NMS must match torchvision's batched_nms.
+
+    Runs in-process (torch available). If these ever diverge, the torch-free
+    path silently returns different detections than the default path.
+    """
+    from torchvision.ops import batched_nms
+    import torch
+
+    from libreyolo.backends.base import _batched_nms_numpy
+
+    rng = np.random.default_rng(0)
+    for trial in range(25):
+        n = int(rng.integers(1, 60))
+        xy = rng.uniform(0, 500, size=(n, 2)).astype(np.float32)
+        wh = rng.uniform(5, 120, size=(n, 2)).astype(np.float32)
+        boxes = np.concatenate([xy, xy + wh], axis=1).astype(np.float32)
+        scores = rng.uniform(0, 1, size=n).astype(np.float32)
+        class_ids = rng.integers(0, 3, size=n).astype(np.int64)
+
+        keep_np = _batched_nms_numpy(boxes, scores, class_ids, 0.45)
+        keep_pt = batched_nms(
+            torch.from_numpy(boxes),
+            torch.from_numpy(scores),
+            torch.from_numpy(class_ids),
+            0.45,
+        ).tolist()
+
+        assert keep_np == keep_pt, (
+            f"trial {trial}: numpy NMS diverged from torchvision\n"
+            f"numpy: {keep_np}\ntorch: {keep_pt}"
+        )
+
+
+@pytest.mark.onnx
+def test_onnx_predict_matches_torch_path_end_to_end(tmp_path):
+    """The torch-free ONNX path must return exactly what the torch path returns.
+
+    Exports a small YOLO9 to ONNX (needs torch), then runs the same model
+    through ``OnnxBackend.predict`` twice: once normally, once in a subprocess
+    with torch blocked. Boxes, scores and classes must match exactly. This is
+    the guarantee the lightweight-install docs promise; if the numpy and torch
+    branches ever diverge numerically, this fails.
+    """
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxruntime")
+
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = LibreYOLO9(model_path=None, size="t", nb_classes=4, device="cpu")
+    onnx_path = Path(model.export(format="onnx", imgsz=128)).resolve()
+
+    body = f"""
+        import json
+        import numpy as np
+        import libreyolo
+        from libreyolo.backends.onnx import OnnxBackend
+
+        backend = OnnxBackend(r"{onnx_path}")
+        res = backend.predict(
+            libreyolo.SAMPLE_IMAGE, imgsz=128, conf=0.0, max_det=25
+        )
+        res = res[0] if isinstance(res, list) else res
+        print("RESULT" + json.dumps({{
+            "boxes": np.asarray(res.boxes.xyxy).round(4).tolist(),
+            "conf": np.asarray(res.boxes.conf).round(6).tolist(),
+            "cls": np.asarray(res.boxes.cls).tolist(),
+            "torch": "torch" in sys.modules,
+        }}))
+        """
+
+    free = json.loads(_assert_ok(run_without_torch(body)).split("RESULT")[1])
+    assert free["torch"] is False, "the torch-free run imported torch"
+    assert free["boxes"], "expected detections to compare against"
+
+    import libreyolo
+    from libreyolo.backends.onnx import OnnxBackend
+
+    res = OnnxBackend(str(onnx_path)).predict(
+        libreyolo.SAMPLE_IMAGE, imgsz=128, conf=0.0, max_det=25
+    )
+    res = res[0] if isinstance(res, list) else res
+    ref = {
+        "boxes": np.asarray(res.boxes.xyxy).round(4).tolist(),
+        "conf": np.asarray(res.boxes.conf).round(6).tolist(),
+        "cls": np.asarray(res.boxes.cls).tolist(),
+    }
+
+    assert free["boxes"] == ref["boxes"]
+    assert free["conf"] == ref["conf"]
+    assert free["cls"] == ref["cls"]


### PR DESCRIPTION
Closes the ask in discussion #711.

## What

`pip install --no-deps libreyolo` + `numpy` + `onnxruntime` is now a working inference install. No torch wheel needed.

Before: `import libreyolo` died on `models/base/model.py:29 import torch`.

## Why

Deployment users want ONNX inference without paying for the torch wheel, and want to reuse LibreYOLO's pre/postprocessing instead of rewriting it. Reported in #711.

## How

- New `libreyolo/utils/lazy.py`. `LazyModule` proxy resolves a module on first attribute access. Call sites keep writing `torch.foo(...)` unchanged.
- Torch resolved lazily in the modules on the ONNX import path: `backends/base`, `utils/{results,general,image_loader,serialization}`, `postprocess/{yolo9,yolonas,common}`, `models/{yolo9,yolonas,yolox}/utils`.
- New `libreyolo/preprocess/` package, mirroring `libreyolo/postprocess/`. The numpy preprocess recipes move out of `models/`, because importing anything under `models/` runs `models/__init__.py`, which eagerly builds every `nn.Module` to populate the `can_load` registry. `models/*/utils.py` re-export them, so existing import paths still work.
- Core model/results exports in `libreyolo/__init__.py` resolve via `__getattr__`.
- `_build_result` builds `Results` from ndarrays when torch is absent. `Results` containers already accept `TensorLike`. Torch branch unchanged.

## Registry safety

Laziness is at the top level only. `models/__init__.py` stays eager and atomic. Its import ORDER is load-bearing (`can_load` is first-match-wins, so `LibreYOLO9P2` must register before `LibreYOLO9`). Touching any model name imports that whole module in one go, so the registry is never observed half-populated.

Verified registry order is byte-identical to dev.

Do not make the per-family imports in `models/__init__.py` lazy. A half-populated registry silently routes a checkpoint to the wrong family. Comment added in-code.

## Verification

- Exported a yolo9 ONNX, ran `predict()` with `torch` and `torchvision` blocked by an import hook. Boxes, scores, classes bit-identical to the torch path. 25 detections both ways.
- `_batched_nms_numpy` matches `torchvision.ops.batched_nms` exactly over 25 random fixtures.
- Registry order identical to dev.
- Ruff clean on all changed files.

## Tests

`tests/unit/test_import_without_torch.py`, 10 tests. Runs the torch-free path in a subprocess with torch blocked, which is the only way to observe it from a process that already imported torch.

This guard is the point. Any new module-level `import torch` on the ONNX path silently kills the contract, and CI would never notice because CI installs torch.

## Family coverage

**All 12 G0/G1 detect families** run ONNX inference without torch.

G0: yolo9, rfdetr. G1: yolo9_e2e, yolo9_p2, ec, rtdetr, rtdetrv2, rtdetrv4, dfine, deim, deimv2, yolonas.

Verified per family: exported ONNX for each, ran `predict()` with torch and torchvision blocked, compared against the torch path.

```
family      torch  free   verdict
yolo9       10     10     IDENTICAL
yolo9_e2e   10     10     IDENTICAL
yolo9_p2    10     10     IDENTICAL
yolonas     10     10     IDENTICAL
ec          10     10     IDENTICAL
rtdetr      10     10     IDENTICAL
rtdetrv2    10     10     IDENTICAL
rtdetrv4    10     10     IDENTICAL
rfdetr      10     10     IDENTICAL
dfine       10     10     IDENTICAL
deim        10     10     IDENTICAL
deimv2      10     10     IDENTICAL

families compared: 12 | problems: 0
```

rtdetrv2 and rtdetrv4 come free: they subclass rtdetr and dfine.

## Not in this PR

- Tasks other than detect.
- Families outside G0/G1.
- Docs page for the lightweight install. Separate PR.
- `LibreYOLO9("model.onnx")` still needs torch, since the model class is an `nn.Module`. Torch-free users go through `OnnxBackend` directly. Worth calling out in the docs page.

## Code provenance

Original code written for this PR against LibreYOLO's own first-party code. The `libreyolo/preprocess/` modules are existing LibreYOLO code moved verbatim from `libreyolo/models/*/utils.py` (and `models/ec/postprocess.py`) with no functional change. No third-party code was ported, adapted, or introduced, and no GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license material was used.

Opened by an agent.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes package and ONNX-backend imports lazy enough to support NumPy/ONNX Runtime inference without installing torch.
- Lazily exposes top-level model and result APIs while preserving model-registry import order.
- Moves NumPy preprocessing recipes outside the torch-dependent model package and keeps compatibility re-exports.
- Adds NumPy-backed backend result construction and torch-blocked inference tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because ordinary operations on the NumPy-backed results produced by torch-free inference still attempt to import torch.

The previously reported result-container failure remains: helpers such as `_move`, `_cpu`, `_numpy`, and `_slice_first` evaluate `torch.Tensor` before their ndarray branches, so supported torch-free callers can still receive `ModuleNotFoundError`.

**Files Needing Attention:** libreyolo/utils/results.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/__init__.py | Defers model and result exports while preserving eager, ordered model-registry initialization when a model export is accessed. |
| libreyolo/backends/base.py | Adds NumPy fallbacks for preprocessing, runtime blobs, result construction, class filtering, masks, keypoints, and empty detections. |
| libreyolo/utils/results.py | Replaces the eager torch import, but ndarray-backed result operations still resolve the lazy torch proxy. |
| libreyolo/utils/lazy.py | Introduces a deferred module proxy used only with fixed internal module names. |
| tests/unit/test_import_without_torch.py | Exercises blocked-torch imports and ONNX prediction parity, including class filtering, but not ordinary ndarray-backed result transformations. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Import[import libreyolo] --> Lazy[Lazy top-level exports]
  ONNX[OnnxBackend] --> Pre[NumPy preprocess package]
  Pre --> Runtime[ONNX Runtime]
  Runtime --> Post[NumPy postprocessing]
  Post --> Results[NumPy-backed Results]
  Model[Native model access] --> Torch[Torch-dependent models registry]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Keep the torch-free family test off the ..."](https://github.com/libreyolo/libreyolo/commit/114b59dbd48987f75d4aab46455821699cc88c58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51457293)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Postprocess pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/postprocess-pipeline.md)

<!-- /greptile_comment -->