### PR TITLE
README rework and two Dome-DETR corrections for v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-LibreYOLO-blue?logo=linkedin)](https://www.linkedin.com/company/libreyolo/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-MIT-licensed computer vision library with inference and training support for a variety of models. It provides a familiar high-level Python and CLI interface and reads common YOLO-format datasets, so existing workflows port over with minimal changes.
+**An MIT-licensed computer vision library.** Detection, segmentation, pose,
+depth, OCR and a dozen more tasks behind one small API, with training and
+export included rather than sold separately. Reads common YOLO-format
+datasets, so existing workflows port over with minimal changes.
 
 ![LibreYOLO Detection Example](libreyolo/assets/parkour_result.jpg)
 
-## Installation & Quick start
+## Install
 
 ```bash
 pip install libreyolo
@@ -30,29 +33,38 @@ model = LibreYOLO("LibreYOLO9t.pt")
 result = model(SAMPLE_IMAGE, save=True)
 ```
 
+That is the whole interface. The checkpoint you name decides the task.
+
 <details>
-<summary><b>Optional pip extras</b></summary>
+<summary><b>Optional extras</b></summary>
 
 <br>
 
-The base install covers YOLOv9 and the other detection models, plus training
-and inference. Add an extra in brackets when you need a heavier model family
-(for example RF-DETR, which needs `transformers`) or an export backend.
-Comma-separate to combine, e.g. `pip install "libreyolo[rfdetr,onnx]"`:
+The base install covers YOLOv9 and the other core detectors, training, and
+inference. Add an extra when you need a heavier family or an export backend.
+Comma-separate to combine, for example `pip install "libreyolo[rfdetr,onnx]"`.
 
 | Group | Extras |
 | --- | --- |
-| Export | `onnx`, `tensorrt`, `openvino`, `mnn`, `ncnn`, `tflite` (alias: `litert`), `coreml` |
-| Serving / deployment | `triton` ([Triton guide](docs/triton.md)) |
-| Models | `rfdetr`, `vlm`, `sam`, `openvocab`, `clip`, `gaze` |
-| Training | `lora`, `plots`, `tensorboard`, `mlflow`, `wandb` |
+| Export | `onnx`, `tensorrt`, `openvino`, `coreml`, `coreai`, `tflite` (alias `litert`), `ncnn`, `mnn`, `paddle`, `executorch` |
+| Serving | `triton` |
+| Models | `rfdetr`, `vlm`, `sam`, `openvocab`, `clip`, `siglip2`, `eomt`, `midas`, `modus`, `sensenova`, `gaze` |
+| Training | `lora`, `plots`, `tensorboard`, `mlflow`, `wandb`, `comet`, `clearml`, `neptune`, `dvclive` |
+| Speed | `fast-eval`, `hub-kernels` |
+| Sources | `stream` |
 | Everything | `pip install "libreyolo[all]"` |
 
-For the full list of extras and per-backend notes, see the [docs](https://www.libreyolo.com/docs#installation).
+`executorch`, `coreai` and `neptune` are deliberately left out of `all`: they
+pin torch or protobuf in ways that would drag the rest of the environment with
+them. Full list and per-backend notes in the
+[install guide](https://www.libreyolo.com/docs/install).
 
 </details>
 
-To install from source (development, or to track unreleased changes):
+<details>
+<summary><b>Install from source</b></summary>
+
+<br>
 
 ```bash
 git clone https://github.com/LibreYOLO/libreyolo.git
@@ -60,107 +72,111 @@ cd libreyolo
 pip install -e .
 ```
 
-A plain clone checks out `release`, the stable branch whose code matches these
-docs. For the latest unreleased work, switch to the integration branch with
-`git checkout dev`.
-
-## Flagship models
-
-LibreYOLO recommends these model families because they offer the best balance
-and receive the heaviest testing:
-
-- **YOLOv9** for CNN-based YOLO models.
-- **RF-DETR** for transformer-based detection and segmentation.
-
-## Detection models
-
-LibreYOLO is a YOLO library first. The table below covers the main detection
-families. `✓` supported. Empty cells are not currently supported.
-
-<table>
-  <thead>
-    <tr>
-      <th rowspan="2">Model family</th>
-      <th colspan="3">Inference</th>
-      <th rowspan="2">Training</th>
-      <th colspan="6">Export formats</th>
-    </tr>
-    <tr>
-      <th>Detection</th>
-      <th>Segmentation</th>
-      <th>Pose</th>
-      <th>ONNX</th>
-      <th>TorchScript</th>
-      <th>TensorRT</th>
-      <th>OpenVINO</th>
-      <th>NCNN</th>
-      <th>TFLite (LiteRT)</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr><td><strong>⭐ YOLOv9</strong></td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-    <tr><td><strong>⭐ RF-DETR</strong></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td>✓</td></tr>
-    <tr><td>YOLOX</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-    <tr><td>YOLO-NAS</td><td>✓</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td>HRNet</td><td></td><td></td><td>✓</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>YOLOv9-E2E</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td>YOLOv9-P2</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td>YOLOv7</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td>D-FINE</td><td>✓</td><td>✓</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>DEIM</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>DEIMv2</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>RT-DETR</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>RT-DETRv2<br><small>OBB inference; ONNX + TorchScript</small></td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>RT-DETRv4</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>Dome-DETR</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>DETR</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>LW-DETR</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>Deformable DETR</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>DINO-DETR</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>Faster R-CNN</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>RetinaNet</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>SSD300</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>Mask R-CNN</td><td>✓</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>FCN</td><td></td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>CenterNet</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>FCOS</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td></td><td>✓</td><td></td><td></td></tr>
-    <tr><td>DeepLabv3 (semantic)</td><td></td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>EfficientDet</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>EC</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>RTMDet</td><td>✓</td><td>✓</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>PicoDet</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td>MiDaS (depth)</td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-  </tbody>
-</table>
-
-## Beyond detection
-
-The same three-line API covers a lot more than boxes: the checkpoint name
-selects the task. These families are extras on top of the core library.
-
-<details>
-<summary><b>All other tasks and their models</b></summary>
-
-<br>
-
-- **Instance segmentation (promptable):** SAM, SAM 2, SAM 3, MobileSAM, EdgeTAM, PicoSAM3, EoMT
-- **Semantic segmentation:** SegFormer, PIDNet, EoMT, DINOv2
-- **Panoptic segmentation:** EoMT
-- **Oriented boxes (OBB):** RF-DETR
-- **Classification:** AlexNet, ResNet, DeiT, ConvNeXt, MobileNetV4, EfficientNetV2, Swin, VGG, ViT, DINOv2, CLIP, SigLIP2
-- **Point detection:** FOMO, LocateAnything
-- **Depth estimation:** Depth Anything 3, Depth Anything V2, ZipDepth
-- **Surface-normal estimation:** MoGe-2 (ViT-S/B/L)
-- **Image restoration & super-resolution:** NAFNet, Real-ESRGAN, SwinIR
-- **Background removal (matting):** BiRefNet, FeyNobg
-- **OCR:** PP-OCR
-- **Gaze estimation:** L2CS
-- **Facial recognition (face embedding):** LibreFaceRec (verification + gallery identification)
-- **Open-vocabulary & VLM detection:** Grounding DINO, OWLv2, OmDet-Turbo, OV-DEIM, Florence-2, Kosmos-2, Qwen3-VL, InternVL3, LFM2-VL, SmolVLM2, LocateAnything
+A plain clone checks out `release`, the stable branch matching the published
+package. For unreleased work, `git checkout dev`.
 
 </details>
 
+## One API, seventeen tasks
+
+The same three lines run every task. Only the checkpoint changes.
+
+```python
+from libreyolo import LibreYOLO
+
+LibreYOLO("LibreYOLO9t.pt")("street.jpg", save=True)             # detection
+LibreYOLO("LibreDeepLabv3mv3-sem.pt")("street.jpg", save=True)   # semantic segmentation
+LibreYOLO("LibreHRNetw32-pose.pt")("street.jpg", save=True)      # pose
+LibreYOLO("LibreMiDaSs-depth.pt")("street.jpg", save=True)       # depth
+LibreYOLO("LibreFeyNobgl-matte.pt")("portrait.jpg", save=True)   # background removal
+LibreYOLO("LibreRTDETRv2n-obb.pt")("aerial.jpg", save=True)      # oriented boxes
+```
+
+Sources are not just files. Point it at a webcam, an RTSP stream, a video, a
+directory, a YouTube URL or your screen:
+
+```bash
+libreyolo predict --model yolo9-t --source 0 --show          # webcam
+libreyolo predict --model yolo9-t --source rtsp://camera/1   # network camera
+libreyolo predict --model yolo9-t --source screen            # screen capture
+```
+
+## What ships
+
+| Task | Models |
+| --- | --- |
+| **Detection** | YOLOv9, RF-DETR, YOLOX, YOLO-NAS, D-FINE, DEIM, RT-DETR v1/v2/v4, RTMDet, PicoDet, YOLOv7, EfficientDet, and the classics: DETR, Deformable DETR, DINO-DETR, LW-DETR, Faster R-CNN, RetinaNet, SSD, FCOS, CenterNet |
+| **Tiny objects** | Dome-DETR (aerial, drone, remote sensing) |
+| **Instance segmentation** | RF-DETR, RTMDet, D-FINE, Mask R-CNN |
+| **Promptable segmentation** | SAM, SAM 2, SAM 3, MobileSAM, EdgeTAM, PicoSAM3 |
+| **Semantic segmentation** | SegFormer, PIDNet, DeepLabv3, FCN, LingBot-Vision, DINOv2, EoMT |
+| **Panoptic segmentation** | EoMT |
+| **Pose** | RF-DETR, YOLO-NAS, HRNet, EC |
+| **Oriented boxes** | RF-DETR, RT-DETRv2 |
+| **Classification** | MobileNetV4, ConvNeXt, EfficientNetV2, ResNet, ViT, Swin, DeiT, VGG, AlexNet, CLIP, SigLIP2, DINOv2 |
+| **Depth** | Depth Anything 3, Depth Anything V2, ZipDepth, MiDaS |
+| **Surface normals** | MoGe-2 |
+| **Edges** | DexiNed, TEED |
+| **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, DINOv2 |
+| **Body mesh** | SAM 3D Body |
+| **Restoration** | NAFNet, Real-ESRGAN, SwinIR |
+| **Background removal** | BiRefNet, FeyNobg |
+| **OCR** | PP-OCR |
+| **Point detection** | FOMO, LocateAnything |
+| **Gaze** | L2CS |
+| **Open vocabulary and VLMs** | Grounding DINO, OWLv2, OmDet-Turbo, OV-DEIM, Florence-2, Kosmos-2, Qwen3-VL, InternVL3, LFM2-VL, SmolVLM2, MODUS |
+
+Per-family sizes, checkpoints and parity evidence live in the
+[model reference](https://www.libreyolo.com/docs/models).
+
+## Train
+
+Training is part of the library, not a separate product. Seventeen detection
+families train, plus classification, semantic segmentation, point and
+restoration families.
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("LibreYOLO9t.pt")
+model.train(data="dataset.yaml", epochs=100, imgsz=640)
+```
+
+```bash
+libreyolo train --model yolo9-t --data dataset.yaml --epochs 100
+```
+
+Multi-GPU, LoRA, layer freezing, distillation, from-scratch training, and
+TensorBoard, MLflow, Weights & Biases, Comet, ClearML, Neptune and DVCLive
+logging are all supported. See the
+[training guide](https://www.libreyolo.com/docs/train).
+
+## Export and deploy
+
+Twelve formats: ONNX, TorchScript, TensorRT, OpenVINO, CoreML, Core AI, TFLite
+(LiteRT), NCNN, MNN, RKNN, Paddle and ExecuTorch. Plus NVIDIA Triton serving
+and DeepStream config generation.
+
+```bash
+libreyolo export --model yolo9-t --format onnx
+```
+
+Support varies by family and task, and every combination is validated rather
+than assumed. The
+[export matrix](https://www.libreyolo.com/docs/reference/export-matrix) is the
+authoritative grid.
+
+## Documentation
+
+- [Docs](https://www.libreyolo.com/docs) covers install, tasks, models, training, prediction, export and the CLI
+- [Upgrading](https://www.libreyolo.com/docs/upgrade) if you are coming from an earlier version
+- [Benchmarks](https://www.visionanalysis.org/) for independent numbers
+- [CHANGELOG.md](CHANGELOG.md) for what changed
+
 ## License
 
-- **Code:** MIT License
-- **Weights:** Pre-trained weights may inherit licensing from the original source. Check the license in the specific HF repo of weights that you are interested in. LibreYOLO HF models always have a license.
+- **Code:** MIT License.
+- **Weights:** pre-trained weights may inherit licensing from their original
+  source, and not all of them are permissive. Check the license on the
+  specific Hugging Face repo before you use one commercially. Every LibreYOLO
+  Hugging Face model states its license.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ model = LibreYOLO("LibreYOLO9t.pt")
 result = model(SAMPLE_IMAGE, save=True)
 ```
 
-That is the whole interface. The checkpoint you name decides the task.
-
 <details>
 <summary><b>Optional extras</b></summary>
 
@@ -131,10 +129,6 @@ Per-family sizes, checkpoints and parity evidence live in the
 
 ## Train
 
-Training is part of the library, not a separate product. Seventeen detection
-families train, plus classification, semantic segmentation, point and
-restoration families.
-
 ```python
 from libreyolo import LibreYOLO
 
@@ -161,15 +155,12 @@ and DeepStream config generation.
 libreyolo export --model yolo9-t --format onnx
 ```
 
-Support varies by family and task, and every combination is validated rather
-than assumed. The
-[export matrix](https://www.libreyolo.com/docs/reference/export-matrix) is the
-authoritative grid.
+Support varies by family and task, see the
+[export matrix](https://www.libreyolo.com/docs/reference/export-matrix).
 
 ## Documentation
 
 - [Docs](https://www.libreyolo.com/docs) covers install, tasks, models, training, prediction, export and the CLI
-- [Upgrading](https://www.libreyolo.com/docs/upgrade) if you are coming from an earlier version
 - [Benchmarks](https://www.visionanalysis.org/) for independent numbers
 - [CHANGELOG.md](CHANGELOG.md) for what changed
 

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -77,7 +77,7 @@ the `alexnet` / `deit` / `mobilenetv4` / `convnext` / `efficientnetv2` /
 | `rtmdet`    | `LibreRTMDet`   | Upstream brand casing preserved (`RTMDet`) |
 | `rfdetr`    | `LibreRFDETR`   | All-caps acronym (hyphen dropped from `RF-DETR`) |
 | `lwdetr`    | `LibreLWDETR`   | All-caps acronym (hyphen dropped from `LW-DETR`) |
-| `domedetr`  | `LibreDOMEDETR` | All-caps acronym (hyphen dropped from `Dome-DETR`); inference-only tiny-object detector. Canonical filenames always carry a dataset suffix (`LibreDOMEDETRs-aitod.pt`, `LibreDOMEDETRs-visdrone.pt`): there is no COCO checkpoint and no bare `LibreDOMEDETRs.pt` |
+| `domedetr`  | `LibreDOMEDETR` | All-caps acronym (hyphen dropped from `Dome-DETR`); trainable tiny-object detector. Canonical filenames always carry a dataset suffix (`LibreDOMEDETRs-aitod.pt`, `LibreDOMEDETRs-visdrone.pt`): there is no COCO checkpoint and no bare `LibreDOMEDETRs.pt` |
 | `faster_rcnn` | `LibreFasterRCNN` | Upstream acronym and underscore retained in the family id; canonical filename drops punctuation; inference-only two-stage detector |
 | `retinanet` | `LibreRetinaNet` | Upstream CamelCase brand preserved; inference-only one-stage focal-loss detector |
 | `ssd`       | `LibreSSD`       | All-caps acronym; fixed-300 inference-only single-shot detector |

--- a/libreyolo/models/domedetr/NOTICE
+++ b/libreyolo/models/domedetr/NOTICE
@@ -28,10 +28,18 @@ CSP/RepNCSPELAN4 encoder blocks, the FDR decoder stack, and the pure-PyTorch
 multi-scale deformable attention) is imported from libreyolo/models/dfine/
 rather than re-vendored here, and is covered by that family's attribution.
 
-Not included: the training-only criterion, matcher, density ground-truth
-generator, and data pipeline; the deformable-encoder branch (no released
-config enables it); and the prebuilt MSDeformAttn CUDA extension under
-src/zoo/dome/ops/.
+The training path is ported too: the Dome-DETR criterion (loss.py, a subclass
+of D-FINE's), the DeFE density and count supervision together with the
+ground-truth density-map construction it is trained against (encoder.py), and
+the contrastive-denoising adaptation for a variable per-image query count
+(denoising.py). Each of those files carries the attribution above in its own
+header.
+
+Not included: upstream's data pipeline, which LibreYOLO replaces with its own;
+the deformable-encoder branch (no released config enables it); and the
+prebuilt MSDeformAttn CUDA extension under src/zoo/dome/ops/. The Hungarian
+matcher is inherited from libreyolo/models/dfine/ rather than re-vendored here,
+and is covered by that family's attribution.
 
 Model weights are not redistributed by LibreYOLO. See
 weights/LICENSE_NOTICE.txt for why.


### PR DESCRIPTION
Last-minute content for v1.5.0, before the tag. Cherry-picked from dev (3ff39c44).

## README rework

The page led with a 31 by 10 HTML table that ate half its height and structurally could not show the 12 export formats the library now has, while 17 tasks behind one API sat folded inside a `<details>` as a bullet dump.

- lead with what the library does, then prove the one-API claim with six real one-liners
- surface predict sources (webcam, RTSP, screen), previously invisible
- task-to-models table in the open; the format grid is delegated to the docs export matrix, which is generated and maintained rather than hand-kept in two places
- training gets its own section
- fills real gaps: edge and mesh tasks, LibreMODUS, LingBot-Vision, Dome-DETR, `compare`/`verify`/`enroll`, five export formats, and the extras table (it listed 7 of 21)
- `LibreFaceRec` corrected to `LibreFaceEmbedder`, the actual exported name

Numbers were derived, not asserted: 17 tasks and 12 formats from `tasks.py` and the exporter registry, "seventeen detection families train" from `MODEL_GROUPS` + `SUPPORTED_TASKS`, and every claimed extra checked against `pyproject.toml`. That check caught `rknn`: it is an export format but not a pip extra.

## Dome-DETR notice, the important one

`libreyolo/models/domedetr/NOTICE` said the training-only criterion, matcher and density ground-truth generator were "not included". Five files say otherwise in their own headers: `loss.py`, `defe.py`, `mwas.py`, `denoising.py`, `trainer.py`, all ported from Dome-DETR at `2dde3bc` under Apache-2.0.

The notice understated what was vendored, which is the one thing a notice must not do. Now states what the training path contains, keeping the genuinely excluded items (upstream's data pipeline, the deformable-encoder branch, the prebuilt CUDA extension) and noting the matcher is inherited from `dfine/`.

## docs/nomenclature.md

Called Dome-DETR inference-only. It is trainable (`TRAIN_CONFIG = DOMEDETRConfig`, `DOMEDETRTrainer`, tier `g2`), so it contradicted the changelog, which headlines it as the one trainable new family.

## Tests

82 pass locally, including the two that read the README (`test_export_support.py`, `test_fcn_upload.py`) and the capability-language guard.

## Merge notes

- This PR targets `release` and shows **no CI checks by design**: the unit and smoke workflows only trigger on `dev`. An empty checks list here is not a green tick. The same content is on `dev` at 3ff39c44, where CI does run.
- Merge with a **merge commit, not a squash**.

## Code provenance

Documentation only, no code changes. All three files are original LibreYOLO content. The NOTICE edit adds no third-party text: it corrects a description of code already vendored and already attributed in its own file headers (Dome-DETR, commit 2dde3bc, Apache-2.0).

https://claude.ai/code/session_01RnfUzHN4o749HJCznMuiBw

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR reworks the README’s presentation of supported tasks, training, export, installation extras, and deployment capabilities. It also corrects Dome-DETR’s nomenclature and NOTICE to describe its trainable implementation and vendored training components accurately.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Reorganizes installation, task coverage, training, export, deployment, and licensing information into a shorter capability-focused overview. |
| docs/nomenclature.md | Corrects Dome-DETR’s family entry from inference-only to trainable. |
| libreyolo/models/domedetr/NOTICE | Expands attribution details for the ported Dome-DETR training path and clarifies which upstream components remain excluded or inherited from D-FINE. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Trim the README per review"](https://github.com/libreyolo/libreyolo/commit/d02745b3aea5423691009f339d43071fcbcf288d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51615081)</sub>

<!-- /greptile_comment -->