### PR TITLE
Document CUDA graph and profiler traps in the RF100-VL skill

### DIFF
--- a/skills/run-rf100vl-benchmark/SKILL.md
+++ b/skills/run-rf100vl-benchmark/SKILL.md
@@ -43,7 +43,7 @@ knowledge those two do not cover.
 | Eval thresholds | conf 0.001; NMS IoU 0.65 for NMS families, identical at selection and final eval; DETR families are NMS-free top-k | LibreYOLO policy |
 | Seed | 0 | LibreYOLO policy |
 | Recipes | one pinned JSON per family in the harness (`va_bench/recipes/rf100vl/`), sha recorded in every run, same recipe for all 100 datasets | LibreYOLO policy |
-| Execution (YOLO) | `cuda_graph: true` and `cache: "disk"` in the recipe protocol when the installed LibreYOLO supports them (bit-identical; covered by recipe hash) | measured 2026-08 |
+| Execution (YOLO) | `cuda_graph: true` and `cache: "disk"` in the recipe protocol when the installed LibreYOLO supports them (bit-identical; covered by recipe hash). Verify capture per family, per commit and per card: see "CUDA graphs and cache" | measured 2026-08 |
 | COCO evaluator | faster-coco-eval (Apache-2.0), now the LibreYOLO default; record the backend in artifacts | measured 2026-08 |
 
 Never report toolkit-native trapezoidal mAP; it inflates up to 2.7 AP on
@@ -293,6 +293,85 @@ libreyolo profile what-if ...  # projected gain from a fix
 High self-CPU on an op like `aten::max` with near-zero self-CUDA usually
 marks a GPU→CPU sync absorbing device wait, not a CPU bottleneck in that
 op. Total self-CUDA ≪ total self-CPU ⇒ launch-bound (CUDA graphs).
+
+**First check that the GPU counters attached at all.** On a rented box where
+CUPTI fails to load, the profiler still prints a full report, but every
+device-side number is zero and the VERDICT line is then an artifact rather
+than a measurement. Measured 2026-08 on an 8x RTX 5060 Ti box:
+
+```
+REAL step 362.3 ms = dataload 0.1 ms + compute 362.3 ms  ->  44.2 img/s
+GPU util 0%  (0 ms GPU-busy / 362 ms step)  |  0 kernels/step @ ~0us
+>> VERDICT: HOST/LAUNCH-BOUND - GPU only ~0% busy
+```
+
+That verdict was wrong: enabling CUDA graphs on the same model and batch
+changed the epoch time by nothing. `0 kernels/step` is the tell. When you see
+it, ignore the verdict and the "self-CUDA vs self-CPU" rule above, both of
+which are derived from the dead counters, and read the per-phase wall table
+instead, which is host-side timing and stays valid:
+
+```
+phase         gpu_ms  wall_ms  kernels     ops
+to_device        0.0      5.9        0       8
+forward          0.0    127.9        0    4562
+backward         0.0    222.9        0    5093
+optimizer        0.0      6.3        0    2800
+```
+
+### CUDA graphs and cache: prefer them, then verify both
+
+Keep `cuda_graph: true` and `cache: "disk"` as the default recipe protocol.
+Both are perf-only and covered by the recipe hash. Two things to verify
+before trusting either, because each has cost a campaign.
+
+**Capture is gated by family and by commit.** At an older pinned LibreYOLO
+only `yolo9` and `rfdetr` implemented the training capture hook; every other
+family took the eager fallback, so setting the flag did nothing but log a
+warning. Current dev covers far more families (`docs/training_cuda_graphs.md`
+holds the table and the per-family speedups). Check that table for the commit
+you actually pinned, not for `dev`, and confirm the run log says
+`cuda_graph: captured training forward/backward at input shape (...)`. Absent
+that line, the flag is decorative.
+
+**The speedup is batch-dependent, and can be zero.** The documented gains are
+measured at batch 8, where launch overhead is a large share of the step. At
+the protocol's batch 16 the same model can show nothing: yolonas-s measured
+83.4 / 78.9 s per epoch eager against 83.6 / 78.4 s graphed, with capture
+confirmed in the log. yolo9 still gains at batch 16. Measure before assuming.
+
+**Capture inflates VRAM, and `libreyolo profile run` will not show it**
+because it does not capture graphs. yolo9-m at 640 and batch 16 profiled at
+15721 MB, which looks survivable on a 16 GB card. The real graphed run OOM'd
+on **all 100 datasets**, with the failure naming the cause:
+
+```
+13.61 GiB allocated in private pools (e.g., CUDA Graphs)
+```
+
+Disabling capture on that box dropped the same run to 15207 MB and it trained
+fine at full protocol batch. So size the lane with a 2-epoch smoke campaign,
+which exercises the real path including capture, EMA and validation:
+
+```bash
+va-bench rf100vl-campaign --model <M> --recipe <R> \
+  --datasets <one-dataset> --gpus 0 --jobs-per-gpu 1 --smoke-epochs 2
+```
+
+For a NMS-family model that cannot hold capture on the target card, dropping
+`cuda_graph` is the cheap deviation: the harness treats graph replay as
+outside the run signature and bit-identical on loss. Dropping physical batch
+is the expensive one, because it changes BatchNorm statistics even though
+`nbs` keeps the effective batch at 16.
+
+### Contribute the speedup back
+
+The campaign is a load test of LibreYOLO training, so treat what the profiler
+finds as a LibreYOLO bug list rather than a campaign workaround list. The
+scoring cost above is the model: it was found by profiling a campaign, fixed
+in the library as a default, and now every user benefits. When a fix belongs
+in the library, send it there and pin the campaign to the commit that carries
+it, rather than carrying a private patch on the box.
 
 ### Shakedown (before any full campaign)
 


