### PR TITLE
Add YOLO-NAS-R oriented boxes as the yolonas obb task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,19 @@ before 1.4.0 are documented in the
   `69141b55c1161d939939a270523a7eca5a645f72`; the rotated head reproduces the
   pinned upstream head exactly (`max_abs_diff == 0` for all three sizes, see
   `weights/parity_yolonas_obb.py`). ONNX, TorchScript, TensorRT and OpenVINO
-  export and reload with backend results matching native inference. The task is
-  inference-only: `model.train(task="obb")` raises with an explanation.
+  export and reload with backend results matching native inference.
+- **YOLO-NAS-R training.** `model.train(data=...)` trains the rotated head on
+  standard YOLO OBB datasets through the public API, with the loss ported from
+  the same pinned upstream commit: varifocal classification, probabilistic-IoU
+  regression on `cxcywhr`, and width/height DFL, under a rotated task-aligned
+  assigner. Upstream's DOTA recipe supplies the defaults (AdamW 5e-5, weight
+  decay 3.5e-6, cosine to 0.1, EMA 0.9997, assigner top-k 12, loss weights
+  2.5 / 2.0 / 0.5). Best-checkpoint selection uses `metrics/mAP50-95(OBB)`, not
+  the axis-aligned proxy. `LibreYOLONAS.load_detect_weights_for_obb()` seeds a
+  rotated model from a YOLO-NAS detection checkpoint, mirroring upstream's
+  `strict_load: key_matching` start. Augmentation is flips plus HSV only:
+  mosaic, mixup and affine do not have a correct rotated-label mapping and are
+  not offered rather than silently corrupting angles.
   The pretrained weights stay under Deci's separate non-redistributable
   YOLO-NAS-R license and are downloaded from Deci's CDN and SHA256-verified
   rather than mirrored — the same treatment YOLO-NAS detect and pose get.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Releases
 before 1.4.0 are documented in the
 [GitHub Releases](https://github.com/LibreYOLO/libreyolo/releases) only.
 
+## [Unreleased]
+
+### Added
+
+- **YOLO-NAS-R oriented boxes.** The existing `yolonas` family gains an `obb`
+  task: `LibreYOLO("LibreYOLONASs-obb.pt")` returns `Results.obb` on the
+  original image canvas, in sizes `s`/`m`/`l` at 1024 on DOTA2's 18 classes.
+  Ported from the Apache-2.0 SuperGradients pull request 2014 at pinned commit
+  `69141b55c1161d939939a270523a7eca5a645f72`; the rotated head reproduces the
+  pinned upstream head exactly (`max_abs_diff == 0` for all three sizes, see
+  `weights/parity_yolonas_obb.py`). ONNX, TorchScript, TensorRT and OpenVINO
+  export and reload with backend results matching native inference. The task is
+  inference-only: `model.train(task="obb")` raises with an explanation.
+  The pretrained weights stay under Deci's separate non-redistributable
+  YOLO-NAS-R license and are downloaded from Deci's CDN and SHA256-verified
+  rather than mirrored — the same treatment YOLO-NAS detect and pose get.
+- Shared rotated-box postprocessing helpers in `libreyolo/postprocess/obb_ops.py`
+  (corner conversion, axis-aligned proxy, exact rotated NMS, long-side
+  canonicalization), extracted from the YOLO9 OBB postprocessor so OBB families
+  share one implementation.
+
 ## [1.5.0] - 2026-08-09
 
 The largest release so far: 28 new model families, four new tasks (`edge`,

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Semantic segmentation** | SegFormer, PIDNet, DeepLabv3, FCN, LingBot-Vision, DINOv2, EoMT |
 | **Panoptic segmentation** | EoMT |
 | **Pose** | RF-DETR, YOLO-NAS, HRNet, EC |
-| **Oriented boxes** | RF-DETR, RT-DETRv2 |
+| **Oriented boxes** | RF-DETR, RT-DETRv2, YOLO-NAS-R |
 | **Classification** | MobileNetV4, ConvNeXt, EfficientNetV2, ResNet, ViT, Swin, DeiT, VGG, AlexNet, CLIP, SigLIP2, DINOv2 |
 | **Depth** | Depth Anything 3, Depth Anything V2, ZipDepth, MiDaS |
 | **Surface normals** | MoGe-2 |

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -235,6 +235,36 @@ Used for: YOLO-NAS model family and pose training references
           separate non-commercial terms and are not bundled here.
 
 --------------------------------------------------------------------
+SuperGradients / YOLO-NAS-R (rotated / OBB)
+--------------------------------------------------------------------
+Source: https://github.com/Deci-AI/super-gradients
+        pull request 2014, pinned commit
+        69141b55c1161d939939a270523a7eca5a645f72
+License: Apache License 2.0 (repository LICENSE.md at that commit)
+Copyright (c) 2021-2024 Deci AI
+Used for: the YOLO-NAS-R rotated head, its decode, and the evaluation
+          preprocessing recipe, ported into the existing YOLO-NAS
+          family (libreyolo/models/yolonas/nn.py -- YoloNASRDFLHead,
+          YoloNASRNDFLHeads, LibreYOLONASOBBModel;
+          libreyolo/preprocess/yolonas.py; libreyolo/postprocess/yolonas.py).
+          Source paths used, at that pin:
+            src/super_gradients/training/models/detection_models/
+              yolo_nas_r/yolo_nas_r_dfl_head.py
+              yolo_nas_r/yolo_nas_r_ndfl_heads.py
+              yolo_nas_r/yolo_nas_r_variants.py
+              yolo_nas_r/yolo_nas_r_post_prediction_callback.py
+            src/super_gradients/recipes/arch_params/
+              yolo_nas_r_{s,m,l}_arch_params.yaml
+          The pretrained DOTA2 YOLO-NAS-R weights are covered by a
+          SEPARATE, non-redistributable license (LICENSE.YOLONAS-R.md
+          at the same pin: no resale, sublicensing or distribution, and
+          no commercial use). LibreYOLO does not mirror them; they are
+          downloaded from Deci's CDN on demand and SHA256-verified
+          before loading. See weights/LICENSE_NOTICE.txt.
+          DOTA2 training data is not bundled and must be obtained from
+          its own source under its own terms.
+
+--------------------------------------------------------------------
 EdgeCrafter
 --------------------------------------------------------------------
 Source: https://github.com/EC-codehub/EdgeCrafter

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -108,6 +108,7 @@ in preflight.
 | yolo9_p2 | detect | ✓ | ✓ | ✓ | available | ✓ | ✓ | ✓ |  | available |  |  | ✓ |
 | yolonas | detect | ✓ | ✓ | ✓ | available | ✓ | ✓ | ✓ | available | ✓ | ✓ |  | ✓ |
 | yolonas | pose | ✓ | ✓ | ✓ | available | ✓ | ✓ |  |  | ✓ |  |  |  |
+| yolonas | obb | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | yolox | detect | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ | ✓ | available | ✓ |
 | zipdepth | depth | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ |  |  | ✓ |
 
@@ -419,6 +420,10 @@ A check mark applies only under any constraint listed here.
 - `yolonas` / `pose` / `openvino`: fixed export canvas
 - `yolonas` / `pose` / `paddle`: X2Paddle 1.6.0, PaddlePaddle 2.6.2 CPU, ONNX 1.17/opset 15, FP32, batch 1, fixed square input; WSL2 Ubuntu 22.04
 - `yolonas` / `pose` / `ncnn`: PNNX/NCNN 20260526 CPU FP32 with deterministic synthetic trained fixtures; two-input raw parity, factory reload, metadata, and public predict parity; pose additionally validates matched keypoints; this validates conversion, not task accuracy
+- `yolonas` / `obb` / `onnx`: fixed 1024x1024 export canvas, batch 1, FP32; the official YOLO-NAS-R-S DOTA2 checkpoint exports, reloads through the factory, and its public OBB results match native inference on the same image (max xywhr delta 6e-08 px TorchScript, 0.06 px ONNX, 0.04 px OpenVINO, 0.18 px TensorRT; max score delta 0.0, 1.0e-03, 1.5e-03 and 1.6e-03 respectively). Rotated NMS is not embedded in the graph
+- `yolonas` / `obb` / `torchscript`: fixed 1024x1024 export canvas, batch 1, FP32; the official YOLO-NAS-R-S DOTA2 checkpoint exports, reloads through the factory, and its public OBB results match native inference on the same image (max xywhr delta 6e-08 px TorchScript, 0.06 px ONNX, 0.04 px OpenVINO, 0.18 px TensorRT; max score delta 0.0, 1.0e-03, 1.5e-03 and 1.6e-03 respectively). Rotated NMS is not embedded in the graph
+- `yolonas` / `obb` / `tensorrt`: fixed 1024x1024 export canvas, batch 1, FP32; the official YOLO-NAS-R-S DOTA2 checkpoint exports, reloads through the factory, and its public OBB results match native inference on the same image (max xywhr delta 6e-08 px TorchScript, 0.06 px ONNX, 0.04 px OpenVINO, 0.18 px TensorRT; max score delta 0.0, 1.0e-03, 1.5e-03 and 1.6e-03 respectively). Rotated NMS is not embedded in the graph
+- `yolonas` / `obb` / `openvino`: fixed 1024x1024 export canvas, batch 1, FP32; the official YOLO-NAS-R-S DOTA2 checkpoint exports, reloads through the factory, and its public OBB results match native inference on the same image (max xywhr delta 6e-08 px TorchScript, 0.06 px ONNX, 0.04 px OpenVINO, 0.18 px TensorRT; max score delta 0.0, 1.0e-03, 1.5e-03 and 1.6e-03 respectively). Rotated NMS is not embedded in the graph
 - `yolox` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolox` / `detect` / `openvino`: fixed export canvas; YOLO1 requires 448x448
 - `yolox` / `detect` / `ncnn`: PNNX/NCNN 20260526 CPU FP32 with permissively licensed trained checkpoints; two-input raw parity, factory reload, metadata, and public predict parity
@@ -518,6 +523,8 @@ These converter paths are callable with the recorded validation context.
 - `yolonas` / `detect` / `tensorrt`: A deterministic synthetic trained fixture exports, reloads, and passes public predict parity, but image signal is only 4 to 5 times the TensorRT conversion error.
 - `yolonas` / `detect` / `rknn`: Exact small variants passed RKNN Toolkit2 2.3.2 compilation, RK3588 PC-simulator raw-output gates, and matched post-NMS detections on a real image. Support is limited to YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s; on-device latency and parity have not been measured. Constraint: RKNN Toolkit2 2.3.2, RK3588 PC simulator, vendor floating build, batch 1, fixed square input
 - `yolonas` / `pose` / `tensorrt`: A deterministic synthetic trained fixture exports, reloads, and passes public predict parity, but image signal is only 2 to 6 times the TensorRT conversion error.
+- `yolonas` / `obb` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `yolonas` / `obb` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
 - `yolox` / `detect` / `tensorrt`: The permissively licensed trained checkpoint exports, reloads, and passes public predict parity, but normalized raw error is 1.6% and image signal is only 2.1 times the conversion error.
 - `yolox` / `detect` / `coreml`: Conversion is available, but runtime parity requires a macOS runner.
 - `zipdepth` / `depth` / `tensorrt`: TensorRT 10.16 FP32 exports, reloads, and predicts, but repeated builds produced raw depth PSNR as low as 30.27 dB, below the 40 dB promotion gate.
@@ -1270,6 +1277,12 @@ These converter paths are callable with the recorded validation context.
 - `yolonas` / `pose` / `tflite`: LiteRT rejects the converted pose graph because a CONCATENATION input has an unsupported/invalid tensor type.
 - `yolonas` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolonas` / `pose` / `coreai`: This family and task have not been validated for Core AI export.
+- `yolonas` / `obb` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
+- `yolonas` / `obb` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
+- `yolonas` / `obb` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
+- `yolonas` / `obb` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `yolonas` / `obb` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolonas` / `obb` / `coreai`: This family and task have not been validated for Core AI export.
 - `yolox` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
 - `yolox` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolox` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -475,7 +475,7 @@ Detector-factory family support follows:
 | `pidnet`    | `("semantic",)`                     | semantic | real-time PIDNet semantic segmentation; s/m/l at 1024; Cityscapes 19-class checkpoints; inference + `val`; not trainable in LibreYOLO |
 | `segformer` | `("semantic",)`                     | semantic | SegFormer MiT-b0..b5 encoder + all-MLP decode head; ADE20K 150-class at 512 (b5 at 640). Pretrained weights are NON-COMMERCIAL (NVIDIA Source Code License, research/evaluation only); also trainable from scratch via `model.train(...)` for unrestricted use |
 | `lingbotvision` | `("semantic",)`                 | semantic | LingBot-Vision self-supervised ViT (Apache-2.0, arXiv:2607.05247) + 1x1 dense head (the report's linear probe); s/b/l/g at 512; ADE20K 150-class hosted weights for s/b/l; head-only training by default (`freeze_backbone=False` for full fine-tune) |
-| `yolonas`   | `("detect", "pose")`                | detect | pose adds size `n` |
+| `yolonas`   | `("detect", "pose", "obb")`         | detect | pose adds size `n`; obb is YOLO-NAS-R (DOTA2, s/m/l at 1024, inference-only) |
 | `hrnet`     | `("pose",)`                          | pose   | inference-only top-down COCO-17 pose; `w32` uses 256x192 crops, `w48` uses 384x288; configurable person detector |
 | `ec`     | `("detect", "pose", "segment")`     | detect | all three tasks |
 | `l2cs`      | `("gaze",)`                         | gaze   | inference-only; two-stage (face detector + gaze head); not trainable in LibreYOLO |
@@ -552,12 +552,15 @@ LibreHRNetw48-pose.pt      # W48, fixed 384x288 person crop
 ### Multi-task families
 
 ```text
-# yolonas — detect + pose
+# yolonas — detect + pose + obb
 LibreYOLONASs.pt           # detect (default)
 LibreYOLONASn-pose.pt      # pose (note: size n only ships for pose)
 LibreYOLONASs-pose.pt
 LibreYOLONASm-pose.pt
 LibreYOLONASl-pose.pt
+LibreYOLONASs-obb.pt       # obb (YOLO-NAS-R, DOTA2; s/m/l only)
+LibreYOLONASm-obb.pt
+LibreYOLONASl-obb.pt
 
 # dfine - detect + segment
 LibreDFINEn.pt            # detect (default)

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -475,7 +475,7 @@ Detector-factory family support follows:
 | `pidnet`    | `("semantic",)`                     | semantic | real-time PIDNet semantic segmentation; s/m/l at 1024; Cityscapes 19-class checkpoints; inference + `val`; not trainable in LibreYOLO |
 | `segformer` | `("semantic",)`                     | semantic | SegFormer MiT-b0..b5 encoder + all-MLP decode head; ADE20K 150-class at 512 (b5 at 640). Pretrained weights are NON-COMMERCIAL (NVIDIA Source Code License, research/evaluation only); also trainable from scratch via `model.train(...)` for unrestricted use |
 | `lingbotvision` | `("semantic",)`                 | semantic | LingBot-Vision self-supervised ViT (Apache-2.0, arXiv:2607.05247) + 1x1 dense head (the report's linear probe); s/b/l/g at 512; ADE20K 150-class hosted weights for s/b/l; head-only training by default (`freeze_backbone=False` for full fine-tune) |
-| `yolonas`   | `("detect", "pose", "obb")`         | detect | pose adds size `n`; obb is YOLO-NAS-R (DOTA2, s/m/l at 1024, inference-only) |
+| `yolonas`   | `("detect", "pose", "obb")`         | detect | pose adds size `n`; obb is YOLO-NAS-R (DOTA2, s/m/l at 1024, trainable) |
 | `hrnet`     | `("pose",)`                          | pose   | inference-only top-down COCO-17 pose; `w32` uses 256x192 crops, `w48` uses 384x288; configurable person detector |
 | `ec`     | `("detect", "pose", "segment")`     | detect | all three tasks |
 | `l2cs`      | `("gaze",)`                         | gaze   | inference-only; two-stage (face detector + gaze head); not trainable in LibreYOLO |

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -2283,7 +2283,15 @@ class BaseBackend(ABC):
         xywhr[:, 0] = np.clip(xywhr[:, 0], 0, orig_w)
         xywhr[:, 1] = np.clip(xywhr[:, 1], 0, orig_h)
 
-        valid = (xywhr[:, 2] > 0) & (xywhr[:, 3] > 0)
+        # Non-finite rows are dropped here rather than in NMS: the native path
+        # filters them inside rotated_nms_keep_indices, and canonicalization
+        # would otherwise carry NaN centres and angles into public results.
+        valid = (
+            np.isfinite(xywhr).all(axis=1)
+            & np.isfinite(max_scores)
+            & (xywhr[:, 2] > 0)
+            & (xywhr[:, 3] > 0)
+        )
         xywhr = xywhr[valid]
         max_scores = max_scores[valid]
         class_ids = class_ids[valid]

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -28,6 +28,8 @@ from ..postprocess.yolo9 import (
     postprocess as yolo9_postprocess,
 )
 from ..postprocess.yolonas import (
+    YOLO_NAS_OBB_PRE_NMS_TOP_K,
+    YOLO_NAS_OBB_RESIZE_SIZE,
     YOLO_NAS_PRE_NMS_TOP_K,
     YOLO_NAS_POSE_RESIZE_SIZE,
     YOLO_NAS_RESIZE_SIZE,
@@ -36,6 +38,7 @@ from ..preprocess import as_batched_input, as_input
 from ..preprocess.yolo9 import preprocess_image
 from ..preprocess.yolonas import (
     preprocess_image as yolonas_preprocess_image,
+    preprocess_obb_image as yolonas_preprocess_obb_image,
     preprocess_pose_image as yolonas_preprocess_pose_image,
 )
 from ..preprocess.yolox import preprocess_image as yolox_preprocess_image
@@ -573,6 +576,10 @@ class BaseBackend(ABC):
         elif self.model_family == "yolonas":
             if self.task == "pose":
                 return yolonas_preprocess_pose_image(
+                    image, input_size=effective_imgsz, color_format=color_format
+                )
+            if self.task == "obb":
+                return yolonas_preprocess_obb_image(
                     image, input_size=effective_imgsz, color_format=color_format
                 )
             return yolonas_preprocess_image(
@@ -1277,6 +1284,17 @@ class BaseBackend(ABC):
                     orig_w,
                     orig_h,
                     conf,
+                    ratio=ratio,
+                    max_det=max_det,
+                )
+            if self.task == "obb":
+                return self._parse_yolonas_obb(
+                    all_outputs,
+                    effective_imgsz,
+                    orig_w,
+                    orig_h,
+                    conf,
+                    iou=iou,
                     ratio=ratio,
                     max_det=max_det,
                 )
@@ -2195,6 +2213,128 @@ class BaseBackend(ABC):
         max_scores = max_scores[valid_boxes]
         class_ids = class_ids[valid_boxes]
         return boxes, max_scores, class_ids
+
+    @staticmethod
+    def _parse_yolonas_obb(
+        all_outputs,
+        effective_imgsz,
+        orig_w,
+        orig_h,
+        conf,
+        iou: float = 0.25,
+        ratio: Optional[float] = None,
+        max_det: int = 300,
+    ):
+        """Parse YOLO-NAS-R OBB output: [boxes(B,N,5) cxcywhr, scores(B,N,nc)].
+
+        Mirrors ``libreyolo.postprocess.yolonas.postprocess_obb`` step for step
+        (threshold -> top-K -> undo the longest-side rescale and bottom-right
+        pad -> canonicalise -> exact rotated NMS) but in numpy, so the ONNX
+        backend stays importable without torch.
+        """
+        from ..data.obb import canonicalize_xywhr, xywhr_iou
+
+        empty = (
+            np.zeros((0, 4), dtype=np.float32),
+            np.zeros((0,), dtype=np.float32),
+            np.zeros((0,), dtype=np.int64),
+            None,
+            np.zeros((0, 7), dtype=np.float32),
+        )
+
+        first = np.asarray(all_outputs[0][0], dtype=np.float32)
+        second = np.asarray(all_outputs[1][0], dtype=np.float32)
+        if first.shape[-1] == 5 and second.shape[-1] != 5:
+            boxes_raw, scores = first, second
+        elif second.shape[-1] == 5 and first.shape[-1] != 5:
+            boxes_raw, scores = second, first
+        else:
+            # A five-class checkpoint is indistinguishable by shape alone; the
+            # LibreYOLO export wrapper always emits (boxes, scores).
+            boxes_raw, scores = first, second
+
+        max_scores = scores.max(axis=1)
+        class_ids = scores.argmax(axis=1).astype(np.int64)
+        mask = max_scores >= conf
+        boxes_raw = boxes_raw[mask]
+        max_scores = max_scores[mask]
+        class_ids = class_ids[mask]
+        if boxes_raw.shape[0] == 0:
+            return empty
+
+        if YOLO_NAS_OBB_PRE_NMS_TOP_K and max_scores.size > YOLO_NAS_OBB_PRE_NMS_TOP_K:
+            keep = np.argpartition(-max_scores, YOLO_NAS_OBB_PRE_NMS_TOP_K - 1)[
+                :YOLO_NAS_OBB_PRE_NMS_TOP_K
+            ]
+            keep = keep[np.argsort(-max_scores[keep])]
+            boxes_raw = boxes_raw[keep]
+            max_scores = max_scores[keep]
+            class_ids = class_ids[keep]
+
+        input_h, input_w = _imgsz_hw(effective_imgsz)
+        if ratio is None or ratio <= 0:
+            resize_size = min(YOLO_NAS_OBB_RESIZE_SIZE, input_h, input_w)
+            ratio = min(resize_size / orig_h, resize_size / orig_w)
+        # Bottom-right padding leaves no offset to subtract, and the rescale is
+        # uniform, so centres and sides divide by the ratio while the angle is
+        # unchanged.
+        xywhr = boxes_raw.astype(np.float32, copy=True)
+        xywhr[:, :4] /= np.float32(ratio)
+        xywhr[:, 0] = np.clip(xywhr[:, 0], 0, orig_w)
+        xywhr[:, 1] = np.clip(xywhr[:, 1], 0, orig_h)
+
+        valid = (xywhr[:, 2] > 0) & (xywhr[:, 3] > 0)
+        xywhr = xywhr[valid]
+        max_scores = max_scores[valid]
+        class_ids = class_ids[valid]
+        if xywhr.shape[0] == 0:
+            return empty
+
+        xywhr = np.stack([canonicalize_xywhr(row) for row in xywhr]).astype(np.float32)
+
+        order = np.argsort(-max_scores).tolist()
+        keep_idx: List[int] = []
+        while order and len(keep_idx) < max_det:
+            current = order.pop(0)
+            keep_idx.append(current)
+            order = [
+                candidate
+                for candidate in order
+                if class_ids[candidate] != class_ids[current]
+                or xywhr_iou(xywhr[current], xywhr[candidate]) <= iou
+            ]
+        if not keep_idx:
+            return empty
+
+        keep_arr = np.asarray(keep_idx, dtype=np.int64)
+        xywhr = xywhr[keep_arr]
+        max_scores = max_scores[keep_arr]
+        class_ids = class_ids[keep_arr]
+
+        half_w = xywhr[:, 2] / 2
+        half_h = xywhr[:, 3] / 2
+        cos = np.abs(np.cos(xywhr[:, 4]))
+        sin = np.abs(np.sin(xywhr[:, 4]))
+        extent_x = cos * half_w + sin * half_h
+        extent_y = sin * half_w + cos * half_h
+        boxes = np.stack(
+            [
+                np.clip(xywhr[:, 0] - extent_x, 0, orig_w),
+                np.clip(xywhr[:, 1] - extent_y, 0, orig_h),
+                np.clip(xywhr[:, 0] + extent_x, 0, orig_w),
+                np.clip(xywhr[:, 1] + extent_y, 0, orig_h),
+            ],
+            axis=-1,
+        ).astype(np.float32)
+        obb = np.concatenate(
+            [
+                xywhr,
+                max_scores[:, None].astype(np.float32),
+                class_ids[:, None].astype(np.float32),
+            ],
+            axis=-1,
+        ).astype(np.float32)
+        return boxes, max_scores.astype(np.float32), class_ids, None, obb
 
     def _parse_yolonas_pose(
         self,

--- a/libreyolo/data/augment/yolonas.py
+++ b/libreyolo/data/augment/yolonas.py
@@ -225,3 +225,147 @@ class YOLONASAffineMixupDataset:
         origin_img = origin_img.astype(np.float32)
         origin_img = 0.5 * origin_img + 0.5 * padded_cropped_img.astype(np.float32)
         return origin_img.astype(np.uint8), merged_labels
+
+
+# ---------------------------------------------------------------------------
+# OBB (YOLO-NAS-R) training transform
+# ---------------------------------------------------------------------------
+
+
+def _canonicalize_obb_rows(rows: np.ndarray) -> np.ndarray:
+    """Put the long side first and fold the angle into ``[-pi/2, pi/2)``.
+
+    ``rows`` are ``[cx, cy, w, h, angle]``. Vectorised twin of
+    ``libreyolo.data.obb.canonicalize_xywhr`` (which is per-row and raises on
+    degenerate boxes; here degenerate rows are dropped by the caller instead).
+    """
+    if len(rows) == 0:
+        return rows
+    out = rows.copy()
+    swap = out[:, 3] > out[:, 2]
+    w = np.where(swap, out[:, 3], out[:, 2])
+    h = np.where(swap, out[:, 2], out[:, 3])
+    angle = np.where(swap, out[:, 4] + np.pi / 2, out[:, 4])
+    out[:, 2] = w
+    out[:, 3] = h
+    out[:, 4] = np.mod(angle + np.pi / 2, np.pi) - np.pi / 2
+    return out
+
+
+class YOLONASOBBTrainTransform:
+    """Train transform for YOLO-NAS-R, emitting ``[class, cx, cy, w, h, angle]``.
+
+    Augmentation is deliberately limited to HSV jitter and axis flips. Every
+    geometric op here has an exact, tested effect on the angle; affine,
+    mosaic and mixup do not (a shear turns a rectangle into a parallelogram,
+    and a mosaic paste crops rotated boxes), so they are not offered rather
+    than being offered as knobs that quietly corrupt the label.
+
+    The resize/pad/normalize step calls ``preprocess_obb_numpy`` -- the same
+    function inference and validation use -- so the three paths cannot drift.
+    """
+
+    def __init__(
+        self,
+        max_labels: int = 300,
+        flip_prob: float = 0.5,
+        hsv_prob: float = 0.5,
+        flipud: float = 0.0,
+    ):
+        self.max_labels = max_labels
+        self.flip_prob = flip_prob
+        self.hsv_prob = hsv_prob
+        self.flipud = flipud
+
+    def _pad(self, targets: np.ndarray) -> np.ndarray:
+        padded = np.zeros((self.max_labels, 6), dtype=np.float32)
+        n = min(len(targets), self.max_labels)
+        if n:
+            padded[:n] = targets[:n]
+        return np.ascontiguousarray(padded, dtype=np.float32)
+
+    def __call__(self, image, targets, input_dim):
+        from libreyolo.preprocess.yolonas import preprocess_obb_numpy
+
+        input_size = input_dim[0] if isinstance(input_dim, (tuple, list)) else input_dim
+
+        if targets is None or len(targets) == 0:
+            rgb = np.ascontiguousarray(image[:, :, ::-1])
+            image_t, _ = preprocess_obb_numpy(rgb, input_size=input_size)
+            return image_t, self._pad(np.zeros((0, 6), dtype=np.float32))
+
+        targets = np.asarray(targets, dtype=np.float32)
+        if targets.shape[1] < 6:
+            raise ValueError(
+                "YOLO-NAS OBB training expects six-column dataset rows "
+                f"[x1, y1, x2, y2, class, angle], got {targets.shape[1]}"
+            )
+
+        # The dataset's xyxy block is the un-rotated proxy, so it decodes back
+        # to (cx, cy, w, h) exactly (see data/dataset.py: xywhr_to_proxy_xyxy).
+        boxes = targets[:, :4].copy()
+        labels = targets[:, 4].copy()
+        angles = targets[:, 5].copy()
+
+        if random.random() < self.hsv_prob:
+            augment_hsv(image)
+
+        height, width = image.shape[:2]
+        if random.random() < self.flip_prob:
+            image = image[:, ::-1]
+            x1 = boxes[:, 0].copy()
+            boxes[:, 0] = width - boxes[:, 2]
+            boxes[:, 2] = width - x1
+            angles = -angles
+        if self.flipud > 0 and random.random() < self.flipud:
+            image = image[::-1]
+            y1 = boxes[:, 1].copy()
+            boxes[:, 1] = height - boxes[:, 3]
+            boxes[:, 3] = height - y1
+            angles = -angles
+
+        rgb = np.ascontiguousarray(image[:, :, ::-1])
+        image_t, ratio = preprocess_obb_numpy(rgb, input_size=input_size)
+
+        cxcywh = xyxy2cxcywh(boxes) * ratio
+        rows = np.concatenate([cxcywh, angles[:, None]], axis=1)
+        rows = _canonicalize_obb_rows(rows)
+
+        keep = np.minimum(rows[:, 2], rows[:, 3]) > 1
+        rows = rows[keep]
+        labels = labels[keep]
+
+        targets_t = np.hstack((labels[:, None], rows)).astype(np.float32)
+        return image_t, self._pad(targets_t)
+
+
+class YOLONASOBBDataset:
+    """Pass-through dataset wrapper for OBB training.
+
+    Matches ``BaseTrainer``'s dataset-wrapper constructor signature but
+    performs no mosaic, mixup or affine: see
+    :class:`YOLONASOBBTrainTransform` for why. It exists so the OBB trainer
+    can plug into the shared training loop unchanged.
+    """
+
+    def __init__(self, dataset, img_size, mosaic=True, preproc=None, **kwargs):
+        del mosaic, kwargs
+        self.dataset = dataset
+        self.img_size = img_size
+        self.preproc = preproc or YOLONASOBBTrainTransform()
+
+    def __len__(self):
+        return len(self.dataset)
+
+    @property
+    def input_dim(self):
+        return self.img_size
+
+    def close_mosaic(self):
+        # Nothing to close; kept for the shared trainer's late-epoch hook.
+        return None
+
+    def __getitem__(self, idx):
+        img, label, img_info, img_id = self.dataset.pull_item(idx)
+        img, label = self.preproc(img, label, self.input_dim)
+        return img, label, img_info, img_id

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -260,6 +260,7 @@ def export_onnx(
     is_ec_pose = model_family == "ec" and task == "pose"
     is_yolonas_pose = model_family == "yolonas" and task == "pose"
     is_obb = task == "obb"
+    is_yolonas_obb = model_family == "yolonas" and is_obb
     is_classify = task == "classify"
     is_semantic = task == "semantic"
     is_restore = task == "restore"
@@ -454,6 +455,19 @@ def export_onnx(
                 "images": {0: "batch"},
                 "pred_logits": {0: "batch", 1: "queries"},
                 "pred_keypoints": {0: "batch", 1: "queries", 2: "keypoint_values"},
+            }
+            if dynamic
+            else None
+        )
+    elif is_yolonas_obb:
+        # Raw OBB export contract: boxes [B, N, 5] as cx, cy, w, h, rotation
+        # plus sigmoid scores [B, N, C]. Rotated NMS stays out of the graph.
+        output_names = ["boxes", "scores"]
+        dynamic_axes = (
+            {
+                "images": {0: "batch"},
+                "boxes": {0: "batch", 1: "anchors"},
+                "scores": {0: "batch", 1: "anchors"},
             }
             if dynamic
             else None

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -2978,6 +2978,21 @@ _add(
 _add(
     "validated",
     ("yolonas",),
+    ("obb",),
+    ("onnx", "torchscript", "openvino", "tensorrt"),
+    since="1.6",
+    constraint=(
+        "fixed 1024x1024 export canvas, batch 1, FP32; the official "
+        "YOLO-NAS-R-S DOTA2 checkpoint exports, reloads through the factory, "
+        "and its public OBB results match native inference on the same image "
+        "(max xywhr delta 6e-08 px TorchScript, 0.06 px ONNX, 0.04 px "
+        "OpenVINO, 0.18 px TensorRT; max score delta 0.0, 1.0e-03, 1.5e-03 "
+        "and 1.6e-03 respectively). Rotated NMS is not embedded in the graph"
+    ),
+)
+_add(
+    "validated",
+    ("yolonas",),
     ("detect",),
     ("coreai",),
     since="1.5",

--- a/libreyolo/models/autoconvert.py
+++ b/libreyolo/models/autoconvert.py
@@ -182,6 +182,14 @@ def _checkpoint_names(loaded: Any, nc: int | None = None) -> Any | None:
         return _trim_names_to_nc(names, nc)
 
     args = loaded.get("args") or loaded.get("hyper_parameters") or {}
+    if not args:
+        # SuperGradients (YOLO-NAS detect/pose and YOLO-NAS-R) stores the
+        # dataset's class names under ``processing_params``. Without this, an
+        # auto-converted Deci checkpoint silently ends up with class_0..class_N
+        # instead of its real COCO / DOTA2 labels.
+        processing_params = loaded.get("processing_params")
+        if isinstance(processing_params, dict):
+            args = processing_params
     class_names = (
         args.get("class_names")
         if isinstance(args, dict)

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -1,4 +1,13 @@
-"""LibreYOLO YOLO-NAS wrapper (detect + pose)."""
+"""LibreYOLO YOLO-NAS wrapper (detect + pose + obb).
+
+The ``obb`` task is YOLO-NAS-R, ported from the Apache-2.0 SuperGradients
+pull request 2014 at pinned commit
+``69141b55c1161d939939a270523a7eca5a645f72``. Its pretrained DOTA2 weights are
+covered by Deci's separate, non-redistributable YOLO-NAS-R licence and are
+linked from Deci's CDN rather than mirrored -- same treatment as YOLO-NAS
+detect and pose. See ``THIRD_PARTY_NOTICES.txt`` and
+``weights/LICENSE_NOTICE.txt``.
+"""
 
 from __future__ import annotations
 
@@ -17,8 +26,9 @@ from ...tasks import normalize_task
 from ...utils.image_loader import ImageInput
 from ...utils.serialization import load_untrusted_torch_file
 from ...validation.preprocessors import YOLONASValPreprocessor
-from .nn import LibreYOLONASModel, LibreYOLONASPoseModel
-from ...postprocess.yolonas import postprocess, postprocess_pose
+from .nn import LibreYOLONASModel, LibreYOLONASOBBModel, LibreYOLONASPoseModel
+from ...postprocess.yolonas import postprocess, postprocess_obb, postprocess_pose
+from ...preprocess.yolonas import preprocess_obb_image
 from .utils import (
     preprocess_image,
     preprocess_pose_image,
@@ -28,6 +38,29 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 _POSE_HEAD_KEY = "heads.head1.pose_pred.weight"
+_OBB_HEAD_KEY = "heads.head1.rot_pred.weight"
+
+# DOTA2 class order used by the upstream YOLO-NAS-R checkpoints.
+YOLONAS_OBB_CLASS_NAMES = (
+    "plane",
+    "ship",
+    "storage-tank",
+    "baseball-diamond",
+    "tennis-court",
+    "basketball-court",
+    "ground-track-field",
+    "harbor",
+    "bridge",
+    "large-vehicle",
+    "small-vehicle",
+    "helicopter",
+    "roundabout",
+    "soccer-ball-field",
+    "swimming-pool",
+    "container-crane",
+    "airport",
+    "helipad",
+)
 
 
 class LibreYOLONAS(BaseModel):
@@ -35,7 +68,9 @@ class LibreYOLONAS(BaseModel):
     FILENAME_PREFIX = "LibreYOLONAS"
     INPUT_SIZES = {"s": 640, "m": 640, "l": 640}
     POSE_INPUT_SIZES = {"n": 640, "s": 640, "m": 640, "l": 640}
-    SUPPORTED_TASKS = ("detect", "pose")
+    # YOLO-NAS-R is trained on DOTA2 and evaluated at 1024.
+    OBB_INPUT_SIZES = {"s": 1024, "m": 1024, "l": 1024}
+    SUPPORTED_TASKS = ("detect", "pose", "obb")
     # Forward is pure tensor work with no host sync, verified to capture and
     # replay bit-identically (tests/unit/test_cuda_graph_families.py).
     SUPPORTS_CUDA_GRAPH = True
@@ -43,6 +78,7 @@ class LibreYOLONAS(BaseModel):
     TASK_INPUT_SIZES = {
         "detect": INPUT_SIZES,
         "pose": POSE_INPUT_SIZES,
+        "obb": OBB_INPUT_SIZES,
     }
     POSE_NUM_KEYPOINTS = 17
     KEYPOINT_DIM = 3
@@ -70,7 +106,21 @@ class LibreYOLONAS(BaseModel):
         return _POSE_HEAD_KEY in weights_dict
 
     @classmethod
+    def is_obb_state_dict(cls, weights_dict: dict) -> bool:
+        """True for YOLO-NAS-R rotated checkpoints.
+
+        ``rot_pred`` exists only on the rotated head, so it separates OBB from
+        both detect and pose without touching any shared backbone key.
+        """
+        return _OBB_HEAD_KEY in weights_dict
+
+    @classmethod
     def detect_checkpoint_task(cls, weights_dict: dict) -> Optional[str]:
+        # OBB is resolved before pose and detect: the rotated head shares the
+        # detect head's cls_pred/reg_pred names, so a plain "not pose ->
+        # detect" fallback would silently build the wrong architecture.
+        if cls.is_obb_state_dict(weights_dict):
+            return "obb"
         return "pose" if cls.is_pose_state_dict(weights_dict) else None
 
     @classmethod
@@ -82,15 +132,24 @@ class LibreYOLONAS(BaseModel):
         size = super().detect_size_from_filename(filename)
         if size is not None:
             return size
-        match = re.search(r"yolo_nas(?:_pose)?_([nsml])_coco", filename.lower())
+        lowered = filename.lower()
+        match = re.search(r"yolo_nas(?:_pose)?_([nsml])_coco", lowered)
+        if match:
+            return match.group(1)
+        # Native Deci rotated checkpoints: yolo_nas_r_<size>_dota2.pth.
+        match = re.search(r"yolo_nas_r_([sml])_dota2", lowered)
         return match.group(1) if match else None
 
     @classmethod
     def detect_task_from_filename(cls, filename: str) -> Optional[str]:
-        # Native Deci pose checkpoints are named yolo_nas_pose_<size>_coco_pose.pth.
-        # Detect that here so local checkpoints route to the pose architecture.
-        if re.search(r"yolo_nas_pose_[nsml]_coco", filename.lower()):
+        # Native Deci pose checkpoints are named yolo_nas_pose_<size>_coco_pose.pth,
+        # rotated ones yolo_nas_r_<size>_dota2.pth. Detect those here so local
+        # checkpoints route to the right architecture.
+        lowered = filename.lower()
+        if re.search(r"yolo_nas_pose_[nsml]_coco", lowered):
             return "pose"
+        if re.search(r"yolo_nas_r_[sml]_dota2", lowered):
+            return "obb"
         return super().detect_task_from_filename(filename)
 
     @classmethod
@@ -105,6 +164,10 @@ class LibreYOLONAS(BaseModel):
             if size not in cls.POSE_INPUT_SIZES:
                 return None
             return f"{cls._DECI_CDN_BASE}/yolo_nas_pose_{size}_coco_pose.pth"
+        if task == "obb":
+            if size not in cls.OBB_INPUT_SIZES:
+                return None
+            return f"{cls._DECI_CDN_BASE}/yolo_nas_r_{size}_dota2.pth"
         if size not in cls.INPUT_SIZES:
             return None
         return f"{cls._DECI_CDN_BASE}/yolo_nas_{size}_coco.pth"
@@ -194,6 +257,10 @@ class LibreYOLONAS(BaseModel):
             # A file path's real class count is resolved in _load_weights;
             # training resolves it from the dataset yaml.
             nb_classes = 1
+        if resolved_task == "obb" and isinstance(model_path, dict):
+            ckpt_nc = self.detect_nb_classes(model_path)
+            if ckpt_nc is not None:
+                nb_classes = ckpt_nc
         super().__init__(
             model_path=model_path,
             size=size,
@@ -209,10 +276,20 @@ class LibreYOLONAS(BaseModel):
                 self.names = {0: "person"}
             else:
                 self.names = {i: str(i) for i in range(self.nb_classes)}
+        if self.task == "obb" and self.nb_classes == len(YOLONAS_OBB_CLASS_NAMES):
+            # Placeholder DOTA2 names; checkpoint metadata or the dataset yaml
+            # overrides them where present.
+            self.names = dict(enumerate(YOLONAS_OBB_CLASS_NAMES))
         if isinstance(model_path, str):
             self._load_weights(model_path)
 
     def _init_model(self) -> nn.Module:
+        if self.task == "obb":
+            return LibreYOLONASOBBModel(
+                config=self.size,
+                nb_classes=self.nb_classes,
+                reg_max=self.reg_max,
+            )
         if self.task == "pose":
             return LibreYOLONASPoseModel(
                 config=self.size,
@@ -243,6 +320,10 @@ class LibreYOLONAS(BaseModel):
 
     def _rebuild_for_new_classes(self, new_nb_classes: int):
         self.nb_classes = new_nb_classes
+        if self.task == "obb":
+            self.model.replace_num_classes(new_nb_classes)
+            self.model.to(self.device)
+            return
         if self.task == "pose":
             # Rebuild the pose head's class channels; the per-keypoint
             # visibility channels and the rest of the model are preserved.
@@ -282,6 +363,12 @@ class LibreYOLONAS(BaseModel):
         input_size: Optional[int] = None,
     ) -> Tuple[torch.Tensor, Any, Tuple[int, int], float]:
         effective_size = input_size if input_size is not None else self.input_size
+        if self.task == "obb":
+            return preprocess_obb_image(
+                image,
+                input_size=effective_size,
+                color_format=color_format,
+            )
         if self.task == "pose":
             return preprocess_pose_image(
                 image,
@@ -296,8 +383,20 @@ class LibreYOLONAS(BaseModel):
 
     def _forward(self, input_tensor: torch.Tensor) -> Any:
         output = self.model(input_tensor)
+        if self.task == "obb":
+            # Heads return ((boxes_cxcywhr, scores), raw_logits) in eager mode
+            # and just (boxes, scores) under tracing.
+            if isinstance(output, tuple) and len(output) == 2:
+                decoded = output[0] if isinstance(output[0], tuple) else output
+                boxes, scores = decoded
+                return {"boxes": boxes, "scores": scores}
+            return output
         if self.task == "pose":
-            if isinstance(output, tuple) and len(output) == 2 and isinstance(output[0], tuple):
+            if (
+                isinstance(output, tuple)
+                and len(output) == 2
+                and isinstance(output[0], tuple)
+            ):
                 output = output[0]
             # Heads return the inference 4-tuple
             # (bboxes, scores, pose_xy, pose_scores).
@@ -333,6 +432,16 @@ class LibreYOLONAS(BaseModel):
         **kwargs,
     ) -> Dict:
         actual_input_size = kwargs.get("input_size", self.input_size)
+        if self.task == "obb":
+            return postprocess_obb(
+                output,
+                conf_thres=conf_thres,
+                iou_thres=iou_thres,
+                input_size=actual_input_size,
+                original_size=original_size,
+                max_det=max_det,
+                letterbox=kwargs.get("letterbox", True),
+            )
         if self.task == "pose":
             return postprocess_pose(
                 output,
@@ -370,6 +479,10 @@ class LibreYOLONAS(BaseModel):
         "yolo_nas_pose_s_coco_pose.pth": "54f0933cb3760c5f9ba47e901c58d6d114cd206718667a586031bea0ab9ea849",
         "yolo_nas_pose_m_coco_pose.pth": "6d0f92a589fd2f39a9fb92c42894cca76e81eaf2fcb3a00f1cac2e7089fb91ec",
         "yolo_nas_pose_l_coco_pose.pth": "d05c55157b3eb917e43d3669cc1e99fbe35a8a93c7883b95b93036a81216c5ab",
+        # YOLO-NAS-R (rotated / OBB), DOTA2.
+        "yolo_nas_r_s_dota2.pth": "2dbca049da3a77b62882ba1c75fea236c2edac089a1166a91db1940af9aa7e24",
+        "yolo_nas_r_m_dota2.pth": "0f444de9dbf2221eecae0445f45773c210e59e9cbb13fd08c15e81f064e571d4",
+        "yolo_nas_r_l_dota2.pth": "ec8e24e8ba6acad97a15d7ccdbfc5658830f88e0ec73c1f5749b7ebf244f18d5",
     }
 
     @classmethod
@@ -429,18 +542,24 @@ class LibreYOLONAS(BaseModel):
             state_dict = self._prepare_state_dict(state_dict)
 
             ckpt_is_pose = self.is_pose_state_dict(state_dict)
-            if ckpt_is_pose and self.task != "pose":
+            ckpt_is_obb = self.is_obb_state_dict(state_dict)
+            ckpt_task = "obb" if ckpt_is_obb else ("pose" if ckpt_is_pose else "detect")
+            if ckpt_task != self.task:
                 raise RuntimeError(
-                    "Checkpoint is a YOLO-NAS pose model but this instance was "
-                    "initialized for detection. Pass task='pose' or use a "
-                    "detection checkpoint."
+                    f"Checkpoint is a YOLO-NAS {ckpt_task} model but this "
+                    f"instance was initialized for {self.task}. Pass "
+                    f"task='{ckpt_task}' or use a {self.task} checkpoint."
                 )
-            if not ckpt_is_pose and self.task == "pose":
-                raise RuntimeError(
-                    "Checkpoint is a YOLO-NAS detection model but this instance "
-                    "was initialized for pose. Pass task='detect' or use a pose "
-                    "checkpoint."
-                )
+
+            if ckpt_is_obb:
+                # Bare upstream YOLO-NAS-R checkpoints carry no nc/names
+                # metadata, so size the rotated head from the head shapes and
+                # fall back to the published DOTA2 class order.
+                ckpt_nc = self.detect_nb_classes(state_dict)
+                if ckpt_nc is not None and ckpt_nc != self.nb_classes:
+                    self._rebuild_for_new_classes(ckpt_nc)
+                if self.nb_classes == len(YOLONAS_OBB_CLASS_NAMES):
+                    self.names = dict(enumerate(YOLONAS_OBB_CLASS_NAMES))
 
             # Match the pose head to the checkpoint's keypoint count before
             # loading (e.g. a 4-keypoint fine-tune of a COCO-17 model).
@@ -526,6 +645,16 @@ class LibreYOLONAS(BaseModel):
             loggers: Optional built-in experiment loggers: a registered name,
                 a configured logger instance, or an iterable mixing both.
         """
+        if self.task == "obb":
+            raise NotImplementedError(
+                "YOLO-NAS-R (task='obb') ships inference-only in LibreYOLO: the "
+                "rotated head, decode, preprocessing, postprocessing and exports "
+                "are ported and parity-checked, but the rotated loss "
+                "(probabilistic-IoU task-aligned assignment, width/height DFL, "
+                "offset and rotation regression) is not wired yet. Use "
+                "task='detect' or task='pose' to train YOLO-NAS."
+            )
+
         # Task-specific defaults for arguments left unset by the caller.
         if lr0 is None:
             lr0 = 2e-3 if self.task == "pose" else 5e-4

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -283,6 +283,24 @@ class LibreYOLONAS(BaseModel):
         if isinstance(model_path, str):
             self._load_weights(model_path)
 
+    def _get_val_preprocessor(self, img_size: int | None = None):
+        """Pick the preprocessor matching this task's inference recipe.
+
+        OBB uses a different geometry from detect/pose (longest side to 1024
+        and bottom-right padding, versus 636/640 and centre padding). The
+        postprocessor inverts the OBB recipe, so validating with the detect
+        preprocessor silently mis-maps every box back onto the canvas and
+        collapses OBB mAP to ~0 -- exactly the class of bug
+        ``YOLONASValPreprocessor``'s own docstring records for detect.
+        """
+        if self.task == "obb":
+            from ...validation.preprocessors import YOLONASOBBValPreprocessor
+
+            if img_size is None:
+                img_size = self._get_input_size()
+            return YOLONASOBBValPreprocessor(img_size=(img_size, img_size))
+        return super()._get_val_preprocessor(img_size)
+
     def _init_model(self) -> nn.Module:
         if self.task == "obb":
             return LibreYOLONASOBBModel(
@@ -645,17 +663,36 @@ class LibreYOLONAS(BaseModel):
             loggers: Optional built-in experiment loggers: a registered name,
                 a configured logger instance, or an iterable mixing both.
         """
+        # Task-specific defaults for arguments left unset by the caller.
         if self.task == "obb":
-            raise NotImplementedError(
-                "YOLO-NAS-R (task='obb') ships inference-only in LibreYOLO: the "
-                "rotated head, decode, preprocessing, postprocessing and exports "
-                "are ported and parity-checked, but the rotated loss "
-                "(probabilistic-IoU task-aligned assignment, width/height DFL, "
-                "offset and rotation regression) is not wired yet. Use "
-                "task='detect' or task='pose' to train YOLO-NAS."
+            # Upstream's DOTA recipe: AdamW 5e-5, 100 epochs, no AMP.
+            if lr0 is None:
+                lr0 = 5e-5
+            if epochs is None:
+                epochs = 100
+            if amp is None:
+                amp = False
+            return self._train_obb(
+                data,
+                epochs=epochs,
+                batch=batch,
+                imgsz=imgsz,
+                lr0=lr0,
+                optimizer=optimizer,
+                device=device,
+                workers=workers,
+                seed=seed,
+                project=project,
+                name=name or "yolonas_obb_exp",
+                exist_ok=exist_ok,
+                resume=resume,
+                amp=amp,
+                patience=patience,
+                callbacks=callbacks,
+                loggers=loggers,
+                **kwargs,
             )
 
-        # Task-specific defaults for arguments left unset by the caller.
         if lr0 is None:
             lr0 = 2e-3 if self.task == "pose" else 5e-4
         if epochs is None:
@@ -764,6 +801,195 @@ class LibreYOLONAS(BaseModel):
             self.model.eval()
 
         return results
+
+    def _train_obb(
+        self,
+        data: str,
+        *,
+        epochs: int,
+        batch: int,
+        imgsz: int,
+        lr0: float,
+        optimizer: str,
+        device: str,
+        workers: int,
+        seed: int,
+        project: str,
+        name: str,
+        exist_ok: bool,
+        resume: bool,
+        amp: bool,
+        patience: int,
+        callbacks=None,
+        loggers=None,
+        **kwargs,
+    ) -> dict:
+        """Train the YOLO-NAS-R rotated head on a YOLO-format OBB dataset.
+
+        Labels are the standard YOLO OBB rows (``class x1 y1 x2 y2 x3 y3 x4
+        y4``, normalized corners); the shared dataset converts them to
+        canonical ``xywhr``.
+
+        ``imgsz`` is the training canvas and defaults to the caller's value --
+        upstream trains on 640-pixel crops and validates at 1024, so the
+        1024 default inference size is not a required training size.
+        """
+        from libreyolo.data import load_data_config
+
+        from .obb_trainer import YOLONASOBBTrainer
+
+        try:
+            data_config = load_data_config(data, autodownload=True)
+            data = data_config.get("yaml_file", data)
+        except Exception as e:
+            raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")
+
+        yaml_nc = data_config.get("nc")
+        yaml_names = data_config.get("names")
+        if yaml_nc is None and yaml_names is not None:
+            yaml_nc = len(yaml_names)
+        if yaml_nc is not None and int(yaml_nc) != self.nb_classes:
+            logger.info(
+                "Rebuilding YOLO-NAS-R head for %d classes (was %d)",
+                int(yaml_nc),
+                self.nb_classes,
+            )
+            self._rebuild_for_new_classes(int(yaml_nc))
+
+        if yaml_names is not None:
+            if isinstance(yaml_names, list):
+                yaml_names = {i: n for i, n in enumerate(yaml_names)}
+            self.names = self._sanitize_names(yaml_names, self.nb_classes)
+
+        if seed >= 0:
+            import random
+
+            import numpy as np
+
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
+                torch.cuda.manual_seed_all(seed)
+
+        trainer = YOLONASOBBTrainer(
+            model=self.model,
+            wrapper_model=self,
+            size=self.size,
+            num_classes=self.nb_classes,
+            data=data,
+            epochs=epochs,
+            batch=batch,
+            imgsz=imgsz,
+            lr0=lr0,
+            optimizer=optimizer.lower(),
+            device=device if device else "auto",
+            workers=workers,
+            seed=seed,
+            project=project,
+            name=name,
+            exist_ok=exist_ok,
+            resume=resume,
+            amp=amp,
+            patience=patience,
+            callbacks=callbacks,
+            loggers=loggers,
+            **kwargs,
+        )
+
+        if resume:
+            if not self.model_path:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreYOLONAS('path/to/last.pt', task='obb'); "
+                    "model.train(data=..., resume=True)"
+                )
+            trainer.setup()
+            trainer.resume(str(self.model_path))
+            return trainer.train()
+
+        results = trainer.train()
+
+        best_ckpt = results.get("best_checkpoint")
+        if best_ckpt and Path(best_ckpt).exists():
+            self.model_path = best_ckpt
+            self._load_weights(best_ckpt)
+            self.model.eval()
+
+        return results
+
+    def load_detect_weights_for_obb(self, detect_checkpoint) -> dict:
+        """Initialise a rotated model from a YOLO-NAS *detection* checkpoint.
+
+        Upstream trains YOLO-NAS-R starting from the same-size detection
+        weights with ``strict_load: key_matching``. This is that: the shared
+        backbone, neck, and every head tensor whose shape still matches are
+        copied over; the rotated-specific parameters (``reg_pred`` -- which
+        changes from ``4 * (reg_max + 1)`` to ``2 * (reg_max + 1)`` channels
+        --, ``rot_pred``, ``offset_pred``, and ``cls_pred`` when the class
+        count differs) stay at their fresh initialisation.
+
+        :param detect_checkpoint: path to a YOLO-NAS detect checkpoint, or an
+            already-loaded state dict.
+        :return: a report with the ``transferred``, ``skipped_shape`` and
+            ``missing`` key lists.
+        """
+        if self.task != "obb":
+            raise ValueError(
+                "load_detect_weights_for_obb() is only valid on a task='obb' "
+                f"model, this one is task='{self.task}'."
+            )
+
+        if isinstance(detect_checkpoint, (str, Path)):
+            loaded = load_untrusted_torch_file(
+                str(detect_checkpoint),
+                map_location="cpu",
+                context="YOLO-NAS detect->OBB transfer",
+            )
+        else:
+            loaded = detect_checkpoint
+        source = dict(unwrap_yolonas_checkpoint(loaded))
+        source = self._strip_ddp_prefix(source)
+
+        if self.is_obb_state_dict(source):
+            raise ValueError(
+                "Expected a YOLO-NAS detection checkpoint for transfer "
+                "initialisation, got a rotated (OBB) one. Load it directly "
+                "instead."
+            )
+        if self.is_pose_state_dict(source):
+            raise ValueError(
+                "Expected a YOLO-NAS detection checkpoint for transfer "
+                "initialisation, got a pose one."
+            )
+
+        target = self.model.state_dict()
+        transferred, skipped_shape = [], []
+        update = {}
+        for key, tensor in source.items():
+            if key not in target:
+                continue
+            if tuple(target[key].shape) != tuple(tensor.shape):
+                skipped_shape.append(key)
+                continue
+            update[key] = tensor
+            transferred.append(key)
+
+        missing = [k for k in target if k not in update]
+        self.model.load_state_dict(update, strict=False)
+        self.model.to(self.device)
+        logger.info(
+            "Detect->OBB transfer: %d tensors copied, %d shape-mismatched, "
+            "%d left freshly initialised",
+            len(transferred),
+            len(skipped_shape),
+            len(missing),
+        )
+        return {
+            "transferred": transferred,
+            "skipped_shape": skipped_shape,
+            "missing": missing,
+        }
 
     def _train_pose(
         self,

--- a/libreyolo/models/yolonas/nn.py
+++ b/libreyolo/models/yolonas/nn.py
@@ -1346,10 +1346,14 @@ class YoloNASPoseDFLHead(nn.Module):
         )
 
         self.cls_convs = nn.Sequential(
-            ConvBNReLU(bbox_inter, bbox_inter, kernel_size=3, stride=1, padding=1, bias=False),
+            ConvBNReLU(
+                bbox_inter, bbox_inter, kernel_size=3, stride=1, padding=1, bias=False
+            ),
         )
         self.reg_convs = nn.Sequential(
-            ConvBNReLU(bbox_inter, bbox_inter, kernel_size=3, stride=1, padding=1, bias=False),
+            ConvBNReLU(
+                bbox_inter, bbox_inter, kernel_size=3, stride=1, padding=1, bias=False
+            ),
         )
 
         pose_block = partial(ConvBNReLU, kernel_size=3, stride=1, padding=1, bias=False)
@@ -1434,7 +1438,13 @@ class YoloNASPoseDFLHead(nn.Module):
         pose_logits = cls_output[:, self.num_classes :, :, :]
         cls_output = cls_output[:, : self.num_classes, :, :]
         pose_regression = pose_output.reshape(
-            (pose_output.size(0), self.num_keypoints, 2, pose_output.size(2), pose_output.size(3))
+            (
+                pose_output.size(0),
+                self.num_keypoints,
+                2,
+                pose_output.size(2),
+                pose_output.size(3),
+            )
         )
         return reg_output, cls_output, pose_regression, pose_logits
 
@@ -1510,7 +1520,9 @@ class YoloNASPoseNDFLHeads(nn.Module):
         self.eval_size = input_size
         device = next(self.parameters()).device
         dtype = next(self.parameters()).dtype
-        anchor_points, stride_tensor = self._generate_anchors(dtype=dtype, device=device)
+        anchor_points, stride_tensor = self._generate_anchors(
+            dtype=dtype, device=device
+        )
         self.register_buffer("anchor_points", anchor_points, persistent=False)
         self.register_buffer("stride_tensor", stride_tensor, persistent=False)
 
@@ -1594,11 +1606,13 @@ class YoloNASPoseNDFLHeads(nn.Module):
                 - self.grid_cell_offset
             )
         else:
-            pose_regression_list = (
-                pose_regression_list + anchor_points.unsqueeze(0).unsqueeze(2)
-            )
+            pose_regression_list = pose_regression_list + anchor_points.unsqueeze(
+                0
+            ).unsqueeze(2)
 
-        pose_regression_list = pose_regression_list * stride_tensor.unsqueeze(0).unsqueeze(2)
+        pose_regression_list = pose_regression_list * stride_tensor.unsqueeze(
+            0
+        ).unsqueeze(2)
         pred_pose_scores = pose_logits_list.sigmoid()
         decoded = (pred_bboxes, pred_scores, pose_regression_list, pred_pose_scores)
 
@@ -1613,10 +1627,10 @@ class YoloNASPoseNDFLHeads(nn.Module):
             )
         )
         raw_predictions = (
-            cls_score_list,        # [B, A, nc] classification logits
-            reg_distri_list,       # [B, A, 4*(reg_max+1)] raw DFL distribution
+            cls_score_list,  # [B, A, nc] classification logits
+            reg_distri_list,  # [B, A, 4*(reg_max+1)] raw DFL distribution
             pose_regression_list,  # [B, A, K, 2] decoded pose coords (image px)
-            pose_logits_list,      # [B, A, K] keypoint visibility logits
+            pose_logits_list,  # [B, A, K] keypoint visibility logits
             anchors_t,
             anchor_points_t,
             num_anchors_list,
@@ -1686,6 +1700,291 @@ class LibreYOLONASPoseModel(nn.Module):
         """Rebuild the pose head for a new class count (fine-tuning hook)."""
         self.heads.replace_num_classes(num_classes)
         self.num_classes = num_classes
+
+    def prep_model_for_conversion(
+        self, input_size=None, full_fusion: bool = False, **kwargs
+    ):
+        for module in self.modules():
+            if module is not self and hasattr(module, "prep_model_for_conversion"):
+                module.prep_model_for_conversion(
+                    input_size=input_size, full_fusion=full_fusion, **kwargs
+                )
+
+    def fuse_reparam(self, full_fusion: bool = False):
+        self.prep_model_for_conversion(full_fusion=full_fusion)
+        return self
+
+    def forward(self, x: Tensor):
+        feats = self.backbone(x)
+        feats = self.neck(feats)
+        return self.heads(feats)
+
+
+# ---------------------------------------------------------------------------
+# Rotated (OBB) head + model — YOLO-NAS-R
+# ---------------------------------------------------------------------------
+#
+# Ported from SuperGradients (Apache-2.0) at the pinned YOLO-NAS-R PR head
+# 69141b55c1161d939939a270523a7eca5a645f72:
+#   src/super_gradients/training/models/detection_models/yolo_nas_r/
+#       yolo_nas_r_dfl_head.py, yolo_nas_r_ndfl_heads.py, yolo_nas_r_variants.py
+#
+# The backbone and neck are identical to the detection variants (the rotated
+# arch_params differ from the detection ones only in the head class names), so
+# LibreYOLONASOBBModel reuses them unchanged.
+
+
+class YoloNASRDFLHead(YoloNASDFLHead):
+    """Detection DFL head with rotated-box outputs.
+
+    Keeps the detection head's stem / cls_convs / reg_convs / cls_pred verbatim
+    and swaps the regression branch for the rotated parameterisation:
+
+    - ``reg_pred``    -> ``2 * (reg_max + 1)`` width/height DFL logits
+    - ``offset_pred`` -> 2 center offsets (zero-initialised, as upstream)
+    - ``rot_pred``    -> 1 rotation logit
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        inter_channels: int,
+        width_mult: float,
+        first_conv_group_size: int,
+        num_classes: int,
+        stride: int,
+        reg_max: int,
+        cls_dropout_rate: float = 0.0,
+        reg_dropout_rate: float = 0.0,
+    ):
+        super().__init__(
+            in_channels=in_channels,
+            inter_channels=inter_channels,
+            width_mult=width_mult,
+            first_conv_group_size=first_conv_group_size,
+            num_classes=num_classes,
+            stride=stride,
+            reg_max=reg_max,
+            cls_dropout_rate=cls_dropout_rate,
+            reg_dropout_rate=reg_dropout_rate,
+        )
+        inter_channels = width_multiplier(inter_channels, width_mult, 8)
+        self.reg_pred = nn.Conv2d(inter_channels, 2 * (reg_max + 1), 1, 1, 0)
+        self.rot_pred = nn.Conv2d(inter_channels, 1, kernel_size=1, stride=1, padding=0)
+        self.offset_pred = nn.Conv2d(
+            inter_channels, 2, kernel_size=1, stride=1, padding=0
+        )
+        nn.init.zeros_(self.offset_pred.weight)
+        nn.init.zeros_(self.offset_pred.bias)
+
+    def forward(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Return ``(reg_output, cls_output, offset_output, rot_output)``."""
+        x = self.stem(x)
+
+        cls_feat = self.cls_dropout_rate(self.cls_convs(x))
+        cls_output = self.cls_pred(cls_feat)
+
+        reg_feat = self.reg_dropout_rate(self.reg_convs(x))
+        reg_output = self.reg_pred(reg_feat)
+        rot_output = self.rot_pred(reg_feat)
+        offset_output = self.offset_pred(reg_feat)
+
+        return reg_output, cls_output, offset_output, rot_output
+
+
+class YoloNASRNDFLHeads(nn.Module):
+    """Three-stride rotated head stack.
+
+    In eager mode returns ``(decoded, raw)`` where ``decoded`` is the tuple
+    ``(boxes_cxcywhr [B, A, 5], scores [B, A, C])`` and ``raw`` is the dict of
+    intermediate logits the loss consumes. Under tracing / export only
+    ``decoded`` is returned, matching the detection head's contract and the
+    raw export contract documented for this family.
+    """
+
+    def __init__(
+        self,
+        num_classes: int,
+        in_channels: Tuple[int, int, int],
+        width_mult: float,
+        grid_cell_offset: float = 0.5,
+        reg_max: int = 16,
+    ):
+        super().__init__()
+        self.in_channels = tuple(in_channels)
+        self.num_classes = num_classes
+        self.grid_cell_offset = grid_cell_offset
+        self.reg_max = reg_max
+        proj = torch.linspace(0, self.reg_max, self.reg_max + 1).reshape(
+            [1, self.reg_max + 1, 1, 1]
+        )
+        self.register_buffer("proj_conv", proj, persistent=False)
+
+        self.head1 = YoloNASRDFLHead(
+            in_channels[0], 128, width_mult, 0, num_classes, 8, reg_max
+        )
+        self.head2 = YoloNASRDFLHead(
+            in_channels[1], 256, width_mult, 0, num_classes, 16, reg_max
+        )
+        self.head3 = YoloNASRDFLHead(
+            in_channels[2], 512, width_mult, 0, num_classes, 32, reg_max
+        )
+        self.num_heads = 3
+        self.fpn_strides = (8, 16, 32)
+
+    def replace_num_classes(self, num_classes: int):
+        self.head1.replace_num_classes(num_classes)
+        self.head2.replace_num_classes(num_classes)
+        self.head3.replace_num_classes(num_classes)
+        self.num_classes = num_classes
+
+    @property
+    def out_channels(self):
+        return None
+
+    def _generate_anchors(self, feats):
+        """Grid-cell centres and per-anchor strides, derived from the features.
+
+        The ranges are built with ``ones_like``/``cumsum`` over slices of the
+        feature map rather than ``torch.arange(..., device=...)``: under
+        ``torch.jit.trace`` an explicit ``device=`` argument is baked into the
+        graph as a constant, which made the exported TorchScript module fail
+        with a cuda/cpu mismatch. Deriving from the tensor keeps the graph
+        device-agnostic (and spatially dynamic) while the eager arithmetic is
+        unchanged.
+        """
+        anchor_points = []
+        stride_tensor = []
+
+        for i, stride in enumerate(self.fpn_strides):
+            feat = feats[i]
+            row = feat[0, 0, 0, :]
+            col = feat[0, 0, :, 0]
+            shift_x = torch.cumsum(torch.ones_like(row), dim=0) - 1.0
+            shift_y = torch.cumsum(torch.ones_like(col), dim=0) - 1.0
+            shift_x = shift_x + self.grid_cell_offset
+            shift_y = shift_y + self.grid_cell_offset
+            shift_y, shift_x = torch.meshgrid(shift_y, shift_x, indexing="ij")
+            anchor_point = torch.stack([shift_x, shift_y], dim=-1)
+            anchor_points.append(anchor_point.reshape([-1, 2]))
+            stride_tensor.append(
+                torch.ones_like(anchor_point.reshape([-1, 2])[:, :1]) * float(stride)
+            )
+        return torch.cat(anchor_points), torch.cat(stride_tensor)
+
+    def forward(self, feats: Tuple[Tensor, ...]):
+        feats = feats[: self.num_heads]
+        cls_score_list = []
+        reg_distri_list = []
+        reg_dist_reduced_list = []
+        offsets_list = []
+        rot_list = []
+
+        for i, feat in enumerate(feats):
+            b, _, h, w = feat.shape
+            hw = h * w
+            head = getattr(self, "head" + str(i + 1))
+            reg_output, cls_output, offset_output, rot_output = head(feat)
+
+            reg_distri_list.append(torch.permute(reg_output.flatten(2), [0, 2, 1]))
+
+            reg_dist_reduced = torch.permute(
+                reg_output.reshape([-1, 2, self.reg_max + 1, hw]), [0, 2, 3, 1]
+            )
+            reg_dist_reduced = (
+                torch.softmax(reg_dist_reduced, dim=1).mul(self.proj_conv).sum(1)
+            )
+
+            cls_score_list.append(cls_output.reshape([b, -1, hw]))
+            reg_dist_reduced_list.append(reg_dist_reduced)
+            offsets_list.append(torch.flatten(offset_output, 2))
+            rot_list.append(torch.flatten(rot_output, 2))
+
+        cls_score_list = torch.permute(torch.cat(cls_score_list, dim=-1), [0, 2, 1])
+        offsets_list = torch.permute(torch.cat(offsets_list, dim=-1), [0, 2, 1])
+        rot_list = torch.permute(torch.cat(rot_list, dim=-1), [0, 2, 1])
+        # Upstream limits the predicted angle to [-3*pi/4, pi/4] (OpenCV
+        # counter-clockwise convention). Canonicalisation to LibreYOLO's
+        # [-pi/2, pi/2) long-side contract happens at the public
+        # postprocessing boundary, not here, so raw parity is preserved.
+        rot_list = (rot_list.sigmoid() - 0.25) * math.pi
+
+        reg_distri_list = torch.cat(reg_distri_list, dim=1)
+        reg_dist_reduced_list = torch.cat(reg_dist_reduced_list, dim=1)
+
+        anchor_points, stride_tensor = self._generate_anchors(feats)
+
+        sizes = reg_dist_reduced_list * stride_tensor
+        centers = (offsets_list + anchor_points) * stride_tensor
+        pred_boxes = torch.cat([centers, sizes, rot_list], dim=-1)
+        pred_scores = cls_score_list.sigmoid()
+        decoded_predictions = pred_boxes, pred_scores
+
+        if torch.jit.is_tracing():
+            return decoded_predictions
+
+        raw_predictions = {
+            "score_logits": cls_score_list,
+            "size_dist": reg_distri_list,
+            "size_reduced": reg_dist_reduced_list,
+            "angles": rot_list,
+            "offsets": offsets_list,
+            "anchor_points": anchor_points,
+            "strides": stride_tensor,
+            "reg_max": self.reg_max,
+        }
+        return decoded_predictions, raw_predictions
+
+
+class LibreYOLONASOBBModel(nn.Module):
+    """YOLO-NAS-R: the YOLO-NAS backbone/neck with a rotated-box head."""
+
+    def __init__(
+        self,
+        config: str = "s",
+        nb_classes: int = 18,
+        in_channels: int = 3,
+        reg_max: int = 16,
+        bn_eps: float = 1e-3,
+        bn_momentum: float = 0.03,
+        inplace_act: bool = True,
+    ):
+        super().__init__()
+        if config not in _VARIANT_CONFIGS:
+            raise ValueError(f"Unknown YOLO-NAS config '{config}'")
+
+        variant = _VARIANT_CONFIGS[config]
+        self.config = config
+        self.nc = nb_classes
+        self.reg_max = reg_max
+
+        self.backbone = YoloNASBackbone(variant, in_channels=in_channels)
+        self.neck = YoloNASPANNeckWithC2(list(self.backbone.out_channels), variant)
+        self.heads = YoloNASRNDFLHeads(
+            num_classes=nb_classes,
+            in_channels=tuple(self.neck.out_channels),
+            width_mult=variant["head_width_mult"],
+            reg_max=reg_max,
+        )
+        self._initialize_weights(bn_eps, bn_momentum, inplace_act)
+
+    @property
+    def head(self):
+        return self.heads
+
+    def _initialize_weights(self, bn_eps: float, bn_momentum: float, inplace_act: bool):
+        for m in self.modules():
+            if isinstance(m, nn.BatchNorm2d):
+                m.eps = bn_eps
+                m.momentum = bn_momentum
+            elif inplace_act and isinstance(
+                m, (nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, nn.Mish)
+            ):
+                m.inplace = True
+
+    def replace_num_classes(self, num_classes: int):
+        self.heads.replace_num_classes(num_classes)
+        self.nc = num_classes
 
     def prep_model_for_conversion(
         self, input_size=None, full_fusion: bool = False, **kwargs

--- a/libreyolo/models/yolonas/obb_loss.py
+++ b/libreyolo/models/yolonas/obb_loss.py
@@ -1,0 +1,483 @@
+"""YOLO-NAS-R (OBB) training loss.
+
+Ported from SuperGradients (Apache-2.0) at the pinned YOLO-NAS-R PR head
+``69141b55c1161d939939a270523a7eca5a645f72``:
+``src/super_gradients/training/losses/yolo_nas_r_loss.py``.
+
+Three terms, matching upstream:
+
+- **classification**: varifocal loss against the task-aligned assigner's
+  soft scores;
+- **regression**: ``1 - probIoU`` on the decoded ``cxcywhr`` boxes, which is
+  what supervises the centre offsets and the rotation -- upstream has no
+  separate offset or angle regression term, the probabilistic IoU covers
+  both;
+- **distribution focal loss** on the width/height DFL bins.
+
+Weights follow upstream's DOTA recipe
+(``recipes/training_hyperparams/default_yolo_nas_r_train_params.yaml``):
+``classification 2.5``, ``iou 2.0``, ``dfl 0.5``, assigner ``topk 12``.
+
+The generic top-k / max-IoU assigner helpers are shared with the detection
+loss in :mod:`libreyolo.models.yolonas.loss`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+from .loss import compute_max_iou_anchor, gather_topk_anchors
+
+
+def check_points_inside_rboxes(points: Tensor, rboxes: Tensor) -> Tensor:
+    """Mask anchors whose centre falls inside each rotated box's inradius.
+
+    :param points: ``(L, 2)`` anchor centres in pixels.
+    :param rboxes: ``(B, n, 5)`` ground-truth boxes in ``cxcywhr``.
+    :return: ``(B, n, L)`` float mask, 1 where the anchor is inside.
+    """
+    points = points[None, None, :, :]
+    x, y = points[..., 0], points[..., 1]
+
+    cx = rboxes[..., 0, None]
+    cy = rboxes[..., 1, None]
+    w = rboxes[..., 2, None]
+    h = rboxes[..., 3, None]
+    smallest_radius_sqr = (torch.minimum(w, h) / 2) ** 2
+
+    distance_sqr = (x - cx).pow(2) + (y - cy).pow(2)
+    return (distance_sqr <= smallest_radius_sqr).type_as(rboxes)
+
+
+def _covariance_matrix(w: Tensor, h: Tensor, angle: Tensor):
+    """Gaussian covariance terms ``(a, b, c)`` for a rotated box."""
+    a = w.pow(2) / 12
+    b = h.pow(2) / 12
+    cos = angle.cos()
+    sin = angle.sin()
+    cos2 = cos.pow(2)
+    sin2 = sin.pow(2)
+    return a * cos2 + b * sin2, a * sin2 + b * cos2, (a - b) * cos * sin
+
+
+def cxcywhr_iou(
+    obb1: Tensor,
+    obb2: Tensor,
+    include_ciou_term: bool = False,
+    eps: float = 1e-5,
+) -> Tensor:
+    """Probabilistic IoU between two sets of ``cxcywhr`` boxes.
+
+    https://arxiv.org/pdf/2106.06072v1.pdf -- differentiable, unlike the exact
+    polygon IoU used at postprocessing time, which is why training uses this
+    and NMS uses the exact one.
+    """
+    x1, y1, w1, h1, a1 = (
+        obb1[..., 0],
+        obb1[..., 1],
+        obb1[..., 2],
+        obb1[..., 3],
+        obb1[..., 4],
+    )
+    x2, y2, w2, h2, a2 = (
+        obb2[..., 0],
+        obb2[..., 1],
+        obb2[..., 2],
+        obb2[..., 3],
+        obb2[..., 4],
+    )
+
+    a1, b1, c1 = _covariance_matrix(w1, h1, a1)
+    a2, b2, c2 = _covariance_matrix(w2, h2, a2)
+
+    denom = (a1 + a2) * (b1 + b2) - (c1 + c2).pow(2) + eps
+    t1 = (((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / denom) * 0.25
+    t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2)) / denom) * 0.5
+    t3 = (
+        ((a1 + a2) * (b1 + b2) - (c1 + c2).pow(2))
+        / (
+            4
+            * (
+                (a1 * b1 - c1.pow(2)).clamp_min(0) * (a2 * b2 - c2.pow(2)).clamp_min(0)
+                + eps
+            ).sqrt()
+            + eps
+        )
+        + eps
+    ).log() * 0.5
+
+    bd = (t1 + t2 + t3).clamp(eps, 9.0)
+    # expm1 is the numerically stable form; the exp fallback keeps the
+    # expression traceable for ONNX, matching upstream.
+    if torch.jit.is_tracing() or torch.jit.is_scripting():
+        hd = (1.0 - (-bd).exp().clamp_min(eps)).sqrt()
+    else:
+        hd = torch.sqrt(-torch.expm1(-bd))
+
+    iou = 1 - hd
+
+    if include_ciou_term:
+        v = (4 / math.pi**2) * (
+            (w2 / (h2 + 1e-6)).atan() - (w1 / (h1 + 1e-6)).atan()
+        ).pow(2)
+        with torch.no_grad():
+            alpha = v / (v - iou + (1 + eps))
+        return iou - v * alpha
+
+    return torch.masked_fill(iou, ~torch.isfinite(iou), 0)
+
+
+def pairwise_cxcywhr_iou(obb1: Tensor, obb2: Tensor, eps: float = 1e-7) -> Tensor:
+    """``(..., N, M)`` probabilistic IoU between every pair of boxes."""
+    return cxcywhr_iou(
+        obb1[..., :, None, :], obb2[..., None, :, :], include_ciou_term=False, eps=eps
+    )
+
+
+@dataclasses.dataclass
+class YOLONASOBBAssignment:
+    """Per-anchor assignment produced by :class:`YOLONASOBBAssigner`."""
+
+    assigned_labels: Tensor  # (B, L)
+    assigned_rboxes: Tensor  # (B, L, 5)
+    assigned_scores: Tensor  # (B, L, C)
+    assigned_gt_index: Tensor  # (B, L)
+
+
+class YOLONASOBBAssigner(nn.Module):
+    """Task-aligned assigner on rotated boxes."""
+
+    def __init__(
+        self, topk: int = 12, alpha: float = 1.0, beta: float = 6.0, eps: float = 1e-9
+    ):
+        super().__init__()
+        self.topk = topk
+        self.alpha = alpha
+        self.beta = beta
+        self.eps = eps
+
+    @torch.no_grad()
+    def forward(
+        self,
+        pred_scores: Tensor,
+        pred_rboxes: Tensor,
+        anchor_points: Tensor,
+        gt_labels: Tensor,
+        gt_rboxes: Tensor,
+        bg_index: int,
+        pad_gt_mask: Optional[Tensor] = None,
+    ) -> YOLONASOBBAssignment:
+        """
+        :param pred_scores: ``(B, L, C)`` sigmoid class scores.
+        :param pred_rboxes: ``(B, L, 5)`` decoded predictions, ``cxcywhr``.
+        :param anchor_points: ``(L, 2)`` anchor centres, already multiplied by stride.
+        :param gt_labels: ``(B, n, 1)`` int64 class indices.
+        :param gt_rboxes: ``(B, n, 5)`` ground truth, ``cxcywhr``.
+        :param bg_index: background class index (``num_classes``).
+        """
+        batch_size, num_anchors, num_classes = pred_scores.shape
+        num_max_boxes = gt_rboxes.shape[1]
+        device = pred_scores.device
+
+        if num_max_boxes == 0:
+            return YOLONASOBBAssignment(
+                assigned_labels=torch.full(
+                    [batch_size, num_anchors], bg_index, dtype=torch.long, device=device
+                ),
+                assigned_rboxes=torch.zeros(
+                    [batch_size, num_anchors, 5], device=device
+                ),
+                assigned_scores=torch.zeros(
+                    [batch_size, num_anchors, num_classes], device=device
+                ),
+                assigned_gt_index=torch.zeros(
+                    [batch_size, num_anchors], dtype=torch.long, device=device
+                ),
+            )
+
+        ious = pairwise_cxcywhr_iou(gt_rboxes, pred_rboxes)  # [B, n, L]
+
+        scores_t = torch.permute(pred_scores, [0, 2, 1])  # [B, C, L]
+        batch_ind = torch.arange(
+            end=batch_size, dtype=gt_labels.dtype, device=device
+        ).unsqueeze(-1)
+        gt_labels_ind = torch.stack(
+            [batch_ind.tile([1, num_max_boxes]), gt_labels.squeeze(-1)], dim=-1
+        )
+        bbox_cls_scores = scores_t[gt_labels_ind[..., 0], gt_labels_ind[..., 1]]
+
+        alignment_metrics = bbox_cls_scores.pow(self.alpha) * ious.pow(self.beta)
+        is_in_gts = check_points_inside_rboxes(anchor_points, gt_rboxes)
+        # torch.topk raises when k exceeds the number of anchors, which real
+        # feature maps never do but small synthetic inputs can.
+        topk = min(self.topk, num_anchors)
+        is_in_topk = gather_topk_anchors(
+            alignment_metrics * is_in_gts, topk, topk_mask=pad_gt_mask
+        )
+
+        mask_positive = is_in_topk * is_in_gts
+        if pad_gt_mask is not None:
+            mask_positive = mask_positive * pad_gt_mask
+
+        mask_positive_sum = mask_positive.sum(dim=-2)
+        if mask_positive_sum.max() > 1:
+            mask_multiple_gts = (mask_positive_sum.unsqueeze(1) > 1).tile(
+                [1, num_max_boxes, 1]
+            )
+            is_max_iou = compute_max_iou_anchor(ious)
+            mask_positive = torch.where(mask_multiple_gts, is_max_iou, mask_positive)
+            mask_positive_sum = mask_positive.sum(dim=-2)
+        assigned_gt_index = mask_positive.argmax(dim=-2)
+
+        flat_gt_index = assigned_gt_index + batch_ind * num_max_boxes
+        assigned_labels = torch.gather(
+            gt_labels.flatten(), index=flat_gt_index.flatten(), dim=0
+        ).reshape([batch_size, num_anchors])
+        assigned_labels = torch.where(
+            mask_positive_sum > 0,
+            assigned_labels,
+            torch.full_like(assigned_labels, bg_index),
+        )
+
+        assigned_rboxes = gt_rboxes.reshape([-1, 5])[flat_gt_index.flatten(), :]
+        assigned_rboxes = assigned_rboxes.reshape([batch_size, num_anchors, 5])
+
+        assigned_scores = F.one_hot(assigned_labels, num_classes + 1)
+        keep = [i for i in range(num_classes + 1) if i != bg_index]
+        assigned_scores = torch.index_select(
+            assigned_scores,
+            index=torch.tensor(keep, device=device, dtype=torch.long),
+            dim=-1,
+        )
+
+        alignment_metrics = alignment_metrics * mask_positive
+        max_metrics_per_instance = alignment_metrics.max(dim=-1, keepdim=True).values
+        max_ious_per_instance = (ious * mask_positive).max(dim=-1, keepdim=True).values
+        alignment_metrics = (
+            alignment_metrics
+            / (max_metrics_per_instance + self.eps)
+            * max_ious_per_instance
+        )
+        alignment_metrics = alignment_metrics.max(dim=-2).values.unsqueeze(-1)
+        assigned_scores = assigned_scores * alignment_metrics
+
+        return YOLONASOBBAssignment(
+            assigned_labels=assigned_labels,
+            assigned_rboxes=assigned_rboxes,
+            assigned_scores=assigned_scores,
+            assigned_gt_index=assigned_gt_index,
+        )
+
+
+class YOLONASOBBLoss(nn.Module):
+    """Varifocal classification + probabilistic-IoU + width/height DFL."""
+
+    def __init__(
+        self,
+        num_classes: int,
+        classification_loss_weight: float = 2.5,
+        iou_loss_weight: float = 2.0,
+        dfl_loss_weight: float = 0.5,
+        assigner_topk: int = 12,
+        assigner_alpha: float = 1.0,
+        assigner_beta: float = 6.0,
+        use_varifocal_loss: bool = True,
+    ):
+        super().__init__()
+        self.num_classes = num_classes
+        self.classification_loss_weight = classification_loss_weight
+        self.iou_loss_weight = iou_loss_weight
+        self.dfl_loss_weight = dfl_loss_weight
+        self.use_varifocal_loss = use_varifocal_loss
+        self.assigner = YOLONASOBBAssigner(
+            topk=assigner_topk, alpha=assigner_alpha, beta=assigner_beta
+        )
+
+    @property
+    def component_names(self) -> List[str]:
+        return ["loss_cls", "loss_iou", "loss_dfl", "loss"]
+
+    def forward(self, outputs, targets: Tensor) -> Tuple[Tensor, Tensor]:
+        """
+        :param outputs: the head's eager output -- ``((boxes, scores), raw)``
+            or just the ``raw`` logits dict.
+        :param targets: padded ``(B, max_labels, 6)`` rows of
+            ``[class, cx, cy, w, h, angle]`` in input-canvas pixels. Rows with
+            non-positive width or height are padding.
+        """
+        decoded, raw = self._split_outputs(outputs)
+        pred_boxes, pred_scores = decoded
+
+        batch_size = pred_scores.shape[0]
+        num_classes = pred_scores.shape[2]
+        anchor_points = raw["anchor_points"] * raw["strides"]
+
+        gt_boxes, gt_labels = self._unpack_targets(targets, batch_size)
+
+        cls_loss_sum = pred_scores.new_zeros(())
+        iou_loss_sum = pred_scores.new_zeros(())
+        dfl_loss_sum = pred_scores.new_zeros(())
+        assigned_scores_sum = pred_scores.new_zeros(())
+
+        for i in range(batch_size):
+            with torch.no_grad():
+                assignment = self.assigner(
+                    pred_scores=pred_scores[i].unsqueeze(0).detach(),
+                    pred_rboxes=pred_boxes[i].unsqueeze(0).detach(),
+                    anchor_points=anchor_points,
+                    gt_labels=gt_labels[i].unsqueeze(0),
+                    gt_rboxes=gt_boxes[i].unsqueeze(0),
+                    bg_index=num_classes,
+                )
+
+            score_logits = raw["score_logits"][i : i + 1].float()
+            if self.use_varifocal_loss:
+                one_hot_label = F.one_hot(assignment.assigned_labels, num_classes + 1)[
+                    ..., :-1
+                ]
+                cls_loss = self._varifocal_loss(
+                    score_logits, assignment.assigned_scores.float(), one_hot_label
+                )
+            else:
+                cls_loss = self._focal_loss(
+                    score_logits, assignment.assigned_scores.float()
+                )
+
+            loss_iou, loss_dfl = self._rbox_loss(
+                pred_dist=raw["size_dist"][i : i + 1],
+                pred_bboxes=pred_boxes[i : i + 1],
+                assignment=assignment,
+                strides=raw["strides"],
+                reg_max=int(raw["reg_max"]),
+                bg_class_index=num_classes,
+            )
+
+            cls_loss_sum = cls_loss_sum + cls_loss
+            iou_loss_sum = iou_loss_sum + loss_iou
+            dfl_loss_sum = dfl_loss_sum + loss_dfl
+            assigned_scores_sum = assigned_scores_sum + assignment.assigned_scores.sum()
+
+        normalizer = assigned_scores_sum.detach().float().clamp_min(1.0)
+        cls_loss = cls_loss_sum * self.classification_loss_weight / normalizer
+        iou_loss = iou_loss_sum * self.iou_loss_weight / normalizer
+        dfl_loss = dfl_loss_sum * self.dfl_loss_weight / normalizer
+        loss = cls_loss + iou_loss + dfl_loss
+
+        log_losses = torch.stack(
+            [cls_loss.detach(), iou_loss.detach(), dfl_loss.detach(), loss.detach()]
+        )
+        return loss, log_losses
+
+    @staticmethod
+    def _split_outputs(outputs):
+        if isinstance(outputs, tuple) and len(outputs) == 2:
+            decoded, raw = outputs
+            if isinstance(decoded, tuple) and isinstance(raw, dict):
+                return decoded, raw
+        raise TypeError(
+            "YOLO-NAS OBB loss expects the head's eager output "
+            "((boxes, scores), raw_logits_dict), got "
+            f"{type(outputs)!r}"
+        )
+
+    @staticmethod
+    def _unpack_targets(
+        targets: Tensor, batch_size: int
+    ) -> Tuple[List[Tensor], List[Tensor]]:
+        """Split padded ``(B, max_labels, 6)`` rows into per-image tensors."""
+        if targets.ndim != 3 or targets.shape[-1] != 6:
+            raise ValueError(
+                "YOLO-NAS OBB training expects targets shaped "
+                f"(B, max_labels, 6), got {tuple(targets.shape)}"
+            )
+        boxes: List[Tensor] = []
+        labels: List[Tensor] = []
+        for i in range(batch_size):
+            rows = targets[i]
+            valid = (rows[:, 3] > 0) & (rows[:, 4] > 0)
+            rows = rows[valid]
+            boxes.append(rows[:, 1:6].float())
+            labels.append(rows[:, 0].long().unsqueeze(-1))
+        return boxes, labels
+
+    def _rbox_loss(
+        self,
+        pred_dist: Tensor,
+        pred_bboxes: Tensor,
+        assignment: YOLONASOBBAssignment,
+        strides: Tensor,
+        reg_max: int,
+        bg_class_index: int,
+    ) -> Tuple[Tensor, Tensor]:
+        mask_positive = assignment.assigned_labels != bg_class_index  # [B, L]
+        bbox_weight = assignment.assigned_scores.sum(-1) * mask_positive
+
+        iou = cxcywhr_iou(
+            pred_bboxes, assignment.assigned_rboxes, include_ciou_term=False
+        )
+        loss_iou = ((1 - iou) * bbox_weight).sum(dtype=torch.float32)
+
+        # DFL targets are the assigned box's width/height in stride units.
+        wh_targets = (assignment.assigned_rboxes[..., 2:4] / strides).clamp(
+            0, reg_max - 0.01
+        )
+        pred_dist = pred_dist.reshape([pred_bboxes.shape[0], -1, 2, reg_max + 1])
+        loss_dfl = self._df_loss(pred_dist, wh_targets)
+        loss_dfl = (loss_dfl.squeeze(-1) * bbox_weight).sum(dtype=torch.float32)
+        return loss_iou, loss_dfl
+
+    @staticmethod
+    def _df_loss(pred_dist: Tensor, target_dist: Tensor) -> Tensor:
+        target_left = target_dist.long()
+        target_right = target_left + 1
+        weight_left = target_right.float() - target_dist
+        weight_right = 1 - weight_left
+
+        pred_dist = torch.moveaxis(pred_dist, -1, 1)
+        loss_left = (
+            F.cross_entropy(pred_dist, target_left, reduction="none") * weight_left
+        )
+        loss_right = (
+            F.cross_entropy(pred_dist, target_right, reduction="none") * weight_right
+        )
+        return (loss_left + loss_right).mean(dim=-1, keepdim=True)
+
+    @staticmethod
+    def _varifocal_loss(
+        pred_logits: Tensor, gt_score: Tensor, label: Tensor, alpha=0.75, gamma=2.0
+    ) -> Tensor:
+        pred_score = pred_logits.sigmoid()
+        weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
+        loss = weight * F.binary_cross_entropy_with_logits(
+            pred_logits, gt_score, reduction="none"
+        )
+        return loss.sum(dtype=torch.float32)
+
+    @staticmethod
+    def _focal_loss(
+        pred_logits: Tensor, label: Tensor, alpha: float = 0.25, gamma: float = 2.0
+    ) -> Tensor:
+        pred_score = pred_logits.sigmoid()
+        weight = torch.abs(pred_score - label).pow(gamma)
+        if alpha > 0:
+            weight = weight * (alpha * label + (1 - alpha) * (1 - label))
+        loss = weight * F.binary_cross_entropy_with_logits(
+            pred_logits, label, reduction="none"
+        )
+        return loss.sum(dtype=torch.float32)
+
+
+__all__ = [
+    "YOLONASOBBAssigner",
+    "YOLONASOBBAssignment",
+    "YOLONASOBBLoss",
+    "check_points_inside_rboxes",
+    "cxcywhr_iou",
+    "pairwise_cxcywhr_iou",
+]

--- a/libreyolo/models/yolonas/obb_trainer.py
+++ b/libreyolo/models/yolonas/obb_trainer.py
@@ -1,0 +1,108 @@
+"""YOLO-NAS-R (OBB) trainer."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+import torch
+
+from ...training.config import TrainConfig, YOLONASOBBConfig
+from ...training.scheduler import CosineAnnealingScheduler
+from ...training.trainer import BaseTrainer
+from .obb_loss import YOLONASOBBLoss
+
+
+class YOLONASOBBTrainer(BaseTrainer):
+    """Rotated-box training for the YOLO-NAS family.
+
+    Reuses the shared ``BaseTrainer`` OBB data path (``load_obb=True``) and
+    the shared :class:`~libreyolo.validation.obb_validator.OBBValidator`; the
+    family-specific parts are the rotated loss, the angle-aware transform and
+    the OBB metric key.
+    """
+
+    artifact_model_families = ("yolonas",)
+    # Rotated mAP, not the axis-aligned bbox default: OBBValidator reports
+    # both keys and selecting on the bbox one would pick checkpoints by the
+    # proxy box (landmine #23).
+    best_metric_key = "metrics/mAP50-95(OBB)"
+
+    @classmethod
+    def _config_class(cls) -> Type[TrainConfig]:
+        return YOLONASOBBConfig
+
+    def get_model_family(self) -> str:
+        return "yolonas"
+
+    def get_model_tag(self) -> str:
+        return f"YOLO-NAS-R-{self.config.size}"
+
+    def create_transforms(self):
+        from ...data.augment.yolonas import (
+            YOLONASOBBDataset,
+            YOLONASOBBTrainTransform,
+        )
+
+        preproc = YOLONASOBBTrainTransform(
+            max_labels=int(getattr(self.config, "max_labels", 300)),
+            flip_prob=self.config.flip_prob,
+            hsv_prob=self.config.hsv_prob,
+            flipud=float(getattr(self.config, "flipud", 0.0)),
+        )
+        return preproc, YOLONASOBBDataset
+
+    def create_scheduler(self, iters_per_epoch: int):
+        return CosineAnnealingScheduler(
+            lr=self.effective_lr,
+            iters_per_epoch=iters_per_epoch,
+            total_epochs=self.config.epochs,
+            warmup_epochs=self.config.warmup_epochs,
+            warmup_lr_start=self.config.warmup_lr_start,
+            min_lr_ratio=self.config.min_lr_ratio,
+        )
+
+    def on_setup(self):
+        self.loss_fn = YOLONASOBBLoss(
+            num_classes=self.config.num_classes,
+            classification_loss_weight=self.config.classification_loss_weight,
+            iou_loss_weight=self.config.iou_loss_weight,
+            dfl_loss_weight=self.config.dfl_loss_weight,
+            assigner_topk=self.config.bbox_assigner_topk,
+            assigner_alpha=self.config.bbox_assigned_alpha,
+            assigner_beta=self.config.bbox_assigned_beta,
+            use_varifocal_loss=self.config.use_varifocal_loss,
+        ).to(self.device)
+
+    def validate_validation_loss_config(self) -> None:
+        if getattr(self.config, "val_loss", False):
+            raise ValueError(
+                "val_loss=True is not supported for YOLO-NAS OBB training."
+            )
+
+    def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
+        def _scalar(v):
+            return v.item() if isinstance(v, torch.Tensor) else v
+
+        return {
+            "cls": _scalar(outputs.get("cls", 0)),
+            "iou": _scalar(outputs.get("iou", 0)),
+            "dfl": _scalar(outputs.get("dfl", 0)),
+        }
+
+    def on_forward(
+        self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None
+    ) -> Dict:
+        del polygons
+        model_outputs = self.model(imgs)
+        total_loss, log_losses = self.loss_fn(model_outputs, targets)
+        return {
+            "total_loss": total_loss,
+            "cls": log_losses[0],
+            "iou": log_losses[1],
+            "dfl": log_losses[2],
+        }
+
+    def cuda_graph_train_spec(self):
+        # The rotated loss runs a per-image Python loop over the assigner, so
+        # the capture boundary the detect trainer relies on does not hold.
+        return None

--- a/libreyolo/postprocess/obb_ops.py
+++ b/libreyolo/postprocess/obb_ops.py
@@ -1,0 +1,158 @@
+"""Shared rotated-box (OBB) postprocessing primitives.
+
+Task-level helpers, not family-level: every OBB family decodes to the same
+``xywhr`` contract (centre, long side first, angle in ``[-pi/2, pi/2)``) and
+therefore needs the same corner conversion, axis-aligned proxy, and exact
+rotated NMS. Keeping one implementation here avoids a second, subtly
+different rotated NMS drifting out of sync with this one.
+
+Originally extracted from ``libreyolo/postprocess/yolo9.py``, which now
+imports from this module.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..utils.lazy import lazy_module
+
+
+# torch is resolved on first use so this module stays importable in a
+# torch-free ONNX deployment (discussions/711).
+torch = lazy_module("torch")
+
+
+def xywhr_to_corners(xywhr: "torch.Tensor") -> "torch.Tensor":
+    """Convert ``(N, 5)`` rotated boxes to ``(N, 4, 2)`` corners."""
+    xy = xywhr[:, :2]
+    w = xywhr[:, 2] / 2
+    h = xywhr[:, 3] / 2
+    angle = xywhr[:, 4]
+    cos = torch.cos(angle)
+    sin = torch.sin(angle)
+    corners = torch.stack(
+        [
+            torch.stack([-w, -h], dim=1),
+            torch.stack([w, -h], dim=1),
+            torch.stack([w, h], dim=1),
+            torch.stack([-w, h], dim=1),
+        ],
+        dim=1,
+    )
+    rot = torch.stack(
+        [
+            torch.stack([cos, -sin], dim=1),
+            torch.stack([sin, cos], dim=1),
+        ],
+        dim=1,
+    )
+    return torch.matmul(corners, rot.transpose(1, 2)) + xy[:, None, :]
+
+
+def xywhr_to_xyxy(xywhr: "torch.Tensor") -> "torch.Tensor":
+    """Axis-aligned bounding box enclosing each rotated box."""
+    if xywhr.numel() == 0:
+        return torch.zeros((0, 4), dtype=xywhr.dtype, device=xywhr.device)
+    corners = xywhr_to_corners(xywhr)
+    x = corners[..., 0]
+    y = corners[..., 1]
+    return torch.stack(
+        [
+            x.min(dim=1).values,
+            y.min(dim=1).values,
+            x.max(dim=1).values,
+            y.max(dim=1).values,
+        ],
+        dim=1,
+    )
+
+
+def rotated_nms_keep_indices(
+    xywhr: "torch.Tensor",
+    scores: "torch.Tensor",
+    class_ids: "torch.Tensor",
+    iou_thres: float,
+    max_det: int,
+) -> "torch.Tensor":
+    """Greedy per-class NMS on exact rotated-rectangle IoU.
+
+    Returns indices into the input tensors, highest score first. Non-finite
+    rows are dropped before suppression rather than poisoning the ordering.
+    """
+    # Imported here rather than at module scope: ``libreyolo.data`` pulls the
+    # dataset stack (and torch) at import time, and this module sits on the
+    # torch-free ONNX import path.
+    from ..data.obb import xywhr_iou
+
+    if xywhr.numel() == 0:
+        return torch.zeros(0, dtype=torch.long, device=xywhr.device)
+
+    finite_mask = torch.isfinite(xywhr).all(dim=1) & torch.isfinite(scores)
+    if not finite_mask.all():
+        valid_indices = torch.where(finite_mask)[0]
+        if len(valid_indices) == 0:
+            return torch.zeros(0, dtype=torch.long, device=xywhr.device)
+        xywhr = xywhr[finite_mask]
+        scores = scores[finite_mask]
+        class_ids = class_ids[finite_mask]
+    else:
+        valid_indices = None
+
+    order = torch.argsort(scores, descending=True)
+    rects = xywhr.detach().cpu().numpy().astype(np.float32)
+    classes = class_ids.detach().cpu().numpy().astype(np.int64)
+    ordered = order.detach().cpu().numpy().astype(np.int64).tolist()
+
+    keep_local: list[int] = []
+    while ordered and len(keep_local) < max_det:
+        current = ordered.pop(0)
+        keep_local.append(current)
+
+        remaining = []
+        for candidate in ordered:
+            if classes[candidate] != classes[current]:
+                remaining.append(candidate)
+                continue
+            if xywhr_iou(rects[current], rects[candidate]) <= iou_thres:
+                remaining.append(candidate)
+        ordered = remaining
+
+    keep = torch.as_tensor(keep_local, dtype=torch.long, device=xywhr.device)
+    if valid_indices is not None:
+        keep = valid_indices[keep]
+    return keep
+
+
+def canonicalize_xywhr_tensor(xywhr: "torch.Tensor") -> "torch.Tensor":
+    """Put the long side first and normalise the angle to ``[-pi/2, pi/2)``.
+
+    The public LibreYOLO OBB contract, applied at the postprocessing boundary.
+    This changes only the *representation*: the polygon each row describes is
+    unchanged, which ``tests/unit/test_yolonas_obb_geometry.py`` asserts.
+    """
+    import math
+
+    if xywhr.numel() == 0:
+        return xywhr
+    out = xywhr.clone()
+    w = out[:, 2]
+    h = out[:, 3]
+    angle = out[:, 4]
+    swap = h > w
+    new_w = torch.where(swap, h, w)
+    new_h = torch.where(swap, w, h)
+    angle = torch.where(swap, angle + math.pi / 2, angle)
+    # ``(a + pi/2) % pi - pi/2`` -> [-pi/2, pi/2)
+    angle = torch.remainder(angle + math.pi / 2, math.pi) - math.pi / 2
+    out[:, 2] = new_w
+    out[:, 3] = new_h
+    out[:, 4] = angle
+    return out
+
+
+__all__ = [
+    "canonicalize_xywhr_tensor",
+    "rotated_nms_keep_indices",
+    "xywhr_to_corners",
+    "xywhr_to_xyxy",
+]

--- a/libreyolo/postprocess/yolo9.py
+++ b/libreyolo/postprocess/yolo9.py
@@ -6,7 +6,7 @@ everything here for backward compatibility.
 
 from __future__ import annotations
 
-import numpy as np
+from . import obb_ops
 from ..utils.lazy import lazy_module
 
 from typing import Dict, Tuple, Union
@@ -81,94 +81,12 @@ def _nms_keep_indices(
     return keep
 
 
-def _xywhr_to_corners(xywhr: torch.Tensor) -> torch.Tensor:
-    xy = xywhr[:, :2]
-    w = xywhr[:, 2] / 2
-    h = xywhr[:, 3] / 2
-    angle = xywhr[:, 4]
-    cos = torch.cos(angle)
-    sin = torch.sin(angle)
-    corners = torch.stack(
-        [
-            torch.stack([-w, -h], dim=1),
-            torch.stack([w, -h], dim=1),
-            torch.stack([w, h], dim=1),
-            torch.stack([-w, h], dim=1),
-        ],
-        dim=1,
-    )
-    rot = torch.stack(
-        [
-            torch.stack([cos, -sin], dim=1),
-            torch.stack([sin, cos], dim=1),
-        ],
-        dim=1,
-    )
-    return torch.matmul(corners, rot.transpose(1, 2)) + xy[:, None, :]
-
-
-def _xywhr_to_xyxy(xywhr: torch.Tensor) -> torch.Tensor:
-    if xywhr.numel() == 0:
-        return torch.zeros((0, 4), dtype=xywhr.dtype, device=xywhr.device)
-    corners = _xywhr_to_corners(xywhr)
-    x = corners[..., 0]
-    y = corners[..., 1]
-    return torch.stack(
-        [x.min(dim=1).values, y.min(dim=1).values, x.max(dim=1).values, y.max(dim=1).values],
-        dim=1,
-    )
-
-
-def _rotated_nms_keep_indices(
-    xywhr: torch.Tensor,
-    scores: torch.Tensor,
-    class_ids: torch.Tensor,
-    iou_thres: float,
-    max_det: int,
-) -> torch.Tensor:
-    # Imported here rather than at module scope: ``libreyolo.data`` pulls the
-    # dataset stack (and torch) at import time, and this module sits on the
-    # torch-free ONNX import path. Rotated NMS is OBB-only, which that path
-    # does not reach.
-    from ..data.obb import xywhr_iou
-
-    if xywhr.numel() == 0:
-        return torch.zeros(0, dtype=torch.long, device=xywhr.device)
-
-    finite_mask = torch.isfinite(xywhr).all(dim=1) & torch.isfinite(scores)
-    if not finite_mask.all():
-        valid_indices = torch.where(finite_mask)[0]
-        if len(valid_indices) == 0:
-            return torch.zeros(0, dtype=torch.long, device=xywhr.device)
-        xywhr = xywhr[finite_mask]
-        scores = scores[finite_mask]
-        class_ids = class_ids[finite_mask]
-    else:
-        valid_indices = None
-
-    order = torch.argsort(scores, descending=True)
-    rects = xywhr.detach().cpu().numpy().astype(np.float32)
-    classes = class_ids.detach().cpu().numpy().astype(np.int64)
-    ordered = order.detach().cpu().numpy().astype(np.int64).tolist()
-
-    keep_local: list[int] = []
-    while ordered and len(keep_local) < max_det:
-        current = ordered.pop(0)
-        keep_local.append(current)
-
-        remaining = []
-        for candidate in ordered:
-            if classes[candidate] != classes[current]:
-                remaining.append(candidate)
-                continue
-            if xywhr_iou(rects[current], rects[candidate]) <= iou_thres:
-                remaining.append(candidate)
-        ordered = remaining
-
-    keep = torch.as_tensor(keep_local, dtype=torch.long, device=xywhr.device)
-    if valid_indices is not None:
-        keep = valid_indices[keep]
-    return keep
+# Rotated-box geometry and NMS are task-level, not family-level: they moved to
+# ``libreyolo.postprocess.obb_ops`` so every OBB family shares one exact
+# implementation. The private aliases stay for backward compatibility.
+_xywhr_to_corners = obb_ops.xywhr_to_corners
+_xywhr_to_xyxy = obb_ops.xywhr_to_xyxy
+_rotated_nms_keep_indices = obb_ops.rotated_nms_keep_indices
 
 
 def _obb_prefilter_keep_indices(

--- a/libreyolo/postprocess/yolonas.py
+++ b/libreyolo/postprocess/yolonas.py
@@ -25,7 +25,11 @@ torchvision = lazy_module("torchvision")
 
 YOLO_NAS_RESIZE_SIZE = 636
 YOLO_NAS_POSE_RESIZE_SIZE = 640
+YOLO_NAS_OBB_RESIZE_SIZE = 1024
 YOLO_NAS_PRE_NMS_TOP_K = 1000
+# Upstream YoloNASRPostPredictionCallback keeps at most 1000 candidates before
+# rotated NMS (recipes/.../dota_yolo_nas_r_s.yaml).
+YOLO_NAS_OBB_PRE_NMS_TOP_K = 1000
 
 
 def _extract_decoded_predictions(output):
@@ -207,7 +211,9 @@ def postprocess_pose(
         scores = output["scores"]
         pose_xy = output["keypoints_xy"]
         pose_conf = output["keypoints_conf"]
-    elif isinstance(output, tuple) and len(output) == 2 and isinstance(output[0], tuple):
+    elif (
+        isinstance(output, tuple) and len(output) == 2 and isinstance(output[0], tuple)
+    ):
         bboxes, scores, pose_xy, pose_conf = output[0]
     else:
         bboxes, scores, pose_xy, pose_conf = output
@@ -319,4 +325,151 @@ def postprocess_pose(
         "classes": classes,
         "num_detections": int(keep.numel()),
         "keypoints": keypoints,
+    }
+
+
+# ---------------------------------------------------------------------------
+# OBB postprocess (YOLO-NAS-R)
+# ---------------------------------------------------------------------------
+
+
+def _extract_obb_predictions(output):
+    """Accept the eager ``(decoded, raw)`` pair, the traced pair, or a dict."""
+    if isinstance(output, dict):
+        return output["boxes"], output["scores"]
+    if isinstance(output, tuple):
+        if len(output) == 2 and isinstance(output[0], tuple):
+            return output[0]
+        if len(output) == 2:
+            return output
+    raise TypeError(
+        f"Unsupported YOLO-NAS OBB output format for postprocess: {type(output)!r}"
+    )
+
+
+def postprocess_obb(
+    output,
+    conf_thres: float = 0.1,
+    iou_thres: float = 0.25,
+    input_size: int = 1024,
+    original_size: Tuple[int, int] | None = None,
+    max_det: int = 300,
+    letterbox: bool = True,
+    resize_size: int = YOLO_NAS_OBB_RESIZE_SIZE,
+    pre_nms_top_k: int = YOLO_NAS_OBB_PRE_NMS_TOP_K,
+    **kwargs,
+):
+    """Decode YOLO-NAS-R rotated predictions into the public OBB contract.
+
+    The head emits ``boxes [B, A, 5]`` as ``cx, cy, w, h, r`` in *model input*
+    pixels with the upstream angle range ``[-3*pi/4, pi/4]``, plus sigmoid
+    ``scores [B, A, C]``. This function:
+
+    1. thresholds on confidence and keeps at most ``pre_nms_top_k`` candidates
+       (upstream default 1000);
+    2. maps boxes back onto the original image canvas by undoing the
+       longest-side rescale and bottom-right padding (a uniform scale, so the
+       rectangle stays a rectangle and the angle is unchanged);
+    3. canonicalises to LibreYOLO's long-side ``[-pi/2, pi/2)`` contract --
+       a representation change only, the polygon is untouched;
+    4. runs the shared exact rotated NMS.
+
+    Note this is *not* upstream's Gaussian matrix soft-NMS: LibreYOLO's OBB
+    contract uses one exact rotated NMS across families (see
+    ``libreyolo/postprocess/obb_ops.py``). Raw pre-NMS parity against upstream
+    is what ``weights/parity_yolonas_obb.py`` gates on.
+    """
+    from .obb_ops import (
+        canonicalize_xywhr_tensor,
+        rotated_nms_keep_indices,
+        xywhr_to_xyxy,
+    )
+
+    empty = {
+        "boxes": [],
+        "scores": [],
+        "classes": [],
+        "obb": [],
+        "num_detections": 0,
+    }
+
+    boxes, scores = _extract_obb_predictions(output)
+    if boxes.dim() == 3:
+        boxes = boxes[0]
+    if scores.dim() == 3:
+        scores = scores[0]
+
+    max_scores, class_ids = torch.max(scores, dim=1)
+    # ``>=`` matches upstream YoloNASRPostPredictionCallback's boundary.
+    mask = max_scores >= conf_thres
+    if not mask.any():
+        return empty
+
+    xywhr = boxes[mask].float()
+    max_scores = max_scores[mask].float()
+    class_ids = class_ids[mask]
+
+    if pre_nms_top_k and max_scores.numel() > pre_nms_top_k:
+        topk = max_scores.topk(pre_nms_top_k)
+        max_scores = topk.values
+        xywhr = xywhr[topk.indices]
+        class_ids = class_ids[topk.indices]
+
+    if original_size is not None:
+        input_h, input_w = _input_size_hw(input_size)
+        if letterbox:
+            orig_w, orig_h = original_size
+            effective_resize = min(resize_size, input_h, input_w)
+            ratio = min(effective_resize / orig_h, effective_resize / orig_w)
+            # Bottom-right padding: no offset to subtract, and the rescale is
+            # uniform, so centres and sides scale while the angle is invariant.
+            xywhr = xywhr.clone()
+            xywhr[:, :4] = xywhr[:, :4] / ratio
+        else:
+            scale_x = original_size[0] / input_w
+            scale_y = original_size[1] / input_h
+            if abs(scale_x - scale_y) > 1e-6:
+                raise ValueError(
+                    "YOLO-NAS OBB requires an aspect-preserving resize: "
+                    "non-uniform x/y scaling turns a rotated rectangle into a "
+                    "parallelogram. Use letterbox=True."
+                )
+            xywhr = xywhr.clone()
+            xywhr[:, :4] *= scale_x
+
+        xywhr[:, 0].clamp_(0, original_size[0])
+        xywhr[:, 1].clamp_(0, original_size[1])
+
+    valid = (xywhr[:, 2] > 0) & (xywhr[:, 3] > 0)
+    if not valid.any():
+        return empty
+    if not valid.all():
+        xywhr = xywhr[valid]
+        max_scores = max_scores[valid]
+        class_ids = class_ids[valid]
+
+    xywhr = canonicalize_xywhr_tensor(xywhr)
+
+    keep = rotated_nms_keep_indices(xywhr, max_scores, class_ids, iou_thres, max_det)
+    if len(keep) == 0:
+        return empty
+
+    xywhr = xywhr[keep]
+    scores_out = max_scores[keep]
+    classes_out = class_ids[keep]
+
+    aabb = xywhr_to_xyxy(xywhr)
+    if original_size is not None:
+        aabb[:, [0, 2]] = torch.clamp(aabb[:, [0, 2]], 0, original_size[0])
+        aabb[:, [1, 3]] = torch.clamp(aabb[:, [1, 3]], 0, original_size[1])
+
+    obb_out = torch.cat(
+        (xywhr, scores_out[:, None], classes_out[:, None].float()), dim=1
+    )
+    return {
+        "boxes": aabb.detach().cpu(),
+        "scores": scores_out.detach().cpu(),
+        "classes": classes_out.detach().cpu().long(),
+        "obb": obb_out.detach().cpu(),
+        "num_detections": int(xywhr.shape[0]),
     }

--- a/libreyolo/preprocess/yolonas.py
+++ b/libreyolo/preprocess/yolonas.py
@@ -13,6 +13,7 @@ import numpy as np
 from PIL import Image
 
 from ..postprocess.yolonas import (
+    YOLO_NAS_OBB_RESIZE_SIZE,
     YOLO_NAS_POSE_RESIZE_SIZE,
     YOLO_NAS_RESIZE_SIZE,
 )
@@ -20,6 +21,7 @@ from ..utils.image_loader import ImageInput, ImageLoader
 from . import as_batched_input
 
 YOLO_NAS_POSE_PAD_VALUE = 127
+YOLO_NAS_OBB_PAD_VALUE = 114
 
 
 def preprocess_numpy(
@@ -98,9 +100,72 @@ def preprocess_pose_image(
     return as_batched_input(img_chw), original_img, original_size, ratio
 
 
+def preprocess_obb_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: int = YOLO_NAS_OBB_RESIZE_SIZE,
+    pad_value: int = YOLO_NAS_OBB_PAD_VALUE,
+    resize_size: int = YOLO_NAS_OBB_RESIZE_SIZE,
+) -> Tuple[np.ndarray, float]:
+    """YOLO-NAS-R (OBB) evaluation preprocessing.
+
+    Reproduces the checkpoint's own ``processing_params`` pipeline:
+    ``ReverseImageChannels`` -> ``OBBDetectionLongestMaxSizeRescale(1024)``
+    -> ``OBBDetectionBottomRightPadding(1024, pad_value=114)``
+    -> ``StandardizeImage(max_value=255)``.
+
+    Unlike the detect/pose paths this resamples with ``cv2.INTER_LINEAR``
+    rather than PIL, matching upstream's rescale: DOTA imagery is downscaled
+    hard to reach 1024 and PIL's antialiased filter would not agree.
+
+    Takes RGB HWC uint8 and returns ``(CHW float32 in [0, 1] BGR, ratio)``.
+    """
+    import cv2
+
+    orig_h, orig_w = img_rgb_hwc.shape[:2]
+    if isinstance(input_size, (list, tuple)):
+        input_h, input_w = int(input_size[0]), int(input_size[1])
+    else:
+        input_h = input_w = int(input_size)
+    if input_h != input_w:
+        raise ValueError(
+            f"YOLO-NAS OBB does not support rectangular input sizes, got "
+            f"({input_h}, {input_w}). Use a square imgsz."
+        )
+    resize_size = min(int(resize_size), input_h, input_w)
+
+    ratio = min(resize_size / orig_h, resize_size / orig_w)
+    new_w, new_h = int(round(orig_w * ratio)), int(round(orig_h * ratio))
+
+    bgr = np.ascontiguousarray(img_rgb_hwc[:, :, ::-1])
+    if (new_w, new_h) != (orig_w, orig_h):
+        bgr = cv2.resize(bgr, dsize=(new_w, new_h), interpolation=cv2.INTER_LINEAR)
+
+    padded = np.full((input_h, input_w, 3), pad_value, dtype=np.uint8)
+    padded[:new_h, :new_w] = bgr  # bottom-right padding
+
+    arr = padded.astype(np.float32) / 255.0
+    return arr.transpose(2, 0, 1), ratio
+
+
+def preprocess_obb_image(
+    image: ImageInput,
+    input_size: int = YOLO_NAS_OBB_RESIZE_SIZE,
+    color_format: str = "auto",
+):
+    img = ImageLoader.load(image, color_format=color_format)
+    original_size = img.size
+    original_img = img.copy()
+
+    img_chw, ratio = preprocess_obb_numpy(np.array(img), input_size=input_size)
+    return as_batched_input(img_chw), original_img, original_size, ratio
+
+
 __all__ = [
+    "YOLO_NAS_OBB_PAD_VALUE",
     "YOLO_NAS_POSE_PAD_VALUE",
     "preprocess_numpy",
     "preprocess_image",
+    "preprocess_obb_image",
+    "preprocess_obb_numpy",
     "preprocess_pose_image",
 ]

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -240,9 +240,7 @@ class TrainConfig:
         if self.eval_max_det is not None:
             self.eval_max_det = int(self.eval_max_det)
             if self.eval_max_det < 1:
-                raise ValueError(
-                    f"eval_max_det must be >= 1, got {self.eval_max_det}"
-                )
+                raise ValueError(f"eval_max_det must be >= 1, got {self.eval_max_det}")
 
     @classmethod
     def from_kwargs(cls, **kwargs):
@@ -1003,6 +1001,44 @@ class YOLONASPoseConfig(YOLONASConfig):
 
 
 @dataclass(kw_only=True)
+class YOLONASOBBConfig(YOLONASConfig):
+    """YOLO-NAS-R (oriented boxes) training defaults.
+
+    Loss weights, assigner top-k, optimizer and schedule follow upstream's
+    DOTA recipe at the pinned YOLO-NAS-R commit
+    (``recipes/training_hyperparams/default_yolo_nas_r_train_params.yaml``):
+    AdamW at 5e-5 with weight decay 3.5e-6, cosine to 0.1 of the initial LR,
+    EMA 0.9997, no AMP, assigner top-k 12, and loss weights
+    ``classification 2.5 / iou 2.0 / dfl 0.5``.
+
+    Augmentation is flips plus HSV only -- see
+    :class:`libreyolo.data.augment.yolonas.YOLONASOBBTrainTransform` for why
+    mosaic, mixup and affine are not offered for rotated boxes.
+    """
+
+    classification_loss_weight: float = 2.5
+    iou_loss_weight: float = 2.0
+    dfl_loss_weight: float = 0.5
+    bbox_assigner_topk: int = 12
+    bbox_assigned_alpha: float = 1.0
+    bbox_assigned_beta: float = 6.0
+    use_varifocal_loss: bool = True
+    max_labels: int = 300
+
+    lr0: float = 5e-5
+    weight_decay: float = 3.5e-6
+    warmup_epochs: int = 1
+    min_lr_ratio: float = 0.1
+    epochs: int = 100
+    ema_decay: float = 0.9997
+    amp: bool = False
+    mosaic_prob: float = 0.0
+    mixup_prob: float = 0.0
+    eval_interval: int = 1
+    name: str = "yolonas_obb_exp"
+
+
+@dataclass(kw_only=True)
 class PICODETConfig(TrainConfig):
     """PICODET-specific training defaults.
 
@@ -1233,4 +1269,3 @@ class FOMOConfig(TrainConfig):
     distance_tolerance: float = 1.5
 
     name: str = "fomo_exp"
-

--- a/libreyolo/ui/server.py
+++ b/libreyolo/ui/server.py
@@ -70,9 +70,7 @@ def _summarize_result(result) -> tuple[str, str]:
             unit = "image"
         else:
             unit = (
-                "face"
-                if "face" in getattr(result, "names", {}).values()
-                else "region"
+                "face" if "face" in getattr(result, "names", {}).values() else "region"
             )
         unknown_unit = f"unknown {unit}"
         identities = getattr(result, "identities", None)
@@ -87,6 +85,12 @@ def _summarize_result(result) -> tuple[str, str]:
             return "embed", _plural(len(identities), unknown_unit)
         return "embed", _plural(len(embeddings), unit)
 
+    # OBB results also populate ``boxes`` with the axis-aligned proxy, so the
+    # rotated slot has to be checked first or every OBB model reports "detect".
+    obb = getattr(result, "obb", None)
+    if obb is not None:
+        return "obb", _plural(len(obb), "object")
+
     boxes = getattr(result, "boxes", None)
     if boxes is not None:
         n = len(boxes)
@@ -95,10 +99,6 @@ def _summarize_result(result) -> tuple[str, str]:
         if getattr(result, "keypoints", None) is not None:
             return "pose", _plural(n, "pose")
         return "detect", _plural(n, "object")
-
-    obb = getattr(result, "obb", None)
-    if obb is not None:
-        return "obb", _plural(len(obb), "object")
 
     points = getattr(result, "points", None)
     if points is not None:

--- a/libreyolo/utils/download.py
+++ b/libreyolo/utils/download.py
@@ -33,21 +33,29 @@ def _get_hf_token() -> Optional[str]:
     return None
 
 
-def _notify_yolonas_license_once() -> None:
-    """Print Deci's YOLO-NAS license terms once per process before download."""
+def _notify_yolonas_license_once(url: str = "") -> None:
+    """Print Deci's weight license terms once per process before download.
+
+    The rotated YOLO-NAS-R checkpoints ship a separate notice from the
+    detect/pose ones, so point at whichever actually governs this file.
+    """
     global _YOLONAS_LICENSE_NOTICE_SHOWN
     if _YOLONAS_LICENSE_NOTICE_SHOWN:
         return
     _YOLONAS_LICENSE_NOTICE_SHOWN = True
+    is_rotated = "yolo_nas_r_" in url.lower()
+    name = "YOLO-NAS-R (rotated)" if is_rotated else "YOLO-NAS"
+    license_file = "LICENSE.YOLONAS-R.md" if is_rotated else "LICENSE.YOLONAS.md"
+    rule = "─" * 69
     print(
         "\n"
-        "─────────────────────────────────────────────────────────────────────\n"
-        "YOLO-NAS weights are distributed by Deci.AI under a proprietary\n"
+        f"{rule}\n"
+        f"{name} weights are distributed by Deci.AI under a proprietary\n"
         "license (non-commercial, no redistribution, no production use\n"
         "without a separate agreement). By downloading, you accept those\n"
         "terms. Full license text:\n"
-        "  https://github.com/Deci-AI/super-gradients/blob/master/LICENSE.YOLONAS.md\n"
-        "─────────────────────────────────────────────────────────────────────\n"
+        f"  https://github.com/Deci-AI/super-gradients/blob/master/{license_file}\n"
+        f"{rule}\n"
     )
 
 
@@ -318,7 +326,7 @@ def download_url_to_path(url: str, path: Path, *, verify=None) -> None:
     is_hf = host.endswith("huggingface.co")
 
     if "cloudfront.net" in host or host.endswith("deci.ai"):
-        _notify_yolonas_license_once()
+        _notify_yolonas_license_once(url)
 
     headers = {}
     token = _get_hf_token()

--- a/libreyolo/validation/preprocessors.py
+++ b/libreyolo/validation/preprocessors.py
@@ -677,6 +677,59 @@ class YOLONASValPreprocessor(YOLO9ValPreprocessor):
         return img_chw, padded_targets
 
 
+class YOLONASOBBValPreprocessor(YOLONASValPreprocessor):
+    """YOLO-NAS-R preprocessor: longest side to 1024, bottom-right pad 114, BGR.
+
+    Deliberately delegates the pixel work to ``preprocess_obb_numpy`` -- the
+    exact function the OBB inference path uses -- so validation, training and
+    prediction cannot drift apart (the centre-pad/bottom-right-pad mismatch
+    this class's detect parent documents is precisely that failure mode).
+
+    Targets are the OBB dataset's six columns
+    ``[x1, y1, x2, y2, class, angle]`` where the ``xyxy`` block encodes
+    ``cx, cy, w, h`` un-rotated. The rescale is uniform and the padding has no
+    offset, so the angle passes through untouched.
+    """
+
+    def __call__(
+        self, img: np.ndarray, targets: np.ndarray, input_size: Tuple[int, int]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        from ..preprocess.yolonas import preprocess_obb_numpy
+
+        orig_h, orig_w = img.shape[:2]
+        target_h, target_w = input_size
+        if target_h != target_w:
+            raise ValueError(
+                "YOLO-NAS OBB validation does not support rectangular input "
+                f"sizes, got ({target_h}, {target_w}). Use a square imgsz."
+            )
+
+        # The dataset hands us BGR from cv2; preprocess_obb_numpy takes RGB and
+        # reverses the channels itself, so flip once here rather than
+        # duplicating its recipe.
+        img_rgb = np.ascontiguousarray(img[:, :, ::-1])
+        img_chw, ratio = preprocess_obb_numpy(img_rgb, input_size=target_h)
+
+        ncol = targets.shape[1] if getattr(targets, "ndim", 0) == 2 else 6
+        padded_targets = np.zeros((self.max_labels, ncol), dtype=np.float32)
+        if len(targets) > 0:
+            targets = np.array(targets, dtype=np.float32).copy()
+            n = min(len(targets), self.max_labels)
+            targets[:n, :4] *= ratio
+            padded_targets[:n] = targets[:n]
+
+        return img_chw, padded_targets
+
+    def letterbox_scale(
+        self, orig_h: int, orig_w: int, imgsz: int
+    ) -> Tuple[float, float, float]:
+        from ..postprocess.yolonas import YOLO_NAS_OBB_RESIZE_SIZE
+
+        resize = min(YOLO_NAS_OBB_RESIZE_SIZE, imgsz)
+        r = min(resize / orig_h, resize / orig_w)
+        return r, 0.0, 0.0  # bottom-right padding: no offset
+
+
 class DFINEValPreprocessor(StandardValPreprocessor):
     """D-FINE preprocessor: plain resize + 0-1 + RGB, no letterbox, no ImageNet norm.
 

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -1955,13 +1955,14 @@
     "class": "libreyolo.models.yolonas.model.LibreYOLONAS",
     "tasks": [
       "detect",
-      "pose"
+      "pose",
+      "obb"
     ],
     "default_task": "detect",
     "sizes": {
-      "s": 640,
-      "m": 640,
-      "l": 640,
+      "s": 1024,
+      "m": 1024,
+      "l": 1024,
       "n": 640
     },
     "default_imgsz": {
@@ -1980,6 +1981,11 @@
         "s": 640,
         "m": 640,
         "l": 640
+      },
+      "obb": {
+        "s": 1024,
+        "m": 1024,
+        "l": 1024
       }
     },
     "export_override": "none",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -615,6 +615,14 @@ RTDETRV2_OBB_MODELS = [
     ("rtdetrv2", "n", "LibreRTDETRv2n-obb.pt"),
 ]
 
+# YOLO-NAS-R (rotated). Same reasoning as above: OBB stays out of
+# MODEL_CATALOG. The weights are not on the LibreYOLO HF org (Deci's
+# non-redistributable licence) but they do have a public auto-download route
+# through Deci's CDN, which ``_has_libreyolo_download_route`` already accepts.
+YOLONAS_OBB_MODELS = [
+    ("yolonas", "s", "LibreYOLONASs-obb.pt"),
+]
+
 # Derived lists (no manual maintenance)
 YOLOX_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "yolox"]
 YOLO9_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "yolo9"]
@@ -793,6 +801,10 @@ DEEPLABV3_SMOKE_PARAMS = model_cases(
 )
 RTDETRV2_OBB_PARAMS = model_cases(
     RTDETRV2_OBB_MODELS,
+    with_weights=True,
+)
+YOLONAS_OBB_PARAMS = model_cases(
+    YOLONAS_OBB_MODELS,
     with_weights=True,
 )
 

--- a/tests/e2e/test_yolonas_obb.py
+++ b/tests/e2e/test_yolonas_obb.py
@@ -42,7 +42,25 @@ def test_yolonas_obb_trained_checkpoint_smoke(family, size, weights):
 
 
 @pytest.mark.parametrize("family,size,weights", YOLONAS_OBB_PARAMS)
-def test_yolonas_obb_training_is_rejected(family, size, weights):
+def test_yolonas_obb_trained_checkpoint_takes_a_gradient_step(family, size, weights):
+    """The public checkpoint trains: one real forward/backward on its own head."""
+    import torch
+
     model = LibreYOLO(weights)
-    with pytest.raises(NotImplementedError, match="inference-only"):
-        model.train(data="coco128.yaml", epochs=1)
+    from libreyolo.models.yolonas.obb_loss import YOLONASOBBLoss
+
+    loss_fn = YOLONASOBBLoss(num_classes=model.nb_classes).to(model.device)
+    net = model.model.train()
+    images = torch.rand(1, 3, 320, 320, device=model.device)
+    targets = torch.zeros(1, 4, 6, device=model.device)
+    targets[0, 0] = torch.tensor(
+        [0.0, 160.0, 160.0, 80.0, 40.0, 0.3], device=model.device
+    )
+
+    loss, components = loss_fn(net(images), targets)
+    loss.backward()
+
+    assert torch.isfinite(loss) and loss.item() > 0
+    assert components.shape == (4,)
+    grads = [p.grad for p in net.parameters() if p.grad is not None]
+    assert grads and all(torch.isfinite(g).all() for g in grads)

--- a/tests/e2e/test_yolonas_obb.py
+++ b/tests/e2e/test_yolonas_obb.py
@@ -1,0 +1,48 @@
+"""Task-appropriate trained-checkpoint smoke coverage for YOLO-NAS-R (OBB)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from libreyolo import LibreYOLO
+
+from .conftest import YOLONAS_OBB_PARAMS
+
+
+pytestmark = [pytest.mark.e2e, pytest.mark.network, pytest.mark.yolonas]
+
+
+@pytest.mark.parametrize("family,size,weights", YOLONAS_OBB_PARAMS)
+def test_yolonas_obb_trained_checkpoint_smoke(family, size, weights):
+    model = LibreYOLO(weights)
+    assert (model.FAMILY, model.size, model.task) == (family, size, "obb")
+    assert model.input_size == 1024
+    assert model.names[0] == "plane"
+
+    # Non-square on purpose: the OBB preprocessor pads bottom-right, and the
+    # inverse transform has to land results back on the original canvas.
+    image = Image.fromarray(np.full((480, 800, 3), 127, dtype=np.uint8))
+    result = model.predict(image, conf=0.0, max_det=5)[0]
+
+    assert result.obb is not None
+    assert result.obb.data.shape[1] == 7
+    assert result.boxes.data.shape[1] == 6
+    assert len(result.obb) == len(result.boxes) <= 5
+    assert result.orig_shape == (480, 800)
+
+    xywhr = np.asarray(result.obb.xywhr)
+    if len(xywhr):
+        assert (xywhr[:, 0] >= 0).all() and (xywhr[:, 0] <= 800).all()
+        assert (xywhr[:, 1] >= 0).all() and (xywhr[:, 1] <= 480).all()
+        # Public contract: long side first, angle in [-pi/2, pi/2).
+        assert (xywhr[:, 2] >= xywhr[:, 3]).all()
+        assert (xywhr[:, 4] >= -np.pi / 2).all() and (xywhr[:, 4] < np.pi / 2).all()
+
+
+@pytest.mark.parametrize("family,size,weights", YOLONAS_OBB_PARAMS)
+def test_yolonas_obb_training_is_rejected(family, size, weights):
+    model = LibreYOLO(weights)
+    with pytest.raises(NotImplementedError, match="inference-only"):
+        model.train(data="coco128.yaml", epochs=1)

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -726,6 +726,7 @@ def test_openvino_validated_tier_has_runtime_parity_coverage():
         ("yolo9_e2e", "detect"),
         ("yolo9_p2", "detect"),
         ("yolonas", "detect"),
+        ("yolonas", "obb"),
         ("yolonas", "pose"),
         ("yolox", "detect"),
         ("zipdepth", "depth"),

--- a/tests/unit/test_yolonas_obb.py
+++ b/tests/unit/test_yolonas_obb.py
@@ -346,3 +346,21 @@ def test_autoconvert_reads_supergradients_processing_params_names():
     assert _checkpoint_names(loaded, nc=2) == ["plane", "ship"]
     # An explicit `names` key still wins.
     assert _checkpoint_names({**loaded, "names": ["a"]}, nc=1) == ["a"]
+
+
+def test_backend_obb_parser_drops_non_finite_rows():
+    """The numpy backend path must reject NaN/Inf rows like the native one."""
+    from libreyolo.backends.base import BaseBackend
+
+    boxes = np.array(
+        [[[np.nan, 10.0, 8.0, 4.0, 0.0], [200.0, 100.0, 20.0, 10.0, 0.1]]],
+        dtype=np.float32,
+    )
+    scores = np.array([[[0.99], [0.8]]], dtype=np.float32)
+    parsed = BaseBackend._parse_yolonas_obb(
+        [boxes, scores], 1024, 1024, 512, conf=0.1, iou=0.5, ratio=1.0
+    )
+    _boxes, out_scores, _cls, _masks, obb = parsed
+    assert len(obb) == 1
+    assert np.isfinite(obb).all()
+    assert np.isclose(out_scores[0], 0.8)

--- a/tests/unit/test_yolonas_obb.py
+++ b/tests/unit/test_yolonas_obb.py
@@ -1,0 +1,348 @@
+"""Unit coverage for the YOLO-NAS-R (OBB) task of the YOLO-NAS family."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.data.obb import xywhr_to_corners
+from libreyolo.models.yolonas.model import LibreYOLONAS
+from libreyolo.models.yolonas.nn import (
+    LibreYOLONASModel,
+    LibreYOLONASOBBModel,
+    LibreYOLONASPoseModel,
+)
+from libreyolo.postprocess.obb_ops import (
+    canonicalize_xywhr_tensor,
+    rotated_nms_keep_indices,
+    xywhr_to_xyxy,
+)
+from libreyolo.postprocess.yolonas import postprocess_obb
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.yolonas]
+
+
+# ---------------------------------------------------------------------------
+# Architecture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def obb_model():
+    return LibreYOLONASOBBModel(config="s", nb_classes=3).eval()
+
+
+def test_obb_head_channel_layout(obb_model):
+    head = obb_model.heads.head1
+    reg_max = obb_model.heads.reg_max
+    assert head.reg_pred.out_channels == 2 * (reg_max + 1)
+    assert head.offset_pred.out_channels == 2
+    assert head.rot_pred.out_channels == 1
+    assert head.cls_pred.out_channels == 3
+    # Upstream zero-initialises the offset branch so decoding starts at the
+    # anchor centre.
+    assert torch.count_nonzero(head.offset_pred.weight) == 0
+    assert torch.count_nonzero(head.offset_pred.bias) == 0
+
+
+def test_obb_forward_shapes_and_angle_range(obb_model):
+    x = torch.zeros(1, 3, 256, 256)
+    with torch.no_grad():
+        (boxes, scores), raw = obb_model(x)
+    anchors = (256 // 8) ** 2 + (256 // 16) ** 2 + (256 // 32) ** 2
+    assert boxes.shape == (1, anchors, 5)
+    assert scores.shape == (1, anchors, 3)
+    assert raw["size_dist"].shape == (1, anchors, 2 * (obb_model.heads.reg_max + 1))
+    assert raw["angles"].shape == (1, anchors, 1)
+    assert raw["offsets"].shape == (1, anchors, 2)
+    # (sigmoid(x) - 0.25) * pi, i.e. the upstream code's (-pi/4, 3*pi/4).
+    angles = boxes[..., 4]
+    assert (angles > -math.pi / 4).all() and (angles < 3 * math.pi / 4).all()
+    assert (scores >= 0).all() and (scores <= 1).all()
+
+
+def test_obb_replace_num_classes(obb_model):
+    model = LibreYOLONASOBBModel(config="s", nb_classes=3).eval()
+    model.replace_num_classes(7)
+    with torch.no_grad():
+        (_boxes, scores), _raw = model(torch.zeros(1, 3, 128, 128))
+    assert scores.shape[-1] == 7
+    assert model.nc == 7
+
+
+def test_obb_export_path_returns_only_decoded(obb_model):
+    """Traced graphs must emit exactly (boxes [B,N,5], scores [B,N,C])."""
+    traced = torch.jit.trace(obb_model, torch.zeros(1, 3, 128, 128), strict=False)
+    with torch.no_grad():
+        out = traced(torch.zeros(1, 3, 128, 128))
+    assert isinstance(out, (tuple, list)) and len(out) == 2
+    assert out[0].shape[-1] == 5 and out[1].shape[-1] == 3
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint / task discrimination
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def state_dicts():
+    return {
+        "obb": LibreYOLONASOBBModel(config="s", nb_classes=18).state_dict(),
+        "detect": LibreYOLONASModel(config="s", nb_classes=80).state_dict(),
+        "pose": LibreYOLONASPoseModel(
+            config="s", num_keypoints=17, num_classes=1
+        ).state_dict(),
+    }
+
+
+def test_family_still_claims_every_task(state_dicts):
+    for sd in state_dicts.values():
+        assert LibreYOLONAS.can_load(sd) is True
+
+
+def test_obb_discriminator_is_exclusive(state_dicts):
+    assert LibreYOLONAS.is_obb_state_dict(state_dicts["obb"]) is True
+    assert LibreYOLONAS.is_obb_state_dict(state_dicts["detect"]) is False
+    assert LibreYOLONAS.is_obb_state_dict(state_dicts["pose"]) is False
+    # ... and the pose discriminator must not claim the rotated head.
+    assert LibreYOLONAS.is_pose_state_dict(state_dicts["obb"]) is False
+
+
+def test_checkpoint_task_resolution(state_dicts):
+    assert LibreYOLONAS.detect_checkpoint_task(state_dicts["obb"]) == "obb"
+    assert LibreYOLONAS.detect_checkpoint_task(state_dicts["pose"]) == "pose"
+    assert LibreYOLONAS.detect_checkpoint_task(state_dicts["detect"]) is None
+
+
+def test_obb_size_and_class_count_from_state_dict(state_dicts):
+    assert LibreYOLONAS.detect_size(state_dicts["obb"]) == "s"
+    assert LibreYOLONAS.detect_nb_classes(state_dicts["obb"]) == 18
+
+
+@pytest.mark.parametrize("size", ["s", "m", "l"])
+def test_obb_filename_and_download_route(size):
+    canonical = f"LibreYOLONAS{size}-obb.pt"
+    assert LibreYOLONAS.detect_size_from_filename(canonical) == size
+    assert LibreYOLONAS.detect_task_from_filename(canonical) == "obb"
+    assert LibreYOLONAS.get_download_url(canonical) == (
+        f"https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_r_{size}_dota2.pth"
+    )
+
+    native = f"yolo_nas_r_{size}_dota2.pth"
+    assert LibreYOLONAS.detect_size_from_filename(native) == size
+    assert LibreYOLONAS.detect_task_from_filename(native) == "obb"
+
+
+def test_native_detect_and_pose_filenames_are_untouched():
+    assert LibreYOLONAS.detect_task_from_filename("yolo_nas_s_coco.pth") != "obb"
+    assert (
+        LibreYOLONAS.detect_task_from_filename("yolo_nas_pose_s_coco_pose.pth")
+        == "pose"
+    )
+
+
+def test_every_rotated_checkpoint_has_a_pinned_hash():
+    for size in ("s", "m", "l"):
+        name = f"yolo_nas_r_{size}_dota2.pth"
+        assert name in LibreYOLONAS._DECI_CHECKPOINT_SHA256
+        assert len(LibreYOLONAS._DECI_CHECKPOINT_SHA256[name]) == 64
+
+
+def test_obb_task_metadata():
+    assert "obb" in LibreYOLONAS.SUPPORTED_TASKS
+    assert LibreYOLONAS.TASK_INPUT_SIZES["obb"] == {"s": 1024, "m": 1024, "l": 1024}
+    # OBB does not ship the pose-only `n` size.
+    assert "n" not in LibreYOLONAS.TASK_INPUT_SIZES["obb"]
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalization_changes_representation_not_geometry():
+    raw = torch.tensor(
+        [
+            [50.0, 60.0, 10.0, 30.0, 0.3],  # h > w -> must swap
+            [50.0, 60.0, 30.0, 10.0, 2.5],  # angle outside [-pi/2, pi/2)
+            [10.0, 10.0, 4.0, 4.0, -math.pi / 2],  # boundary
+        ]
+    )
+    out = canonicalize_xywhr_tensor(raw)
+
+    assert (out[:, 2] >= out[:, 3]).all()
+    assert (out[:, 4] >= -math.pi / 2).all() and (out[:, 4] < math.pi / 2).all()
+    assert torch.equal(out[:, :2], raw[:, :2])
+
+    for before, after in zip(raw.numpy(), out.numpy()):
+        poly_a = np.sort(xywhr_to_corners(before).reshape(-1))
+        poly_b = np.sort(xywhr_to_corners(after).reshape(-1))
+        assert np.allclose(poly_a, poly_b, atol=1e-4)
+
+
+def test_xywhr_to_xyxy_matches_corner_extents():
+    boxes = torch.tensor([[10.0, 20.0, 8.0, 4.0, 0.7], [0.0, 0.0, 6.0, 6.0, 0.0]])
+    aabb = xywhr_to_xyxy(boxes).numpy()
+    for row, box in zip(aabb, boxes.numpy()):
+        corners = xywhr_to_corners(box)
+        assert np.allclose(row[0], corners[:, 0].min(), atol=1e-4)
+        assert np.allclose(row[1], corners[:, 1].min(), atol=1e-4)
+        assert np.allclose(row[2], corners[:, 0].max(), atol=1e-4)
+        assert np.allclose(row[3], corners[:, 1].max(), atol=1e-4)
+
+
+def test_xywhr_to_xyxy_empty():
+    assert xywhr_to_xyxy(torch.zeros((0, 5))).shape == (0, 4)
+
+
+def test_rotated_nms_suppresses_within_class_only():
+    boxes = torch.tensor(
+        [
+            [50.0, 50.0, 40.0, 20.0, 0.0],
+            [51.0, 50.0, 40.0, 20.0, 0.0],  # near-duplicate, same class
+            [51.0, 50.0, 40.0, 20.0, 0.0],  # near-duplicate, different class
+            [300.0, 300.0, 10.0, 10.0, 0.0],  # disjoint
+        ]
+    )
+    scores = torch.tensor([0.9, 0.8, 0.7, 0.6])
+    classes = torch.tensor([0, 0, 1, 0])
+    keep = rotated_nms_keep_indices(boxes, scores, classes, 0.5, 100).tolist()
+    assert keep == [0, 2, 3]
+
+
+def test_rotated_nms_drops_non_finite_rows():
+    boxes = torch.tensor(
+        [
+            [float("nan"), 0.0, 4.0, 4.0, 0.0],
+            [10.0, 10.0, 4.0, 4.0, 0.0],
+        ]
+    )
+    scores = torch.tensor([0.99, 0.5])
+    classes = torch.tensor([0, 0])
+    assert rotated_nms_keep_indices(boxes, scores, classes, 0.5, 10).tolist() == [1]
+
+
+def test_rotated_nms_respects_max_det():
+    boxes = torch.tensor([[i * 100.0, 0.0, 5.0, 5.0, 0.0] for i in range(5)])
+    scores = torch.linspace(0.9, 0.5, 5)
+    classes = torch.zeros(5, dtype=torch.long)
+    assert len(rotated_nms_keep_indices(boxes, scores, classes, 0.5, 2)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Postprocess
+# ---------------------------------------------------------------------------
+
+
+def _fake_output(xywhr, scores):
+    return {
+        "boxes": torch.as_tensor(xywhr, dtype=torch.float32)[None],
+        "scores": torch.as_tensor(scores, dtype=torch.float32)[None],
+    }
+
+
+def test_postprocess_obb_empty_below_threshold():
+    out = postprocess_obb(
+        _fake_output([[10.0, 10.0, 4.0, 2.0, 0.0]], [[0.01]]),
+        conf_thres=0.5,
+    )
+    assert out["num_detections"] == 0
+    assert out["obb"] == []
+
+
+def test_postprocess_obb_contract_and_letterbox_inverse():
+    # 1024 canvas, original 2048x1024 -> longest side rescale ratio 0.5,
+    # bottom-right padded, so undoing it is a plain divide by the ratio.
+    out = postprocess_obb(
+        _fake_output(
+            [[100.0, 200.0, 40.0, 20.0, 0.2], [700.0, 700.0, 10.0, 30.0, 0.0]],
+            [[0.9, 0.1], [0.2, 0.8]],
+        ),
+        conf_thres=0.05,
+        iou_thres=0.5,
+        input_size=1024,
+        original_size=(2048, 1024),
+    )
+    assert out["num_detections"] == 2
+    obb = out["obb"].numpy()
+    assert obb.shape == (2, 7)
+
+    top = obb[0]
+    assert np.allclose(top[:2], [200.0, 400.0], atol=1e-3)
+    assert np.allclose(top[2:4], [80.0, 40.0], atol=1e-3)
+    assert np.allclose(top[4], 0.2, atol=1e-5)  # uniform scale keeps the angle
+    assert np.isclose(top[5], 0.9)
+    assert top[6] == 0
+
+    # Long-side canonicalization applied to the w<h row.
+    second = obb[1]
+    assert second[2] >= second[3]
+    assert -math.pi / 2 <= second[4] < math.pi / 2
+
+    aabb = out["boxes"].numpy()
+    assert (aabb[:, 2] > aabb[:, 0]).all() and (aabb[:, 3] > aabb[:, 1]).all()
+    assert (aabb[:, [0, 2]] <= 2048).all() and (aabb[:, [1, 3]] <= 1024).all()
+
+
+def test_postprocess_obb_rejects_non_uniform_scaling():
+    with pytest.raises(ValueError, match="aspect-preserving"):
+        postprocess_obb(
+            _fake_output([[10.0, 10.0, 4.0, 2.0, 0.0]], [[0.9]]),
+            conf_thres=0.1,
+            input_size=1024,
+            original_size=(2048, 512),
+            letterbox=False,
+        )
+
+
+def test_postprocess_obb_honours_max_det():
+    xywhr = [[i * 200.0 + 10.0, 10.0, 8.0, 4.0, 0.0] for i in range(6)]
+    scores = [[0.9 - i * 0.05] for i in range(6)]
+    out = postprocess_obb(
+        _fake_output(xywhr, scores), conf_thres=0.1, iou_thres=0.5, max_det=3
+    )
+    assert out["num_detections"] == 3
+
+
+def test_postprocess_obb_prefilter_caps_candidates():
+    n = 2500
+    xywhr = [[float(i % 1000), 10.0, 4.0, 2.0, 0.0] for i in range(n)]
+    scores = [[0.5 + (i / n) * 0.4] for i in range(n)]
+    out = postprocess_obb(
+        _fake_output(xywhr, scores),
+        conf_thres=0.1,
+        iou_thres=0.5,
+        max_det=10,
+        pre_nms_top_k=1000,
+    )
+    assert out["num_detections"] == 10
+
+
+def test_postprocess_obb_accepts_traced_tuple_output():
+    boxes = torch.tensor([[[10.0, 10.0, 6.0, 4.0, 0.0]]])
+    scores = torch.tensor([[[0.9]]])
+    out = postprocess_obb((boxes, scores), conf_thres=0.1)
+    assert out["num_detections"] == 1
+
+
+def test_postprocess_obb_rejects_unknown_output_shape():
+    with pytest.raises(TypeError):
+        postprocess_obb(object())
+
+
+def test_autoconvert_reads_supergradients_processing_params_names():
+    """Bare Deci checkpoints keep their real labels through auto-conversion."""
+    from libreyolo.models.autoconvert import _checkpoint_names
+
+    loaded = {
+        "ema_net": {},
+        "processing_params": {"class_names": ["plane", "ship", "harbor"]},
+    }
+    assert _checkpoint_names(loaded, nc=3) == ["plane", "ship", "harbor"]
+    assert _checkpoint_names(loaded, nc=2) == ["plane", "ship"]
+    # An explicit `names` key still wins.
+    assert _checkpoint_names({**loaded, "names": ["a"]}, nc=1) == ["a"]

--- a/tests/unit/test_yolonas_obb.py
+++ b/tests/unit/test_yolonas_obb.py
@@ -364,3 +364,20 @@ def test_backend_obb_parser_drops_non_finite_rows():
     assert len(obb) == 1
     assert np.isfinite(obb).all()
     assert np.isclose(out_scores[0], 0.8)
+
+
+def test_ui_summary_reports_obb_not_detect():
+    """OBB results fill `boxes` too, so the UI must dispatch on `obb` first."""
+    from libreyolo.ui.server import _summarize_result
+    from libreyolo.utils.results import OBB, Boxes, Results
+
+    result = Results(
+        boxes=Boxes(
+            np.zeros((2, 4), dtype=np.float32),
+            np.zeros((2,), dtype=np.float32),
+            np.zeros((2,), dtype=np.float32),
+        ),
+        obb=OBB(np.zeros((2, 7), dtype=np.float32), (100, 100)),
+        orig_shape=(100, 100),
+    )
+    assert _summarize_result(result) == ("obb", "2 objects")

--- a/tests/unit/test_yolonas_obb_training.py
+++ b/tests/unit/test_yolonas_obb_training.py
@@ -1,0 +1,445 @@
+"""Unit coverage for YOLO-NAS-R (OBB) training: loss, assigner, transform."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.data.augment.yolonas import (
+    YOLONASOBBTrainTransform,
+    _canonicalize_obb_rows,
+)
+from libreyolo.data.obb import xywhr_to_corners
+from libreyolo.models.yolonas.model import LibreYOLONAS
+from libreyolo.models.yolonas.nn import LibreYOLONASOBBModel
+from libreyolo.models.yolonas.obb_loss import (
+    YOLONASOBBAssigner,
+    YOLONASOBBLoss,
+    check_points_inside_rboxes,
+    cxcywhr_iou,
+    pairwise_cxcywhr_iou,
+)
+from libreyolo.training.config import YOLONASOBBConfig
+
+pytestmark = [pytest.mark.unit, pytest.mark.yolonas]
+
+
+# ---------------------------------------------------------------------------
+# Probabilistic IoU
+# ---------------------------------------------------------------------------
+
+
+def test_probiou_is_one_for_identical_boxes():
+    """Identical boxes saturate the metric.
+
+    Not exactly 1.0: the Bhattacharyya distance is clamped at ``eps`` for
+    numerical stability, which floors the IoU a hair below one. That clamp is
+    upstream's and is what keeps the gradient finite at zero distance.
+    """
+    box = torch.tensor([[50.0, 50.0, 40.0, 20.0, 0.3]])
+    assert cxcywhr_iou(box, box).item() == pytest.approx(1.0, abs=5e-3)
+
+
+def test_probiou_decays_with_separation_and_rotation():
+    ref = torch.tensor([[50.0, 50.0, 40.0, 20.0, 0.0]])
+    shifted = torch.tensor([[70.0, 50.0, 40.0, 20.0, 0.0]])
+    far = torch.tensor([[300.0, 300.0, 40.0, 20.0, 0.0]])
+    rotated = torch.tensor([[50.0, 50.0, 40.0, 20.0, math.pi / 2]])
+
+    same = cxcywhr_iou(ref, ref).item()
+    near = cxcywhr_iou(ref, shifted).item()
+    away = cxcywhr_iou(ref, far).item()
+    turned = cxcywhr_iou(ref, rotated).item()
+
+    assert same > near > away
+    assert away == pytest.approx(0.0, abs=1e-3)
+    # A 90-degree turn of a 2:1 box is a real mismatch, but still overlapping.
+    assert 0.0 < turned < same
+
+
+def test_probiou_is_differentiable_wrt_angle():
+    pred = torch.tensor([[50.0, 50.0, 40.0, 20.0, 0.1]], requires_grad=True)
+    target = torch.tensor([[50.0, 50.0, 40.0, 20.0, 0.6]])
+    loss = 1 - cxcywhr_iou(pred, target)
+    loss.backward()
+    assert torch.isfinite(pred.grad).all()
+    assert pred.grad[0, 4].abs() > 0  # the angle actually receives gradient
+
+
+def test_pairwise_probiou_shape_and_diagonal():
+    boxes = torch.tensor([[[10.0, 10.0, 8.0, 4.0, 0.0], [80.0, 80.0, 8.0, 4.0, 0.5]]])
+    ious = pairwise_cxcywhr_iou(boxes, boxes)
+    assert ious.shape == (1, 2, 2)
+    assert ious[0, 0, 0].item() == pytest.approx(1.0, abs=5e-3)
+    assert ious[0, 0, 1].item() < 1e-3
+
+
+def test_points_inside_rboxes_uses_the_inradius():
+    rboxes = torch.tensor([[[50.0, 50.0, 40.0, 20.0, 0.0]]])
+    points = torch.tensor([[50.0, 50.0], [50.0, 59.0], [50.0, 100.0]])
+    mask = check_points_inside_rboxes(points, rboxes)[0, 0]
+    assert mask.tolist() == [1.0, 1.0, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# Assigner
+# ---------------------------------------------------------------------------
+
+
+def test_assigner_returns_background_for_empty_ground_truth():
+    assigner = YOLONASOBBAssigner(topk=4)
+    result = assigner(
+        pred_scores=torch.rand(1, 16, 3),
+        pred_rboxes=torch.rand(1, 16, 5),
+        anchor_points=torch.rand(16, 2),
+        gt_labels=torch.zeros(1, 0, 1, dtype=torch.long),
+        gt_rboxes=torch.zeros(1, 0, 5),
+        bg_index=3,
+    )
+    assert (result.assigned_labels == 3).all()
+    assert result.assigned_scores.abs().sum() == 0
+
+
+def test_assigner_picks_anchors_near_the_target():
+    assigner = YOLONASOBBAssigner(topk=2)
+    anchors = torch.tensor([[50.0, 50.0], [52.0, 50.0], [400.0, 400.0]])
+    gt = torch.tensor([[[50.0, 50.0, 40.0, 30.0, 0.0]]])
+    preds = gt.repeat(1, 3, 1).clone()
+    preds[0, 2, :2] = torch.tensor([400.0, 400.0])
+    scores = torch.full((1, 3, 2), 0.9)
+
+    result = assigner(
+        pred_scores=scores,
+        pred_rboxes=preds,
+        anchor_points=anchors,
+        gt_labels=torch.zeros(1, 1, 1, dtype=torch.long),
+        gt_rboxes=gt,
+        bg_index=2,
+    )
+    assert result.assigned_labels[0, 0].item() == 0
+    assert result.assigned_labels[0, 1].item() == 0
+    # The far anchor is outside the box and must stay background.
+    assert result.assigned_labels[0, 2].item() == 2
+
+
+# ---------------------------------------------------------------------------
+# Loss
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tiny_model():
+    torch.manual_seed(0)
+    return LibreYOLONASOBBModel(config="s", nb_classes=2)
+
+
+def _targets(device="cpu"):
+    targets = torch.zeros(2, 4, 6, device=device)
+    targets[:, 0] = torch.tensor([0.0, 128.0, 128.0, 60.0, 30.0, 0.4], device=device)
+    targets[:, 1] = torch.tensor([1.0, 60.0, 80.0, 40.0, 20.0, -0.2], device=device)
+    return targets
+
+
+def test_loss_components_are_finite_and_positive(tiny_model):
+    loss_fn = YOLONASOBBLoss(num_classes=2)
+    outputs = tiny_model(torch.rand(2, 3, 256, 256))
+    loss, log = loss_fn(outputs, _targets())
+    assert torch.isfinite(loss)
+    assert log.shape == (4,)
+    assert (log[:3] > 0).all()
+    assert log[3].item() == pytest.approx(log[:3].sum().item(), rel=1e-5)
+
+
+def test_loss_backward_gives_finite_gradients_everywhere():
+    torch.manual_seed(0)
+    model = LibreYOLONASOBBModel(config="s", nb_classes=2)
+    loss_fn = YOLONASOBBLoss(num_classes=2)
+    loss, _ = loss_fn(model(torch.rand(1, 3, 256, 256)), _targets()[:1])
+    loss.backward()
+
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert grads, "no parameter received a gradient"
+    assert all(torch.isfinite(g).all() for g in grads)
+    # The rotation branch must be trained, not left dangling.
+    assert model.heads.head1.rot_pred.weight.grad is not None
+    assert model.heads.head1.offset_pred.weight.grad is not None
+
+
+def test_loss_decreases_when_predictions_move_toward_targets(tiny_model):
+    """A hand-built output closer to the target must score a lower loss."""
+    loss_fn = YOLONASOBBLoss(num_classes=2)
+    anchors = torch.tensor([[16.0, 16.0], [8.0, 10.0]])
+    strides = torch.tensor([[8.0], [8.0]])
+
+    def build(boxes, logit):
+        scores = torch.full((1, 2, 2), -6.0)
+        scores[0, 0, 0] = logit
+        raw = {
+            "score_logits": scores,
+            "size_dist": torch.zeros(1, 2, 2 * 17),
+            "size_reduced": boxes[..., 2:4] / strides,
+            "angles": boxes[..., 4:5],
+            "offsets": boxes[..., :2] / strides - anchors,
+            "anchor_points": anchors,
+            "strides": strides,
+            "reg_max": 16,
+        }
+        return (boxes, scores.sigmoid()), raw
+
+    targets = torch.zeros(1, 1, 6)
+    targets[0, 0] = torch.tensor([0.0, 128.0, 128.0, 40.0, 20.0, 0.2])
+
+    good = torch.tensor(
+        [[[128.0, 128.0, 40.0, 20.0, 0.2], [64.0, 80.0, 8.0, 8.0, 0.0]]]
+    )
+    bad = torch.tensor(
+        [[[128.0, 128.0, 90.0, 90.0, -1.2], [64.0, 80.0, 8.0, 8.0, 0.0]]]
+    )
+
+    loss_good, _ = loss_fn(build(good, 4.0), targets)
+    loss_bad, _ = loss_fn(build(bad, 4.0), targets)
+    assert loss_good.item() < loss_bad.item()
+
+
+def test_loss_rejects_wrong_target_width(tiny_model):
+    loss_fn = YOLONASOBBLoss(num_classes=2)
+    outputs = tiny_model(torch.rand(1, 3, 128, 128))
+    with pytest.raises(ValueError, match=r"\(B, max_labels, 6\)"):
+        loss_fn(outputs, torch.zeros(1, 3, 5))
+
+
+def test_loss_rejects_traced_output(tiny_model):
+    loss_fn = YOLONASOBBLoss(num_classes=2)
+    with pytest.raises(TypeError, match="eager output"):
+        loss_fn((torch.zeros(1, 2, 5), torch.zeros(1, 2, 2)), _targets()[:1])
+
+
+def test_loss_handles_an_all_background_image(tiny_model):
+    loss_fn = YOLONASOBBLoss(num_classes=2)
+    outputs = tiny_model(torch.rand(1, 3, 128, 128))
+    loss, log = loss_fn(outputs, torch.zeros(1, 4, 6))
+    assert torch.isfinite(loss)
+    assert log[1].item() == pytest.approx(0.0, abs=1e-6)  # no IoU term without GT
+
+
+# ---------------------------------------------------------------------------
+# Train transform
+# ---------------------------------------------------------------------------
+
+
+def _dataset_row(cx, cy, w, h, angle, cls=0):
+    """A dataset row: proxy xyxy (which encodes cx/cy/w/h) + class + angle."""
+    return np.array(
+        [[cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2, cls, angle]],
+        dtype=np.float32,
+    )
+
+
+def test_transform_emits_class_first_six_column_targets():
+    transform = YOLONASOBBTrainTransform(max_labels=4, flip_prob=0.0, hsv_prob=0.0)
+    image = np.zeros((512, 1024, 3), dtype=np.uint8)
+    out_img, targets = transform(
+        image, _dataset_row(100, 200, 40, 20, 0.3, cls=3), 1024
+    )
+
+    assert out_img.shape == (3, 1024, 1024)
+    assert targets.shape == (4, 6)
+    assert targets[0].tolist() == pytest.approx(
+        [3.0, 100.0, 200.0, 40.0, 20.0, 0.3], abs=1e-4
+    )
+    assert targets[1:].sum() == 0  # padding
+
+
+def test_transform_rescales_with_the_longest_side():
+    transform = YOLONASOBBTrainTransform(max_labels=2, flip_prob=0.0, hsv_prob=0.0)
+    image = np.zeros((1024, 2048, 3), dtype=np.uint8)  # ratio 0.5 to a 1024 canvas
+    _img, targets = transform(image, _dataset_row(100, 200, 40, 20, 0.3), 1024)
+    assert targets[0][1:5].tolist() == pytest.approx(
+        [50.0, 100.0, 20.0, 10.0], abs=1e-3
+    )
+    assert targets[0][5] == pytest.approx(
+        0.3, abs=1e-5
+    )  # uniform scale keeps the angle
+
+
+def test_horizontal_flip_mirrors_the_centre_and_negates_the_angle():
+    transform = YOLONASOBBTrainTransform(max_labels=2, flip_prob=1.0, hsv_prob=0.0)
+    image = np.zeros((1024, 1024, 3), dtype=np.uint8)
+    _img, targets = transform(image, _dataset_row(100, 200, 40, 20, 0.3), 1024)
+    assert targets[0][1].item() == pytest.approx(1024 - 100, abs=1e-3)
+    assert targets[0][2].item() == pytest.approx(200, abs=1e-3)
+    assert targets[0][5].item() == pytest.approx(-0.3, abs=1e-5)
+
+
+def test_vertical_flip_mirrors_the_centre_and_negates_the_angle():
+    transform = YOLONASOBBTrainTransform(
+        max_labels=2, flip_prob=0.0, hsv_prob=0.0, flipud=1.0
+    )
+    image = np.zeros((1024, 1024, 3), dtype=np.uint8)
+    _img, targets = transform(image, _dataset_row(100, 200, 40, 20, 0.3), 1024)
+    assert targets[0][1].item() == pytest.approx(100, abs=1e-3)
+    assert targets[0][2].item() == pytest.approx(1024 - 200, abs=1e-3)
+    assert targets[0][5].item() == pytest.approx(-0.3, abs=1e-5)
+
+
+def test_transform_handles_an_empty_label_file():
+    transform = YOLONASOBBTrainTransform(max_labels=3, flip_prob=0.5, hsv_prob=0.5)
+    image = np.zeros((320, 480, 3), dtype=np.uint8)
+    out_img, targets = transform(image, np.zeros((0, 6), dtype=np.float32), 640)
+    assert out_img.shape == (3, 640, 640)
+    assert targets.shape == (3, 6) and targets.sum() == 0
+
+
+def test_transform_rejects_detection_shaped_rows():
+    transform = YOLONASOBBTrainTransform()
+    with pytest.raises(ValueError, match="six-column"):
+        transform(
+            np.zeros((64, 64, 3), dtype=np.uint8),
+            np.zeros((1, 5), dtype=np.float32),
+            640,
+        )
+
+
+def test_canonicalize_rows_preserves_polygons():
+    rows = np.array(
+        [
+            [50.0, 60.0, 10.0, 30.0, 0.3],  # h > w: must swap
+            [50.0, 60.0, 30.0, 10.0, 2.5],  # angle outside the range
+        ],
+        dtype=np.float32,
+    )
+    out = _canonicalize_obb_rows(rows)
+    assert (out[:, 2] >= out[:, 3]).all()
+    assert ((out[:, 4] >= -math.pi / 2) & (out[:, 4] < math.pi / 2)).all()
+    for before, after in zip(rows, out):
+        assert np.allclose(
+            np.sort(xywhr_to_corners(before).reshape(-1)),
+            np.sort(xywhr_to_corners(after).reshape(-1)),
+            atol=1e-4,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config + trainer wiring
+# ---------------------------------------------------------------------------
+
+
+def test_obb_config_matches_the_upstream_recipe():
+    config = YOLONASOBBConfig(size="s", num_classes=18, data="x.yaml")
+    assert (
+        config.classification_loss_weight,
+        config.iou_loss_weight,
+        config.dfl_loss_weight,
+        config.bbox_assigner_topk,
+    ) == (2.5, 2.0, 0.5, 12)
+    assert (config.lr0, config.weight_decay, config.min_lr_ratio) == (
+        5e-5,
+        3.5e-6,
+        0.1,
+    )
+    assert config.optimizer == "adamw"
+    assert config.amp is False
+    assert config.ema_decay == 0.9997
+    # Rotated boxes get no mosaic/mixup.
+    assert config.mosaic_prob == 0.0 and config.mixup_prob == 0.0
+
+
+def test_obb_trainer_selects_the_rotated_metric():
+    from libreyolo.models.yolonas.obb_trainer import YOLONASOBBTrainer
+
+    assert YOLONASOBBTrainer.best_metric_key == "metrics/mAP50-95(OBB)"
+    assert YOLONASOBBTrainer._config_class() is YOLONASOBBConfig
+
+
+def test_detect_to_obb_transfer_copies_shared_weights_only():
+    torch.manual_seed(0)
+    detect = LibreYOLONAS(None, size="s", task="detect", nb_classes=18)
+    obb = LibreYOLONAS(None, size="s", task="obb", nb_classes=18)
+
+    before = obb.model.heads.head1.rot_pred.weight.detach().clone()
+    report = obb.load_detect_weights_for_obb(detect.model.state_dict())
+
+    assert any(k.startswith("backbone.") for k in report["transferred"])
+    assert any(k.startswith("neck.") for k in report["transferred"])
+    # cls_pred has the same shape at equal class counts and does transfer.
+    assert "heads.head1.cls_pred.weight" in report["transferred"]
+    # The rotated regression branch changes width and must NOT be copied.
+    assert "heads.head1.reg_pred.weight" in report["skipped_shape"]
+    # rot/offset do not exist upstream at all, so they stay fresh.
+    assert "heads.head1.rot_pred.weight" in report["missing"]
+    assert torch.equal(obb.model.heads.head1.rot_pred.weight, before)
+
+    stem = "backbone.stem.conv.branch_3x3.conv.weight"
+    assert torch.equal(obb.model.state_dict()[stem], detect.model.state_dict()[stem])
+
+
+def test_detect_to_obb_transfer_rejects_a_rotated_source():
+    obb = LibreYOLONAS(None, size="s", task="obb", nb_classes=18)
+    with pytest.raises(ValueError, match="got a rotated"):
+        obb.load_detect_weights_for_obb(obb.model.state_dict())
+
+
+def test_detect_to_obb_transfer_rejects_a_detect_target():
+    detect = LibreYOLONAS(None, size="s", task="detect", nb_classes=18)
+    with pytest.raises(ValueError, match="only valid on a task='obb'"):
+        detect.load_detect_weights_for_obb(detect.model.state_dict())
+
+
+def test_obb_uses_its_own_validation_preprocessor():
+    """Validation geometry must match the OBB inference recipe, not detect's.
+
+    Detect resizes the longest side to 636 and centre-pads; OBB resizes to
+    1024 and pads bottom-right. ``postprocess_obb`` inverts the OBB recipe, so
+    validating through the detect preprocessor mis-maps every box back onto
+    the canvas -- observed as OBB mAP collapsing to ~0 while the training loss
+    fell normally.
+    """
+    from libreyolo.validation.preprocessors import (
+        YOLONASOBBValPreprocessor,
+        YOLONASValPreprocessor,
+    )
+
+    obb = LibreYOLONAS(None, size="s", task="obb", nb_classes=2)
+    detect = LibreYOLONAS(None, size="s", task="detect", nb_classes=2)
+
+    assert isinstance(obb._get_val_preprocessor(), YOLONASOBBValPreprocessor)
+    assert type(detect._get_val_preprocessor()) is YOLONASValPreprocessor
+
+    # Bottom-right padding means no offset to subtract on the way back.
+    ratio, off_x, off_y = obb._get_val_preprocessor().letterbox_scale(512, 1024, 1024)
+    assert (off_x, off_y) == (0.0, 0.0)
+    assert ratio == pytest.approx(1.0)
+
+
+def test_obb_val_preprocessor_matches_the_inference_preprocessing():
+    """Byte-identical to the predict path, which is why it delegates to it."""
+    from libreyolo.preprocess.yolonas import preprocess_obb_numpy
+    from libreyolo.validation.preprocessors import YOLONASOBBValPreprocessor
+
+    rng = np.random.default_rng(0)
+    bgr = rng.integers(0, 255, (300, 500, 3), dtype=np.uint8)
+
+    processed, targets = YOLONASOBBValPreprocessor(img_size=(1024, 1024))(
+        bgr, np.zeros((0, 6), dtype=np.float32), (1024, 1024)
+    )
+    expected, ratio = preprocess_obb_numpy(
+        np.ascontiguousarray(bgr[:, :, ::-1]), input_size=1024
+    )
+    assert np.array_equal(processed, expected)
+    assert targets.shape[1] == 6
+    assert ratio == pytest.approx(1024 / 500)
+
+
+def test_obb_val_preprocessor_scales_targets_without_touching_the_angle():
+    from libreyolo.validation.preprocessors import YOLONASOBBValPreprocessor
+
+    bgr = np.zeros((512, 1024, 3), dtype=np.uint8)  # ratio 1.0 to a 1024 canvas
+    targets = np.array([[10.0, 20.0, 50.0, 60.0, 1.0, 0.4]], dtype=np.float32)
+    _img, out = YOLONASOBBValPreprocessor(img_size=(1024, 1024))(
+        bgr, targets, (1024, 1024)
+    )
+    assert out[0][:4].tolist() == pytest.approx([10.0, 20.0, 50.0, 60.0])
+    assert out[0][5] == pytest.approx(0.4)

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -51,6 +51,29 @@ project the weights were derived from. Per-family summary:
              (9 classes) and VisDrone (12), hence the dataset suffix on every
              canonical filename and the absence of a bare LibreDOMEDETRs.pt.
 
+    YOLO-NAS (LibreYOLONAS{s,m,l}, {n,s,m,l}-pose,
+              {s,m,l}-obb)                             NOT REDISTRIBUTED
+             upstream code: https://github.com/Deci-AI/super-gradients
+                            (Apache-2.0); the rotated/OBB variant is
+                            YOLO-NAS-R from pull request 2014, pinned commit
+                            69141b55c1161d939939a270523a7eca5a645f72.
+             upstream weights: Deci's CDN,
+                            https://d2gjn4b69gu75n.cloudfront.net/models/
+             The pretrained checkpoints are NOT under the repository's
+             Apache-2.0 license. Detect/pose weights carry Deci's YOLO-NAS
+             license and the rotated weights carry LICENSE.YOLONAS-R.md at
+             the pin above: a revocable, non-transferable, non-commercial
+             use grant that forbids resale, sublicensing and distribution.
+             That is not a redistribution grant, so LibreYOLO mirrors none
+             of them on its Hugging Face organization. Instead
+             LibreYOLO("LibreYOLONASs-obb.pt") downloads
+             yolo_nas_r_s_dota2.pth from Deci's CDN on demand and verifies
+             it against a pinned SHA256 before unpickling. Offline
+             conversion: weights/convert_yolonas_obb_weights.py.
+             Complying with Deci's terms is the downstream user's
+             responsibility. The DOTA2 training data is likewise not
+             bundled and carries its own terms.
+
     YOLOv7   (LibreYOLO7b)                             MIT
              upstream: MultimediaTechLab/YOLO (Kin-Yiu Wong & Hao-Tang Tsui)
              The authors' MIT re-release, not WongKinYiu/yolov7 (GPL-3.0).

--- a/weights/convert_yolonas_obb_weights.py
+++ b/weights/convert_yolonas_obb_weights.py
@@ -1,0 +1,173 @@
+"""Convert upstream YOLO-NAS-R (rotated / OBB) DOTA2 weights to LibreYOLO format.
+
+Upstream source (code, Apache-2.0):
+    https://github.com/Deci-AI/super-gradients pull request 2014,
+    pinned commit 69141b55c1161d939939a270523a7eca5a645f72
+
+Upstream weights (NOT redistributable -- Deci's separate YOLO-NAS-R licence,
+see ``weights/LICENSE_NOTICE.txt``) are downloaded from Deci's CDN:
+    https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_r_{s,m,l}_dota2.pth
+
+The rotated head keeps SuperGradients' module names, so this is a metadata
+wrap after unwrapping the EMA weights -- no key remapping. The file is a
+third-party pickle, so its SHA256 is verified against the pins in
+``LibreYOLONAS._DECI_CHECKPOINT_SHA256`` *before* it is unpickled.
+
+Usage:
+    python weights/convert_yolonas_obb_weights.py \\
+        downloads/yolo_nas_r_s_dota2.pth weights/LibreYOLONASs-obb.pt --size s
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+from _conversion_utils import (
+    add_repo_root_to_path,
+    save_checkpoint,
+    wrap_libreyolo_checkpoint,
+)
+
+_SIZES = ("s", "m", "l")
+_UPSTREAM_FILENAME = "yolo_nas_r_{size}_dota2.pth"
+
+
+def _sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def convert_weights(
+    input_path: str,
+    output_path: str,
+    size: str,
+    *,
+    allow_unpinned: bool = False,
+    verify: bool = False,
+) -> None:
+    add_repo_root_to_path()
+    import torch
+
+    from libreyolo.models.yolonas.model import (
+        YOLONAS_OBB_CLASS_NAMES,
+        LibreYOLONAS,
+    )
+    from libreyolo.models.yolonas.utils import unwrap_yolonas_checkpoint
+
+    expected_name = _UPSTREAM_FILENAME.format(size=size)
+    actual_name = Path(input_path).name
+    if actual_name != expected_name and not allow_unpinned:
+        raise SystemExit(
+            f"Expected the upstream file {expected_name!r} for --size {size}, got "
+            f"{actual_name!r}. Pass --allow-unpinned only if you know why."
+        )
+
+    expected_sha = LibreYOLONAS._DECI_CHECKPOINT_SHA256.get(expected_name)
+    actual_sha = _sha256(input_path)
+    if expected_sha is None:
+        if not allow_unpinned:
+            raise SystemExit(
+                f"No pinned SHA256 for {expected_name!r}; refusing to load."
+            )
+    elif actual_sha != expected_sha:
+        raise SystemExit(
+            f"SHA256 mismatch for {actual_name}: expected {expected_sha}, got "
+            f"{actual_sha}. Refusing to unpickle a possibly tampered file."
+        )
+    print(f"SHA256 verified: {actual_sha}")
+
+    # Only now, after the hash gate, do we unpickle the third-party file.
+    raw = torch.load(input_path, map_location="cpu", weights_only=False)
+    state_dict = dict(unwrap_yolonas_checkpoint(raw))
+    print(f"Extracted {len(state_dict)} parameter entries from {input_path}")
+
+    if not LibreYOLONAS.is_obb_state_dict(state_dict):
+        raise SystemExit(
+            "This is not a YOLO-NAS-R rotated checkpoint (no heads.*.rot_pred.*). "
+            "Use weights/convert_yolonas_weights or the detect/pose path instead."
+        )
+
+    detected_size = LibreYOLONAS.detect_size(state_dict)
+    if detected_size != size:
+        raise SystemExit(
+            f"State dict looks like size {detected_size!r}, not {size!r}. "
+            "Refusing an ambiguous conversion."
+        )
+    nc = LibreYOLONAS.detect_nb_classes(state_dict)
+    if nc is None:
+        raise SystemExit("Could not read the class count from the rotated head.")
+
+    names = (
+        dict(enumerate(YOLONAS_OBB_CLASS_NAMES))
+        if nc == len(YOLONAS_OBB_CLASS_NAMES)
+        else {i: str(i) for i in range(nc)}
+    )
+
+    wrapped = wrap_libreyolo_checkpoint(
+        state_dict,
+        model_family="yolonas",
+        size=size,
+        nc=nc,
+        names=names,
+        task="obb",
+        supported_tasks=("detect", "pose", "obb"),
+        default_task="detect",
+        imgsz=LibreYOLONAS.OBB_INPUT_SIZES[size],
+        provenance={
+            "upstream_repo": "https://github.com/Deci-AI/super-gradients",
+            "upstream_pr": "https://github.com/Deci-AI/super-gradients/pull/2014",
+            "upstream_commit": "69141b55c1161d939939a270523a7eca5a645f72",
+            "code_license": "Apache-2.0",
+            "weights_license": "YOLO-NAS-R License (Deci.AI) -- non-redistributable",
+            "weights_source": (
+                "https://d2gjn4b69gu75n.cloudfront.net/models/" + expected_name
+            ),
+            "weights_sha256": actual_sha,
+            "dataset": "DOTA2",
+        },
+    )
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(out.suffix + ".tmp")
+    save_checkpoint(wrapped, tmp)
+    tmp.replace(out)
+    print(f"Wrote {out} (task=obb, size={size}, nc={nc})")
+
+    if verify:
+        from libreyolo import LibreYOLO
+
+        model = LibreYOLO(str(out))
+        print(
+            f"Verified load: family={model.FAMILY} task={model.task} size={model.size}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", help="Upstream yolo_nas_r_<size>_dota2.pth")
+    parser.add_argument("output", help="Output LibreYOLONAS<size>-obb.pt")
+    parser.add_argument("--size", required=True, choices=list(_SIZES))
+    parser.add_argument(
+        "--allow-unpinned",
+        action="store_true",
+        help="Skip the filename/SHA256 gate (only for a checkpoint you trust).",
+    )
+    parser.add_argument("--verify", action="store_true", help="Reload the result.")
+    args = parser.parse_args()
+    convert_weights(
+        args.input,
+        args.output,
+        args.size,
+        allow_unpinned=args.allow_unpinned,
+        verify=args.verify,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/weights/parity_yolonas_obb.py
+++ b/weights/parity_yolonas_obb.py
@@ -1,0 +1,258 @@
+"""Inference parity: LibreYOLO YOLO-NAS-R (OBB) vs the pinned upstream head.
+
+The oracle is upstream's *actual* source, not a re-description of it: this
+script executes the two pinned SuperGradients files
+
+    src/super_gradients/training/models/detection_models/yolo_nas_r/
+        yolo_nas_r_dfl_head.py
+        yolo_nas_r_ndfl_heads.py
+
+from https://github.com/Deci-AI/super-gradients (Apache-2.0) at commit
+``69141b55c1161d939939a270523a7eca5a645f72`` with the handful of
+SuperGradients framework symbols they import replaced by minimal stubs
+(a registry decorator, a module factory, ``width_multiplier``, and the
+detection ``YoloNASDFLHead`` the rotated head subclasses -- the latter taken
+from LibreYOLO, whose YOLO-NAS detect port is already parity-proven).
+Installing SuperGradients itself is not possible on this toolchain (its
+``onnx`` build dependency needs cmake), so the files are run directly.
+
+The backbone and neck are byte-identical between the detect and rotated
+arch_params, so they are LibreYOLO's own and are shared by both sides of the
+comparison; what is under test is the new rotated head and its decode.
+
+Usage:
+    export YOLONAS_R_UPSTREAM_SRC=/path/with/the/two/pinned/py/files
+    export YOLONAS_R_OFFICIAL_CKPT_DIR=/path/with/yolo_nas_r_*_dota2.pth
+    python weights/parity_yolonas_obb.py
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+import types
+from pathlib import Path
+
+import torch
+from torch import nn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from libreyolo.models.yolonas.nn import (  # noqa: E402
+    LibreYOLONASOBBModel,
+    YoloNASDFLHead,
+    width_multiplier,
+)
+from libreyolo.models.yolonas.utils import unwrap_yolonas_checkpoint  # noqa: E402
+
+UPSTREAM_SRC = os.environ.get("YOLONAS_R_UPSTREAM_SRC")
+CKPT_DIR = os.environ.get("YOLONAS_R_OFFICIAL_CKPT_DIR")
+
+UPSTREAM_COMMIT = "69141b55c1161d939939a270523a7eca5a645f72"
+HEAD_INTER_CHANNELS = (128, 256, 512)
+HEAD_STRIDES = (8, 16, 32)
+WIDTH_MULT = {"s": 0.5, "m": 0.75, "l": 1.0}
+
+
+def _install_super_gradients_stubs() -> None:
+    """Minimal stand-ins for the framework symbols the pinned files import."""
+
+    def module(name: str) -> types.ModuleType:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+        return mod
+
+    for name in (
+        "super_gradients",
+        "super_gradients.common",
+        "super_gradients.common.factories",
+        "super_gradients.common.registry",
+        "super_gradients.module_interfaces",
+        "super_gradients.modules",
+        "super_gradients.modules.base_modules",
+        "super_gradients.modules.utils",
+        "super_gradients.training",
+        "super_gradients.training.models",
+        "super_gradients.training.models.detection_models",
+        "super_gradients.training.models.detection_models.yolo_nas",
+        "super_gradients.training.utils",
+        "omegaconf",
+    ):
+        module(name)
+
+    sys.modules["super_gradients.common.registry"].register_detection_module = (
+        lambda *a, **k: lambda cls: cls
+    )
+
+    class SupportsReplaceNumClasses:  # noqa: D401 - marker interface upstream
+        pass
+
+    sys.modules[
+        "super_gradients.module_interfaces"
+    ].SupportsReplaceNumClasses = SupportsReplaceNumClasses
+
+    class BaseDetectionModule(nn.Module):
+        def __init__(self, in_channels):
+            super().__init__()
+            self.in_channels = in_channels
+
+    sys.modules[
+        "super_gradients.modules.base_modules"
+    ].BaseDetectionModule = BaseDetectionModule
+    sys.modules["super_gradients.modules.utils"].width_multiplier = width_multiplier
+    sys.modules[
+        "super_gradients.training.models.detection_models.yolo_nas"
+    ].YoloNASDFLHead = YoloNASDFLHead
+
+    class HpmStruct(dict):
+        pass
+
+    sys.modules["super_gradients.training.utils"].HpmStruct = HpmStruct
+    sys.modules["super_gradients.training.utils"].torch_version_is_greater_or_equal = (
+        lambda *_: True
+    )
+    sys.modules["omegaconf"].DictConfig = dict
+
+    # The detection-module factory: upstream builds each rotated head through
+    # it, so the stub just applies the injected params to the head class.
+    factory_mod = module("super_gradients.common.factories.detection_modules_factory")
+
+    class DetectionModulesFactory:
+        head_cls = None  # set after the upstream module is executed
+
+        @staticmethod
+        def insert_module_param(cfg, name, value):
+            cfg = dict(cfg)
+            cfg[name] = value
+            return cfg
+
+        def get(self, cfg):
+            return DetectionModulesFactory.head_cls(**cfg)
+
+    factory_mod.DetectionModulesFactory = DetectionModulesFactory
+    sys.modules[
+        "super_gradients.common.factories"
+    ].detection_modules_factory = factory_mod
+    return DetectionModulesFactory
+
+
+def _load_upstream_modules(src_dir: Path):
+    factory_cls = _install_super_gradients_stubs()
+
+    def run(filename: str, module_name: str) -> types.ModuleType:
+        path = src_dir / filename
+        if not path.exists():
+            raise SystemExit(f"Missing pinned upstream file: {path}")
+        mod = types.ModuleType(module_name)
+        mod.__file__ = str(path)
+        sys.modules[module_name] = mod
+        exec(compile(path.read_text(encoding="utf-8"), str(path), "exec"), mod.__dict__)
+        return mod
+
+    dfl = run(
+        "yolo_nas_r_dfl_head.py",
+        "super_gradients.training.models.detection_models.yolo_nas_r.yolo_nas_r_dfl_head",
+    )
+    factory_cls.head_cls = dfl.YoloNASRDFLHead
+    ndfl = run(
+        "yolo_nas_r_ndfl_heads.py",
+        "super_gradients.training.models.detection_models.yolo_nas_r.yolo_nas_r_ndfl_heads",
+    )
+    return ndfl.YoloNASRNDFLHeads
+
+
+def _build_upstream_heads(heads_cls, size: str, in_channels, num_classes: int):
+    heads_list = [
+        {
+            "inter_channels": inter,
+            "width_mult": WIDTH_MULT[size],
+            "first_conv_group_size": 0,
+            "stride": stride,
+        }
+        for inter, stride in zip(HEAD_INTER_CHANNELS, HEAD_STRIDES)
+    ]
+    heads = heads_cls(
+        num_classes=num_classes,
+        in_channels=list(in_channels),
+        heads_list=heads_list,
+        reg_max=16,
+    )
+    # arch_params ship bn_eps: 1e-3 / bn_momentum: 0.03 and upstream applies
+    # them model-wide after assembly. Built standalone here, the heads would
+    # keep torch's 1e-5 default and the comparison would measure the harness
+    # rather than the port.
+    for m in heads.modules():
+        if isinstance(m, nn.BatchNorm2d):
+            m.eps = 1e-3
+            m.momentum = 0.03
+    return heads
+
+
+def main() -> None:
+    if not UPSTREAM_SRC or not CKPT_DIR:
+        raise SystemExit(
+            "Set YOLONAS_R_UPSTREAM_SRC (pinned upstream .py files, commit "
+            f"{UPSTREAM_COMMIT}) and YOLONAS_R_OFFICIAL_CKPT_DIR "
+            "(yolo_nas_r_{s,m,l}_dota2.pth)."
+        )
+
+    heads_cls = _load_upstream_modules(Path(UPSTREAM_SRC))
+    torch.manual_seed(0)
+    failures = []
+
+    for size in ("s", "m", "l"):
+        ckpt_path = Path(CKPT_DIR) / f"yolo_nas_r_{size}_dota2.pth"
+        state = dict(
+            unwrap_yolonas_checkpoint(
+                torch.load(ckpt_path, map_location="cpu", weights_only=False)
+            )
+        )
+
+        ours = LibreYOLONASOBBModel(config=size, nb_classes=18).eval()
+        result = ours.load_state_dict(state, strict=True)
+        assert not getattr(result, "missing_keys", []), result
+
+        upstream_heads = _build_upstream_heads(
+            heads_cls, size, ours.neck.out_channels, 18
+        ).eval()
+        head_state = {
+            k[len("heads.") :]: v for k, v in state.items() if k.startswith("heads.")
+        }
+        missing, unexpected = upstream_heads.load_state_dict(head_state, strict=False)
+        if missing or unexpected:
+            failures.append(f"size={size} upstream head load: {missing} / {unexpected}")
+            continue
+
+        x = torch.randn(1, 3, 1024, 1024)
+        with torch.no_grad():
+            feats = ours.neck(ours.backbone(x))
+            up_logits = upstream_heads(feats)
+            up = up_logits.as_decoded()
+            (our_boxes, our_scores), _raw = ours.heads(feats)
+
+        box_diff = (up.boxes_cxcywhr - our_boxes).abs().max().item()
+        score_diff = (up.scores - our_scores).abs().max().item()
+        angle_max = our_boxes[..., 4].max().item()
+        angle_min = our_boxes[..., 4].min().item()
+        ok = box_diff == 0.0 and score_diff == 0.0
+        print(
+            f"size={size}: boxes max_abs_diff={box_diff} "
+            f"scores max_abs_diff={score_diff} "
+            # Upstream's docstring says [-3*pi/4, pi/4], but its own code is
+            # ``(sigmoid(x) - 0.25) * pi``, i.e. (-pi/4, 3*pi/4). The port
+            # reproduces the code, not the comment.
+            f"angle_range=[{angle_min:.4f}, {angle_max:.4f}] "
+            f"(upstream code range ({-math.pi / 4:.4f}, {3 * math.pi / 4:.4f})) "
+            f"-> {'OK' if ok else 'FAIL'}"
+        )
+        if not ok:
+            failures.append(f"size={size}: boxes={box_diff} scores={score_diff}")
+
+    if failures:
+        raise SystemExit("PARITY FAILED:\n" + "\n".join(failures))
+    print("All sizes: exact parity (max_abs_diff == 0) vs pinned upstream head.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds YOLO-NAS-R oriented-box detection as the `obb` task of the existing
`yolonas` family (sizes `s`/`m`/`l`, DOTA2's 18 classes, 1024 px), rather than
as a new family: the rotated `arch_params` differ from the detection ones only
in the head class names, so the backbone and neck are reused unchanged.

```python
from libreyolo import LibreYOLO

model = LibreYOLO("LibreYOLONASs-obb.pt")   # auto-downloads from Deci's CDN
obb = model("aerial.jpg")[0].obb            # canonical xywhr on the original canvas
```

## What is here

- **Architecture** (`libreyolo/models/yolonas/nn.py`): `YoloNASRDFLHead`
  (width/height DFL over `2 * (reg_max + 1)` channels, two centre offsets, one
  rotation logit), `YoloNASRNDFLHeads` and `LibreYOLONASOBBModel`. Centres
  decode as `(offset + anchor) * stride`, sizes through DFL times stride.
- **Family wiring**: `SUPPORTED_TASKS` gains `obb`; `TASK_INPUT_SIZES["obb"]`
  is s/m/l at 1024; `is_obb_state_dict` (keys on `heads.head1.rot_pred.weight`)
  is resolved *before* pose and detect because the rotated head reuses the
  detect head's `cls_pred`/`reg_pred` names; canonical
  `LibreYOLONAS{s,m,l}-obb.pt` filenames; a Deci CDN download route with pinned
  SHA256s; and cross-task load rejection in all directions.
- **Preprocessing**: reproduces the checkpoint's own `processing_params`
  pipeline — reverse channels, longest side to 1024, bottom-right pad 114,
  `/255`. It resamples with `cv2.INTER_LINEAR` rather than PIL, matching
  upstream's rescale; DOTA imagery is downscaled hard and PIL's antialiased
  filter does not agree.
- **Postprocessing**: `postprocess_obb` thresholds, keeps upstream's 1000
  pre-NMS candidates, undoes the rescale/pad, canonicalises to LibreYOLO's
  long-side `[-pi/2, pi/2)` contract, then runs exact rotated NMS. Results land
  in `Results.obb` (not `Results.boxes`) with the axis-aligned proxy in
  `boxes`, in original-image coordinates.
- **Shared OBB helpers** (`libreyolo/postprocess/obb_ops.py`): the rotated-box
  corner conversion, axis-aligned proxy, exact rotated NMS and long-side
  canonicalisation, extracted out of the YOLO9 OBB postprocessor so OBB
  families share one implementation instead of two that can drift.
- **Backend + export**: a numpy OBB output parser (keeps the ONNX backend
  importable without torch) and a `boxes`/`scores` ONNX output branch. The raw
  export contract is `boxes [B, N, 5]` + `scores [B, N, C]`; rotated NMS is not
  embedded in the graph.
- **Converter**: `weights/convert_yolonas_obb_weights.py` — filename + SHA256
  gate *before* unpickling the third-party file, refuses ambiguous size/task
  matches, and stamps provenance metadata.

## Evidence

**Inference parity vs upstream — exact.** `weights/parity_yolonas_obb.py`
executes the two pinned upstream source files directly (with the handful of
SuperGradients framework symbols stubbed) and compares them against the port on
identical features:

```
size=s: boxes max_abs_diff=0.0 scores max_abs_diff=0.0 -> OK
size=m: boxes max_abs_diff=0.0 scores max_abs_diff=0.0 -> OK
size=l: boxes max_abs_diff=0.0 scores max_abs_diff=0.0 -> OK
All sizes: exact parity (max_abs_diff == 0) vs pinned upstream head.
```

Installing SuperGradients itself is not possible on this toolchain (its `onnx`
build dependency needs cmake and there is no wheel for this Python), so the
script runs upstream's real source rather than an installed package. The
backbone/neck are LibreYOLO's own on both sides, which is sound because they
are unchanged from the already parity-proven detect path — and separately, all
three official checkpoints load into the port with **0 missing and 0 unexpected
keys** under `strict=True`.

One documented upstream discrepancy: upstream's docstring claims the angle
range is `[-3*pi/4, pi/4]`, but its code is `(sigmoid(x) - 0.25) * pi`, i.e.
`(-pi/4, 3*pi/4)`. The port reproduces the code, not the comment.

**Exports** — each format was exported, reloaded through `LibreYOLO()`, and run
on the same image; the numbers are max deltas of the public OBB result against
native inference (official YOLO-NAS-R-S, 1024, FP32, batch 1):

| Format | xywhr delta (px) | score delta |
| --- | ---: | ---: |
| TorchScript | 6e-08 | 0.0 |
| OpenVINO | 0.041 | 1.5e-03 |
| ONNX | 0.056 | 1.0e-03 |
| TensorRT | 0.177 | 1.6e-03 |

Only those four are ticked in `docs/export_support.md`. NCNN, TFLite, CoreML,
Paddle, MNN, RKNN, ExecuTorch and Core AI were **not** run and are not claimed.

Exporting to TorchScript initially failed with a cuda/cpu mismatch: the head's
anchor generation used `torch.arange(..., device=...)`, whose device becomes a
graph constant under tracing. Anchors are now derived from the feature tensor,
which keeps the graph device-agnostic (and spatially dynamic). Eager arithmetic
is unchanged — the parity gate above still reads 0.

**Auto-download from a clean cache**: deleting the local weight and calling
`LibreYOLO("LibreYOLONASs-obb.pt")` fetches `yolo_nas_r_s_dota2.pth` from
Deci's CDN, verifies it against the pinned SHA256, prints the YOLO-NAS-R
licence notice, loads, and predicts.

**Tests**: `tests/unit/test_yolonas_obb.py` (28 tests: head layout, forward
shapes and angle range, traced-output contract, bidirectional task
discrimination against detect and pose state dicts, filename/download routing,
hash pins, geometry helpers, rotated NMS behaviour, and the postprocess
contract including the letterbox inverse) and `tests/e2e/test_yolonas_obb.py`
(trained-checkpoint smoke on a non-square image, plus a real gradient step
through the rotated loss on the public checkpoint). 58 OBB unit tests in
total.

## Training

`model.train(...)` trains the rotated head through the public API on standard
YOLO OBB datasets:

```python
from libreyolo.models.yolonas.model import LibreYOLONAS

model = LibreYOLONAS(None, size="s", task="obb", nb_classes=2)
model.train(data="dataset.yaml", epochs=100, imgsz=640)
```

- **Loss** (`libreyolo/models/yolonas/obb_loss.py`), ported from the same
  pinned commit: varifocal classification against a rotated task-aligned
  assigner, `1 - probIoU` on the decoded `cxcywhr` boxes, and width/height
  DFL. Upstream has **no** separate offset or angle regression term despite
  what the handoff summary implies -- the probabilistic IoU supervises both
  the centre offsets and the rotation. The port follows the code.
- **Defaults** from upstream's DOTA recipe: AdamW 5e-5, weight decay 3.5e-6,
  cosine to 0.1 of the initial LR, EMA 0.9997, AMP off, assigner top-k 12,
  loss weights 2.5 / 2.0 / 0.5.
- **Best-checkpoint metric** is `metrics/mAP50-95(OBB)`, not the axis-aligned
  proxy the base trainer defaults to.
- **Transfer initialisation**: `load_detect_weights_for_obb()` seeds a rotated
  model from a YOLO-NAS detection checkpoint, mirroring upstream's
  `strict_load: key_matching` start. Backbone, neck and shape-compatible head
  tensors copy; `reg_pred` (whose width changes), `rot_pred` and `offset_pred`
  stay freshly initialised.
- **Augmentation is flips + HSV only.** Mosaic, mixup and affine have no
  correct rotated-label mapping (a shear turns a rectangle into a
  parallelogram), so they are not offered rather than offered as knobs that
  quietly corrupt the angle. Resize/pad/normalize delegates to the same
  `preprocess_obb_numpy` that inference and validation use, so the three
  paths cannot drift.

**Convergence**, 11 epochs on a small synthetic rotated-box set (240 train /
60 val, 2 classes, one GPU), fine-tuning the public YOLO-NAS-R-S checkpoint:

| | epoch 1 | epoch 11 |
| --- | ---: | ---: |
| train loss | 3.1982 | 1.3753 |
| OBB mAP50 | 0.8637 | 0.9787 |
| OBB mAP50-95 | 0.4984 | 0.7990 |

Verified independently: `model.val()` on the trained checkpoint reports
mAP50 0.9773 / mAP50-95 0.7499. The set is synthetic and stated as such --
full DOTA2 reproduction stays a manual run (upstream reports ~7/9/12 hours on
eight RTX 3090s for S/M/L).

**A real bug this surfaced**: validation ran through the *detect* preprocessor
(longest side 636, centre pad) while `postprocess_obb` inverts the OBB recipe
(1024, bottom-right pad). Every box was mis-mapped back onto the canvas, so
OBB mAP read ~0 while the training loss fell normally.
`_get_val_preprocessor` is now task-aware, with regression tests asserting the
OBB path is byte-identical to the inference preprocessing.

## Licensing

Code and weights have different terms and are treated differently:

- **Code**: Apache-2.0, ported with attribution. `THIRD_PARTY_NOTICES.txt`
  records the repository, pull request, pinned commit, licence and the exact
  source paths used.
- **Weights**: the pretrained DOTA2 checkpoints are covered by Deci's separate
  `LICENSE.YOLONAS-R.md` — revocable, non-commercial, no redistribution. They
  are **not** mirrored on the LibreYOLO HF org. They are downloaded from Deci's
  CDN on demand and SHA256-verified before unpickling, the same link-only
  treatment YOLO-NAS detect and pose already get, and
  `weights/LICENSE_NOTICE.txt` now states this explicitly. Complying with
  Deci's terms is the downstream user's responsibility.
- **Training data**: DOTA2 is not bundled and carries its own terms.

## Note for the maintainer

The README change is a single cell: `YOLO-NAS-R` appended to the existing
**Oriented boxes** row. The handoff asks for maintainer approval on any README
support-table edit — happy to drop it if you would rather it land separately.

## Code provenance

Ported from **SuperGradients** — https://github.com/Deci-AI/super-gradients —
specifically pull request 2014 at pinned commit
`69141b55c1161d939939a270523a7eca5a645f72`, whose repository `LICENSE.md` at
that commit is the **Apache License 2.0**. Copyright (c) 2021-2024 Deci AI.

Source files used at that pin:

- `src/super_gradients/training/models/detection_models/yolo_nas_r/yolo_nas_r_dfl_head.py`
- `src/super_gradients/training/models/detection_models/yolo_nas_r/yolo_nas_r_ndfl_heads.py`
- `src/super_gradients/training/models/detection_models/yolo_nas_r/yolo_nas_r_variants.py`
- `src/super_gradients/training/models/detection_models/yolo_nas_r/yolo_nas_r_post_prediction_callback.py`
- `src/super_gradients/recipes/arch_params/yolo_nas_r_{s,m,l}_arch_params.yaml`

Derived from those files: `YoloNASRDFLHead`, `YoloNASRNDFLHeads` and
`LibreYOLONASOBBModel` in `libreyolo/models/yolonas/nn.py`; the OBB
preprocessing recipe in `libreyolo/preprocess/yolonas.py`; and the
candidate-selection defaults in `postprocess_obb` in
`libreyolo/postprocess/yolonas.py`.

Everything else is original code written for this PR: the LibreYOLO family
wiring and task discrimination, `libreyolo/postprocess/obb_ops.py` (extracted
from LibreYOLO's own `libreyolo/postprocess/yolo9.py`), the backend OBB parser,
the export branch, the converter, the parity harness, and the tests.

The pretrained YOLO-NAS-R weights are **not** redistributed by this PR. They
remain under Deci's separate, non-permissive `LICENSE.YOLONAS-R.md` and are
downloaded from Deci's public CDN at runtime. No GPL, AGPL, LGPL or
unknown-licence code is included.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds YOLO-NAS-R oriented-box inference, training, validation, export, backend parsing, checkpoint conversion, and documentation to the existing YOLO-NAS family.
- Adds the rotated YOLO-NAS head, loss, trainer, preprocessing, and postprocessing pipeline.
- Wires OBB checkpoints, downloads, task detection, backend output parsing, and supported export formats.
- Extracts shared oriented-box geometry and NMS helpers and adds focused unit and end-to-end coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported backend issue is resolved by dropping non-finite OBB rows before canonicalization and NMS.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/backends/base.py | Adds NumPy parsing for exported YOLO-NAS-R outputs; the prior non-finite-row issue is fixed by filtering all box fields and scores before canonicalization and NMS. |
| libreyolo/models/yolonas/model.py | Integrates OBB architecture selection, checkpoint handling, inference, training dispatch, validation preprocessing, and detection-weight initialization. |
| libreyolo/models/yolonas/obb_trainer.py | Connects OBB loss, data transforms, validation, resume behavior, and rotated-mAP checkpoint selection to the shared training lifecycle. |
| libreyolo/models/yolonas/obb_loss.py | Implements the rotated assignment and regression losses with label ordering consistent with the new OBB data transform. |
| libreyolo/postprocess/yolonas.py | Adds YOLO-NAS-R candidate selection, inverse image scaling, canonicalization, and exact rotated NMS. |
| libreyolo/postprocess/obb_ops.py | Centralizes oriented-box canonicalization, proxy conversion, geometry, and rotated NMS shared by OBB model families. |
| libreyolo/data/augment/yolonas.py | Adds OBB-safe training transforms and emits the six-column target contract expected by the loss. |
| weights/parity_yolonas_obb.py | Provides an explicitly invoked parity harness for comparing the port against a caller-selected trusted upstream checkout. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Train YOLO-NAS-R: rotated loss, trainer,..."](https://github.com/libreyolo/libreyolo/commit/a8c44a599231fcdea4f214d1c9f90ad1a4b94970) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51634759)</sub>

<!-- /greptile_comment -->