### PR TITLE
Explain lingbotvision-g instead of 404ing

### DIFF
--- a/libreyolo/models/lingbotvision/model.py
+++ b/libreyolo/models/lingbotvision/model.py
@@ -83,6 +83,10 @@ class LibreLingBotVision(BaseModel):
     DEFAULT_TASK: ClassVar[str] = "semantic"
     REQUIRE_TASK_SUFFIX: ClassVar[bool] = True
     INPUT_SIZES: ClassVar[Dict[str, int]] = {size: 512 for size in SIZE_CONFIGS}
+    # g is the 1.1B teacher: loadable and fine-tunable, but no LibreYOLO-hosted
+    # checkpoint exists for it (see the module docstring). Kept as data so
+    # get_download_url and the error message cannot drift apart.
+    UNPUBLISHED_SIZES: ClassVar[Tuple[str, ...]] = ("g",)
 
     # ViT square canvas: stretch-resize (like LibreDINOv2), patch-16 grid.
     semantic_resize_mode: ClassVar[str] = "stretch"
@@ -90,6 +94,42 @@ class LibreLingBotVision(BaseModel):
     # The linear-probe recipe uses no photometric jitter; SemanticDataset
     # defaults to 0.5, so declare it explicitly (see LibreSegformer precedent).
     semantic_hsv_prob: ClassVar[float] = 0.0
+
+    # ------------------------------------------------------------------
+    # Weight download
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        """Refuse to auto-download the sizes that have no published weights.
+
+        Sizes s/b/l are hosted under ``LibreYOLO/``; g is the 1.1B teacher and
+        is not. Left to the base implementation, ``lingbotvision-g`` builds a
+        URL for a repo that does not exist and the user gets an HTTP failure
+        against ``LibreYOLO/LibreLingBotVisiong-sem``, which reads like an
+        outage rather than a checkpoint that was never published. Raise with
+        the reason instead.
+
+        The size guard matters: ``download_weights`` asks every registered
+        family in turn and takes the first non-None answer, so raising on a
+        filename that is not ours would hijack another family's download.
+        """
+        name = Path(filename).name
+        size = cls.detect_size_from_filename(name)
+        if size is None:
+            return None
+        if size in cls.UNPUBLISHED_SIZES:
+            published = ", ".join(
+                f"{cls.FAMILY}-{s}" for s in SIZE_CONFIGS if s not in cls.UNPUBLISHED_SIZES
+            )
+            raise FileNotFoundError(
+                f"{name}: LibreYOLO publishes no weights for {cls.FAMILY}-{size}. "
+                f"Size {size} is the upstream teacher backbone, supported for loading "
+                f"and fine-tuning from a local checkpoint but never mirrored under "
+                f"LibreYOLO/. Pass a local .pt path, or use one of the published "
+                f"sizes: {published}."
+            )
+        return super().get_download_url(name)
 
     # ------------------------------------------------------------------
     # Registry / can_load interface

--- a/tests/unit/test_lingbotvision.py
+++ b/tests/unit/test_lingbotvision.py
@@ -305,3 +305,50 @@ def test_lingbotvision_train_smoke(tmp_path):
         amp=False,
     )
     assert result.get("best_checkpoint") or result.get("last_checkpoint")