### PR DESCRIPTION
Keeps `cuda_graph: true` and `cache: "disk"` as the recommended default, and
adds the verification each one needs. All numbers measured this week on an
8x RTX 5060 Ti campaign box.

## What changed

- New section: CUDA graphs and cache, prefer them then verify
- New trap: the profiler's verdict is an artifact when CUPTI does not attach
- Protocol table row points at the new section
- Short note: send speedups to the library, do not patch the rented box

## Measurements behind it

- Capture is gated by family AND by commit. On the pinned LibreYOLO only
  `yolo9` and `rfdetr` had the training hook, so the flag was a no-op plus a
  warning for everything else. Current dev covers many more families.
- Gain is batch dependent. Documented speedups are at batch 8. At the
  protocol's batch 16, yolonas-s: 83.4 / 78.9 s per epoch eager vs
  83.6 / 78.4 s graphed, capture confirmed in the log. No gain. yolo9 still
  gains at 16.
- Capture inflates VRAM and `libreyolo profile run` does not capture, so it
  under-reports. yolo9-m profiled 15721 MB on a 16 GB card, looked fine, then
  OOM'd on 100 of 100 datasets: `13.61 GiB allocated in private pools
  (e.g., CUDA Graphs)`. Same run without capture: 15207 MB, trains fine at
  full protocol batch.
- Dead counters: profiler printed `0 kernels/step`, `GPU util 0%` and
  `VERDICT: HOST/LAUNCH-BOUND`. Enabling graphs changed epoch time by
  nothing, so the verdict was wrong. Per-phase wall table stayed valid.

## Why it matters

Two campaign restarts came out of this. The 100 of 100 OOM was 4 minutes of
GPU time only because the failure was loud; the misleading profiler verdict
nearly bought a config change that measures as zero.

## Code provenance

Documentation only, no code. Prose written for this PR by me, an AI agent,
from measurements taken on our own RF100-VL campaign boxes this week. Log and
profiler excerpts quoted in the skill are output produced by LibreYOLO and by
the vision-analysis-benchmark harness on those runs. No third party code,
text, or documentation was copied or adapted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR expands the RF100-VL benchmark skill with CUDA graph capture checks, profiler-counter failure guidance, VRAM smoke-testing advice, and a recommendation to upstream performance fixes.
- Warns that zero GPU counters make profiler bottleneck verdicts unreliable.
- Documents capture support, batch-dependent gains, and graph-related memory overhead.
- Retains CUDA graphs and disk caching as defaults, although only graph verification is documented.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation-only PR appears safe to merge, with a non-blocking gap in the promised disk-cache verification guidance.

The CUDA graph and profiler guidance is consistent with the checked implementation, but operators are told to verify both performance defaults while receiving instructions only for CUDA graphs.

**Files Needing Attention:** skills/run-rf100vl-benchmark/SKILL.md
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| skills/run-rf100vl-benchmark/SKILL.md | Adds useful campaign guidance, but the new section promises verification of both CUDA graphs and disk caching without providing a cache-verification procedure. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Askills%2Frun-rf100vl-benchmark%2FSKILL.md%3A324-326%0A**Disk-cache%20verification%20is%20missing**%0A%0AThis%20section%20says%20both%20%60cuda_graph%60%20and%20%60cache%3A%20%22disk%22%60%20require%20verification%2C%20but%20the%20following%20procedure%20only%20explains%20how%20to%20verify%20graph%20capture.%20Add%20a%20concrete%20check%20that%20confirms%20the%20disk%20cache%20was%20created%20and%20reused%20so%20operators%20can%20complete%20the%20promised%20campaign%20validation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=739&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22skill-rf100vl-perf%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22skill-rf100vl-perf%22.%0A%0A%23%23%23%20Issue%201%0Askills%2Frun-rf100vl-benchmark%2FSKILL.md%3A324-326%0A**Disk-cache%20verification%20is%20missing**%0A%0AThis%20section%20says%20both%20%60cuda_graph%60%20and%20%60cache%3A%20%22disk%22%60%20require%20verification%2C%20but%20the%20following%20procedure%20only%20explains%20how%20to%20verify%20graph%20capture.%20Add%20a%20concrete%20check%20that%20confirms%20the%20disk%20cache%20was%20created%20and%20reused%20so%20operators%20can%20complete%20the%20promised%20campaign%20validation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=739&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Document CUDA graph and profiler traps i..."](https://github.com/libreyolo/libreyolo/commit/0b5551f7a7f158f0195285cd9a991abe80ea242c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51460152)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->