### PR TITLE
Make checkpoint autoconversion atomic

### DIFF
--- a/libreyolo/models/autoconvert.py
+++ b/libreyolo/models/autoconvert.py
@@ -34,6 +34,7 @@ import argparse
 import logging
 import os
 import re
+import stat
 import tempfile
 from pathlib import Path
 from typing import Any, Optional, Tuple
@@ -691,7 +692,7 @@ def _canonical_path(source: Path, prefix: str, size: str, task: str) -> Path:
     return source.parent / f"{source.stem}-{prefix}{size}{task_part}.pt"
 
 
-def _atomic_torch_save(value: Any, path: Path) -> None:
+def _atomic_torch_save(value: Any, path: Path, *, mode: int | None = None) -> None:
     """Save a checkpoint without exposing a partially written zip archive."""
     fd, temporary_name = tempfile.mkstemp(
         prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
@@ -700,6 +701,8 @@ def _atomic_torch_save(value: Any, path: Path) -> None:
     temporary = Path(temporary_name)
     try:
         torch.save(value, temporary)
+        if mode is not None:
+            os.chmod(temporary, mode)
         os.replace(temporary, path)
     finally:
         temporary.unlink(missing_ok=True)
@@ -758,11 +761,22 @@ def autoconvert_upstream_checkpoint(
     wrapped, family, prefix, size, task = result
     out_path = _canonical_path(path, prefix, size, task)
 
+    # mkstemp uses owner-only permissions on POSIX. Preserve an existing
+    # conversion's mode, or inherit the source checkpoint's mode on first
+    # publication, so atomic replacement does not make shared weights private.
+    publication_mode = None
+    if os.name != "nt":
+        try:
+            mode_source = out_path if out_path.exists() else path
+            publication_mode = stat.S_IMODE(mode_source.stat().st_mode)
+        except OSError:
+            pass
+
     # Always (re)write the source-specific conversion. This keeps repeated loads
     # of the same source fresh while avoiding collisions with official weights
     # or other fine-tunes of the same family/size/task in the directory.
     try:
-        _atomic_torch_save(wrapped, out_path)
+        _atomic_torch_save(wrapped, out_path, mode=publication_mode)
     except (OSError, RuntimeError) as exc:
         # Read-only source directory (e.g. a mounted cache). torch.save can
         # surface the failure as OSError (Python open) or RuntimeError (its

--- a/libreyolo/models/autoconvert.py
+++ b/libreyolo/models/autoconvert.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import re
 import tempfile
 from pathlib import Path
@@ -690,6 +691,20 @@ def _canonical_path(source: Path, prefix: str, size: str, task: str) -> Path:
     return source.parent / f"{source.stem}-{prefix}{size}{task_part}.pt"
 
 
+def _atomic_torch_save(value: Any, path: Path) -> None:
+    """Save a checkpoint without exposing a partially written zip archive."""
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    os.close(fd)
+    temporary = Path(temporary_name)
+    try:
+        torch.save(value, temporary)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 def autoconvert_upstream_checkpoint(
     model_path: str,
     *,
@@ -747,7 +762,7 @@ def autoconvert_upstream_checkpoint(
     # of the same source fresh while avoiding collisions with official weights
     # or other fine-tunes of the same family/size/task in the directory.
     try:
-        torch.save(wrapped, out_path)
+        _atomic_torch_save(wrapped, out_path)
     except (OSError, RuntimeError) as exc:
         # Read-only source directory (e.g. a mounted cache). torch.save can
         # surface the failure as OSError (Python open) or RuntimeError (its

--- a/tests/unit/test_autoconvert.py
+++ b/tests/unit/test_autoconvert.py
@@ -6,6 +6,8 @@ tests stay fast and need no external weights.
 """
 
 import argparse
+import os
+import stat
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -188,6 +190,29 @@ class TestAutoconvertOrchestration:
         assert all(path.parent == destination.parent for path in staged_paths)
         assert all(not path.exists() for path in staged_paths)
         assert torch.load(destination, weights_only=True)["writer"].item() in {0, 1}
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+    def test_first_conversion_inherits_source_mode(self, tmp_path):
+        src = tmp_path / "v9-t.pt"
+        torch.save({"model": _synthetic_upstream_yolo9(nc=2)}, src)
+        src.chmod(0o640)
+
+        out = Path(autoconvert_upstream_checkpoint(str(src)))
+
+        assert stat.S_IMODE(out.stat().st_mode) == 0o640
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+    def test_reconversion_preserves_destination_mode(self, tmp_path):
+        src = tmp_path / "v9-t.pt"
+        destination = tmp_path / "v9-t-LibreYOLO9t.pt"
+        torch.save({"model": _synthetic_upstream_yolo9(nc=2)}, src)
+        destination.write_bytes(b"old conversion")
+        destination.chmod(0o660)
+
+        out = Path(autoconvert_upstream_checkpoint(str(src)))
+
+        assert out == destination
+        assert stat.S_IMODE(out.stat().st_mode) == 0o660
 
     def test_converts_upstream_yolo9_with_custom_nc(self, tmp_path):
         src = tmp_path / "v9-t.pt"

--- a/tests/unit/test_autoconvert.py
+++ b/tests/unit/test_autoconvert.py
@@ -6,6 +6,8 @@ tests stay fast and need no external weights.
 """
 
 import argparse
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -111,6 +113,82 @@ def _synthetic_upstream_yolo9(nc: int) -> dict:
 
 
 class TestAutoconvertOrchestration:
+    def test_publishes_conversion_atomically(self, tmp_path, monkeypatch):
+        src = tmp_path / "v9-t.pt"
+        torch.save({"model": _synthetic_upstream_yolo9(nc=2)}, src)
+        expected = tmp_path / "v9-t-LibreYOLO9t.pt"
+        real_save = torch.save
+        observed = {}
+
+        def inspect_save(value, destination, *args, **kwargs):
+            destination = Path(destination)
+            observed["temporary"] = destination
+            assert destination != expected
+            assert destination.parent == expected.parent
+            assert not expected.exists()
+            real_save(value, destination, *args, **kwargs)
+            assert not expected.exists()
+
+        monkeypatch.setattr(autoconvert_module.torch, "save", inspect_save)
+
+        out = autoconvert_upstream_checkpoint(str(src))
+
+        assert out == str(expected)
+        assert expected.exists()
+        assert not observed["temporary"].exists()
+
+    def test_atomic_save_preserves_existing_file_on_failure(
+        self, tmp_path, monkeypatch
+    ):
+        destination = tmp_path / "converted.pt"
+        destination.write_bytes(b"complete-old-checkpoint")
+
+        def fail_after_partial_write(_value, temporary):
+            Path(temporary).write_bytes(b"partial")
+            raise RuntimeError("injected save failure")
+
+        monkeypatch.setattr(autoconvert_module.torch, "save", fail_after_partial_write)
+
+        with pytest.raises(RuntimeError, match="injected save failure"):
+            autoconvert_module._atomic_torch_save({}, destination)
+
+        assert destination.read_bytes() == b"complete-old-checkpoint"
+        assert list(tmp_path.glob(f".{destination.name}.*.tmp")) == []
+
+    def test_concurrent_writers_use_private_staging_files(
+        self, tmp_path, monkeypatch
+    ):
+        destination = tmp_path / "converted.pt"
+        barrier = threading.Barrier(2)
+        real_save = torch.save
+        staged_paths = []
+        staged_paths_lock = threading.Lock()
+
+        def synchronized_save(value, temporary, *args, **kwargs):
+            with staged_paths_lock:
+                staged_paths.append(Path(temporary))
+            barrier.wait(timeout=5)
+            real_save(value, temporary, *args, **kwargs)
+
+        monkeypatch.setattr(autoconvert_module.torch, "save", synchronized_save)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(
+                    autoconvert_module._atomic_torch_save,
+                    {"writer": torch.tensor([writer])},
+                    destination,
+                )
+                for writer in range(2)
+            ]
+            for future in futures:
+                future.result(timeout=10)
+
+        assert len(set(staged_paths)) == 2
+        assert all(path.parent == destination.parent for path in staged_paths)
+        assert all(not path.exists() for path in staged_paths)
+        assert torch.load(destination, weights_only=True)["writer"].item() in {0, 1}
+
     def test_converts_upstream_yolo9_with_custom_nc(self, tmp_path):
         src = tmp_path / "v9-t.pt"
         torch.save(


### PR DESCRIPTION
<!--
Write your PR description however you like. Structure it your own way.
Only the "Code provenance" section below is required (CI checks it exists and
is filled). Everything else is up to you.
-->

## Code provenance

<!--
Required. Replace this comment with a statement of where the code in this PR
comes from. Use whatever wording and structure you prefer, as long as the
provenance is clear. Cover, as applicable:
  - original code written for this PR, and/or
  - code ported, adapted, or derived from a third party: the upstream
    repository, the commit or version, and its license.
Only permissively licensed sources are acceptable (MIT, Apache-2.0, BSD, or
similar). GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license
code is not accepted, in any form (including rewrites or renamed adaptations).
-->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes checkpoint autoconversion atomic by saving into a private same-directory staging file and replacing the destination only after serialization succeeds.
- Preserves the source mode for initial conversion and the destination mode for reconversion on POSIX.
- Cleans up staging files after both successful and failed writes.
- Adds coverage for atomic publication, failed and concurrent writes, and permission preservation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/autoconvert.py | Adds same-directory atomic checkpoint publication and preserves the intended final-file permissions. |
| tests/unit/test_autoconvert.py | Adds focused tests for atomicity, failure cleanup, concurrent writers, and POSIX mode preservation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Preserve autoconvert checkpoint permissi..."](https://github.com/libreyolo/libreyolo/commit/9bd921decd5d13b8d3dc5fbd85d63861f9f166b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51470999)</sub>

<!-- /greptile_comment -->