+
+
+def test_unpublished_size_download_explains_itself():
+    """``lingbotvision-g`` has no hosted checkpoint, so say so, do not 404.
+
+    Sizes s/b/l are mirrored under ``LibreYOLO/``; g is the 1.1B teacher and
+    never was. Left to the base implementation the user gets an HTTP failure
+    against a repo that does not exist, which reads like an outage rather
+    than a checkpoint that was never published.
+    """
+    from libreyolo.models.lingbotvision.model import LibreLingBotVision
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        LibreLingBotVision.get_download_url("LibreLingBotVisiong-sem.pt")
+    message = str(excinfo.value)
+    assert "publishes no weights" in message
+    assert "lingbotvision-s" in message
+    assert "lingbotvision-l" in message
+    assert "lingbotvision-g" not in message.split("published sizes:")[-1]
+
+
+@pytest.mark.parametrize("size", ["s", "b", "l"])
+def test_published_sizes_still_resolve(size):
+    """The guard must not swallow the sizes that are actually hosted."""
+    from libreyolo.models.lingbotvision.model import LibreLingBotVision
+
+    url = LibreLingBotVision.get_download_url(f"LibreLingBotVision{size}-sem.pt")
+    assert url == (
+        f"https://huggingface.co/LibreYOLO/LibreLingBotVision{size}-sem"
+        f"/resolve/main/LibreLingBotVision{size}-sem.pt"
+    )
+
+
+@pytest.mark.parametrize(
+    "foreign",
+    ["LibreSegformerb0-sem.pt", "LibreDINOv2s-sem.pt", "LibreYOLO9t.pt", "LibreDOMEDETRs-aitod.pt"],
+)
+def test_download_hook_ignores_other_families(foreign):
+    """The hook must claim only LingBot-Vision filenames.
+
+    ``download_weights`` asks every registered family in turn and takes the
+    first non-None answer, so a hook that raised on a foreign name would
+    hijack that family's download with the wrong error.
+    """
+    from libreyolo.models.lingbotvision.model import LibreLingBotVision
+
+    assert LibreLingBotVision.get_download_url(foreign) is None


### PR DESCRIPTION
Found by the v1.5.0 release weight-autodownload gate.

## Problem

- `libreyolo predict --model lingbotvision-g` resolves to `LibreYOLO/LibreLingBotVisiong-sem`
- that repo does not exist (HTTP 401); only s/b/l are published
- `g` is user-reachable: `INPUT_SIZES` is built from `SIZE_CONFIGS`, which carries s/b/l/g
- user sees an HTTP failure, reads it as an outage, goes hunting for a network fault

`g` having no hosted weights is intentional, it is the 1.1B teacher backbone. Only the error was wrong.

## Fix

- override `get_download_url` to raise `FileNotFoundError` naming the reason and the published sizes
- follows the Dome-DETR precedent in `libreyolo/models/domedetr/model.py`
- `UNPUBLISHED_SIZES` kept as data so the guard and the message cannot drift apart
- returns `None` for foreign filenames: `download_weights` asks every family in turn and takes the first non-None answer, so raising unconditionally would hijack another family's download

What the user sees now:

```
LibreLingBotVisiong-sem.pt: LibreYOLO publishes no weights for lingbotvision-g.
Size g is the upstream teacher backbone, supported for loading and fine-tuning
from a local checkpoint but never mirrored under LibreYOLO/. Pass a local .pt
path, or use one of the published sizes: lingbotvision-s, lingbotvision-b,
lingbotvision-l.
```

## Tests

3 new tests in `tests/unit/test_lingbotvision.py`: the error content, s/b/l still resolving to their real URLs, and foreign filenames still returning `None`. 9 passed locally. Verified end to end through `download_weights`, not just the classmethod.

## Code provenance

Original code written for this PR. No third-party code ported, adapted, or derived. The error-hook shape follows an existing in-repo pattern (`libreyolo/models/domedetr/model.py`, itself original LibreYOLO code).

https://claude.ai/code/session_01RnfUzHN4o749HJCznMuiBw

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the misleading remote-download failure for the intentionally unpublished LingBotVision `g` teacher checkpoint with a targeted local error.
- Adds data-driven tracking of unpublished LingBotVision sizes.
- Preserves URL generation for the published `s`, `b`, and `l` checkpoints.
- Ensures foreign model filenames remain available to other registered model families.
- Adds focused tests for the error message, published URLs, and foreign-filename handling.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or compatibility defects identified.

The new hook relies on the existing family-specific filename parser, raises only for the recognized unpublished teacher size, delegates published sizes to the established URL builder, and returns `None` for filenames owned by other model families.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/lingbotvision/model.py | Adds a family-scoped download hook that rejects the unpublished `g` checkpoint while preserving existing resolution for published and foreign filenames. |
| tests/unit/test_lingbotvision.py | Covers unpublished-size diagnostics, published-size URL generation, and registry-safe handling of foreign filenames. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Explain lingbotvision-g instead of 404in..."](https://github.com/libreyolo/libreyolo/commit/849037b37de62d4a1efe2579367e0bf9958f169b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51578094)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->