### PR TITLE
Fix direct weight autodownload

### DIFF
--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -317,11 +317,20 @@ class LibreDEIM(BaseModel):
     def _load_weights(self, model_path: str):
         model_path = self._resolve_weights_path(model_path)
         path = Path(model_path)
+        download_error = None
         if not path.exists():
             from ...utils.download import download_weights
 
-            download_weights(model_path, self.size)
+            try:
+                download_weights(model_path, self.size)
+            except Exception as exc:
+                download_error = exc
         if not path.exists():
+            if download_error is not None:
+                raise FileNotFoundError(
+                    f"DEIM weights file not found: {model_path}\n"
+                    f"Auto-download failed: {download_error}"
+                ) from download_error
             raise FileNotFoundError(f"DEIM weights file not found: {model_path}")
 
         try:

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -315,7 +315,13 @@ class LibreDEIM(BaseModel):
         return results
 
     def _load_weights(self, model_path: str):
-        if not Path(model_path).exists():
+        model_path = self._resolve_weights_path(model_path)
+        path = Path(model_path)
+        if not path.exists():
+            from ...utils.download import download_weights
+
+            download_weights(model_path, self.size)
+        if not path.exists():
             raise FileNotFoundError(f"DEIM weights file not found: {model_path}")
 
         try:

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -431,7 +431,13 @@ class LibreDEIMv2(BaseModel):
             )
 
     def _load_weights(self, model_path: str):
-        if not Path(model_path).exists():
+        model_path = self._resolve_weights_path(model_path)
+        path = Path(model_path)
+        if not path.exists():
+            from ...utils.download import download_weights
+
+            download_weights(model_path, self.size)
+        if not path.exists():
             raise FileNotFoundError(f"DEIMv2 weights file not found: {model_path}")
 
         try:

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -433,11 +433,20 @@ class LibreDEIMv2(BaseModel):
     def _load_weights(self, model_path: str):
         model_path = self._resolve_weights_path(model_path)
         path = Path(model_path)
+        download_error = None
         if not path.exists():
             from ...utils.download import download_weights
 
-            download_weights(model_path, self.size)
+            try:
+                download_weights(model_path, self.size)
+            except Exception as exc:
+                download_error = exc
         if not path.exists():
+            if download_error is not None:
+                raise FileNotFoundError(
+                    f"DEIMv2 weights file not found: {model_path}\n"
+                    f"Auto-download failed: {download_error}"
+                ) from download_error
             raise FileNotFoundError(f"DEIMv2 weights file not found: {model_path}")
 
         try:

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -408,11 +408,20 @@ class LibreDFINE(BaseModel):
     def _load_weights(self, model_path: str):
         model_path = self._resolve_weights_path(model_path)
         path = Path(model_path)
+        download_error = None
         if not path.exists():
             from ...utils.download import download_weights
 
-            download_weights(model_path, self.size)
+            try:
+                download_weights(model_path, self.size)
+            except Exception as exc:
+                download_error = exc
         if not path.exists():
+            if download_error is not None:
+                raise FileNotFoundError(
+                    f"D-FINE weights file not found: {model_path}\n"
+                    f"Auto-download failed: {download_error}"
+                ) from download_error
             raise FileNotFoundError(f"D-FINE weights file not found: {model_path}")
 
         try:

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -406,7 +406,13 @@ class LibreDFINE(BaseModel):
         return results
 
     def _load_weights(self, model_path: str):
-        if not Path(model_path).exists():
+        model_path = self._resolve_weights_path(model_path)
+        path = Path(model_path)
+        if not path.exists():
+            from ...utils.download import download_weights
+
+            download_weights(model_path, self.size)
+        if not path.exists():
             raise FileNotFoundError(f"D-FINE weights file not found: {model_path}")
 
         try:

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -579,7 +579,13 @@ class LibreEC(BaseModel):
         return results
 
     def _load_weights(self, model_path: str):
-        if not Path(model_path).exists():
+        model_path = self._resolve_weights_path(model_path)
+        path = Path(model_path)
+        if not path.exists():
+            from ...utils.download import download_weights
+
+            download_weights(model_path, self.size)
+        if not path.exists():
             raise FileNotFoundError(f"EC weights file not found: {model_path}")
 
         try:

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -581,11 +581,20 @@ class LibreEC(BaseModel):
     def _load_weights(self, model_path: str):
         model_path = self._resolve_weights_path(model_path)
         path = Path(model_path)
+        download_error = None
         if not path.exists():
             from ...utils.download import download_weights
 
-            download_weights(model_path, self.size)
+            try:
+                download_weights(model_path, self.size)
+            except Exception as exc:
+                download_error = exc
         if not path.exists():
+            if download_error is not None:
+                raise FileNotFoundError(
+                    f"EC weights file not found: {model_path}\n"
+                    f"Auto-download failed: {download_error}"
+                ) from download_error
             raise FileNotFoundError(f"EC weights file not found: {model_path}")
 
         try:

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -345,17 +345,20 @@ def test_direct_constructor_attempts_autodownload(
     target = Path("weights") / filename
     calls = []
 
-    class DownloadTriggered(RuntimeError):
-        pass
+    failure = RuntimeError("connection reset while fetching checkpoint")
 
     def fake_download(model_path, requested_size):
         calls.append((Path(model_path), requested_size))
-        raise DownloadTriggered
+        raise failure
 
     monkeypatch.setattr(model_cls, "_init_model", lambda _self: torch.nn.Identity())
     monkeypatch.setattr(download, "download_weights", fake_download)
 
-    with pytest.raises(DownloadTriggered):
+    with pytest.raises(
+        FileNotFoundError,
+        match="Auto-download failed: connection reset while fetching checkpoint",
+    ) as exc_info:
         model_cls(filename, size=size, device="cpu")
 
     assert calls == [(target, size)]
+    assert exc_info.value.__cause__ is failure

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -5,10 +5,15 @@ import queue
 import time
 from pathlib import Path
 
-import requests
 import pytest
+import requests
+import torch
 
 from libreyolo.models.base.model import BaseModel
+from libreyolo.models.deim.model import LibreDEIM
+from libreyolo.models.deimv2.model import LibreDEIMv2
+from libreyolo.models.dfine.model import LibreDFINE
+from libreyolo.models.ec.model import LibreEC
 from libreyolo.utils import download
 
 pytestmark = pytest.mark.unit
@@ -321,3 +326,36 @@ def test_factory_reports_and_chains_download_failure(monkeypatch, tmp_path):
         models.LibreYOLO("LibreYOLO9t.pt")
 
     assert exc_info.value.__cause__ is failure
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "filename", "size"),
+    [
+        (LibreDFINE, "LibreDFINEn.pt", "n"),
+        (LibreDEIM, "LibreDEIMn.pt", "n"),
+        (LibreDEIMv2, "LibreDEIMv2atto.pt", "atto"),
+        (LibreEC, "LibreECs.pt", "s"),
+    ],
+    ids=("dfine", "deim", "deimv2", "ec"),
+)
+def test_direct_constructor_attempts_autodownload(
+    model_cls, filename, size, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    target = Path("weights") / filename
+    calls = []
+
+    class DownloadTriggered(RuntimeError):
+        pass
+
+    def fake_download(model_path, requested_size):
+        calls.append((Path(model_path), requested_size))
+        raise DownloadTriggered
+
+    monkeypatch.setattr(model_cls, "_init_model", lambda _self: torch.nn.Identity())
+    monkeypatch.setattr(download, "download_weights", fake_download)
+
+    with pytest.raises(DownloadTriggered):
+        model_cls(filename, size=size, device="cpu")
+
+    assert calls == [(target, size)]


### PR DESCRIPTION
<!--
Write your PR description however you like. Structure it your own way.
Only the "Code provenance" section below is required (CI checks it exists and
is filled). Everything else is up to you.
-->

## Code provenance

<!--
Required. Replace this comment with a statement of where the code in this PR
comes from. Use whatever wording and structure you prefer, as long as the
provenance is clear. Cover, as applicable:
  - original code written for this PR, and/or
  - code ported, adapted, or derived from a third party: the upstream
    repository, the commit or version, and its license.
Only permissively licensed sources are acceptable (MIT, Apache-2.0, BSD, or
similar). GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license
code is not accepted, in any form (including rewrites or renamed adaptations).
-->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes direct weight auto-download behavior for DEIM, DEIMv2, D-FINE, and EC constructors.
- Resolves bare checkpoint names before checking or downloading them.
- Converts failed downloads for still-missing files into model-specific `FileNotFoundError` exceptions while preserving the original cause.
- Adds parameterized coverage for all four direct constructors.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported exception-contract issue is fixed for all four affected direct constructors.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/deim/model.py | Resolves missing DEIM checkpoints, attempts auto-download, and preserves the missing-file exception contract on failure. |
| libreyolo/models/deimv2/model.py | Applies the corrected direct-constructor download and error-handling flow to DEIMv2. |
| libreyolo/models/dfine/model.py | Applies the corrected direct-constructor download and error-handling flow to D-FINE. |
| libreyolo/models/ec/model.py | Applies the corrected direct-constructor download and error-handling flow to EC. |
| tests/unit/test_download.py | Adds parameterized tests confirming all four direct constructors attempt downloads and chain failures into FileNotFoundError. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Direct model constructor] --> B[Resolve checkpoint path]
    B --> C{Checkpoint exists?}
    C -->|Yes| G[Load checkpoint]
    C -->|No| D[Attempt weight download]
    D --> E{Resolved checkpoint now exists?}
    E -->|Yes| G
    E -->|No, download failed| F[Raise chained FileNotFoundError]
    E -->|No, no captured error| H[Raise FileNotFoundError]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Preserve download failure contract"](https://github.com/libreyolo/libreyolo/commit/a0985b2cb3f287b9dfb111799d3b56d2c08443fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51458391)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->