### PR TITLE
Add Perception Encoder Core (LibrePE): zero-shot classify + image/text/video embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Releases
 before 1.4.0 are documented in the
 [GitHub Releases](https://github.com/LibreYOLO/libreyolo/releases) only.
 
+## [Unreleased]
+
+### Added
+
+- **Perception Encoder (PE) Core** (`pe` / `LibrePE`) — Meta's dual-tower
+  vision-language encoder, in all five released sizes (`t16`, `s16`, `b16`,
+  `l14`, `g14`). Zero-shot `classify` through `set_classes(...)` and `embed`
+  for images, text and **whole videos**, all in one normalized space:
+
+  ```python
+  model = LibreYOLO("LibrePEb16-cls.pt", task="embed")
+  model.predict("photo.jpg")          # (1, D) image row
+  model.embed_text(["a dog"])         # (1, D) text row
+  model.predict("clip.mp4")           # (1, D) row for the whole clip
+  ```
+
+  PE is the first family to embed a finite video as a *single* vector rather
+  than one result per frame: frames are sampled uniformly, encoded
+  independently, averaged, then L2-normalized once. This is opt-in per family
+  via the new `BaseModel.VIDEO_EMBED_MODE` (default `"frames"`), so CLIP,
+  SigLIP2, DINOv2 and every other family keep their existing frame-by-frame
+  behavior. Live cameras, network streams and screen captures are rejected for
+  whole-clip embedding rather than buffered without bound. `predict()` accepts
+  `clip_frames=` (default 8) to change how many frames are sampled.
+
+  Inference-only by design: PE Core has no closed-set supervised head, so
+  `train()` rejects immediately with an explanation instead of silently routing
+  to the generic classification trainer.
+
+  Exports: ONNX and TorchScript, for image embedding, frozen-class
+  classification, and fixed-frame video embedding.
+
+  The towers are a native `torch` re-implementation adapted from timm v1.0.28
+  (Apache-2.0) and OpenCLIP v3.2.0 (MIT); neither is imported at runtime.
+  Image, text, zero-shot-logit and video outputs are bit-identical
+  (`max_abs_diff == 0.0`) to `open_clip_torch==3.2.0` on float32 CPU for all
+  five sizes.
+
 ## [1.5.0] - 2026-08-09
 
 The largest release so far: 28 new model families, four new tasks (`edge`,

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Panoptic segmentation** | EoMT |
 | **Pose** | RF-DETR, YOLO-NAS, HRNet, EC |
 | **Oriented boxes** | RF-DETR, RT-DETRv2 |
-| **Classification** | MobileNetV4, ConvNeXt, EfficientNetV2, ResNet, ViT, Swin, DeiT, VGG, AlexNet, CLIP, SigLIP2, DINOv2 |
+| **Classification** | MobileNetV4, ConvNeXt, EfficientNetV2, ResNet, ViT, Swin, DeiT, VGG, AlexNet, CLIP, SigLIP2, Perception Encoder, DINOv2 |
 | **Depth** | Depth Anything 3, Depth Anything V2, ZipDepth, MiDaS |
 | **Surface normals** | MoGe-2 |
 | **Edges** | DexiNed, TEED |
-| **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, DINOv2 |
+| **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, Perception Encoder (image, text and whole-video), DINOv2 |
 | **Body mesh** | SAM 3D Body |
 | **Restoration** | NAFNet, Real-ESRGAN, SwinIR |
 | **Background removal** | BiRefNet, FeyNobg |

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Panoptic segmentation** | EoMT |
 | **Pose** | RF-DETR, YOLO-NAS, HRNet, EC |
 | **Oriented boxes** | RF-DETR, RT-DETRv2 |
-| **Classification** | MobileNetV4, ConvNeXt, EfficientNetV2, ResNet, ViT, Swin, DeiT, VGG, AlexNet, CLIP, SigLIP2, Perception Encoder, DINOv2 |
+| **Classification** | MobileNetV4, ConvNeXt, EfficientNetV2, ResNet, ViT, Swin, DeiT, VGG, AlexNet, CLIP, SigLIP2, DINOv2 |
 | **Depth** | Depth Anything 3, Depth Anything V2, ZipDepth, MiDaS |
 | **Surface normals** | MoGe-2 |
 | **Edges** | DexiNed, TEED |
-| **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, Perception Encoder (image, text and whole-video), DINOv2 |
+| **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, Perception Encoder (image, text, whole-video; also zero-shot classify), DINOv2 |
 | **Body mesh** | SAM 3D Body |
 | **Restoration** | NAFNet, Real-ESRGAN, SwinIR |
 | **Background removal** | BiRefNet, FeyNobg |

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -131,6 +131,40 @@ checkpoints (state-dict metadata wrap only; learned parameters unchanged). See
 libreyolo/models/siglip2/NOTICE.md.
 
 --------------------------------------------------------------------
+Perception Encoder / PE Core (Meta AI)
+--------------------------------------------------------------------
+Source: https://github.com/huggingface/pytorch-image-models (tag v1.0.28,
+        commit 8ef73809f622e0031bd7f4940265734aef8b9978)
+        https://github.com/mlfoundations/open_clip (tag v3.2.0,
+        commit 6f939057c792a2f3d4d58df748de60ca47c4aed4)
+License: Apache License 2.0 (pytorch-image-models); MIT License (open_clip)
+Copyright (c) Ross Wightman; (c) 2012-2021 OpenCLIP authors.
+Used for: the LibrePE family (libreyolo/models/pe/). The vision tower
+(PEVisionTransformer, PEBlock, PEAttentionRope, PEAttentionPoolLatent,
+RotaryEmbeddingCat and the rotary/fourier helpers in libreyolo/models/pe/nn.py)
+is adapted from timm's EVA implementation (timm/models/eva.py,
+timm/layers/pos_embed_sincos.py, timm/layers/attention_pool.py). The text tower
+(PETextTransformer, Transformer, ResidualAttentionBlock in the same file) is
+adapted from open_clip's src/open_clip/transformer.py. Neither timm nor
+open_clip is imported at runtime. The OpenAI BPE tokenizer is reused from the
+existing libreyolo/models/clip/ implementation rather than duplicated.
+
+The Perception Encoder architecture itself is described in
+"Perception Encoder: The best visual embeddings are not at the output of the
+network" (Meta AI, https://arxiv.org/abs/2504.13181).
+
+NOTE: the official facebookresearch/perception_models repository (commit
+3e352cca660658d4b5c90f42a7808b11469e4c66) ships LICENSE.PE with Apache-2.0
+terms while the same revision's setup.py declares a noncommercial/proprietary
+package license. That inconsistency is unresolved, and is why no code was
+copied or adapted from that repository. The Perception Language Model
+(LICENSE.PLM, noncommercial), PE Spatial and PE-AV are out of scope.
+
+The shipped LibrePE weights are converted from the Apache-2.0
+OpenCLIP-compatible timm/PE-Core-* repositories (state-dict metadata wrap only;
+learned parameters unchanged). See libreyolo/models/pe/NOTICE.md.
+
+--------------------------------------------------------------------
 YOLOX (Megvii-BaseDetection)
 --------------------------------------------------------------------
 Source: https://github.com/Megvii-BaseDetection/YOLOX

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -110,6 +110,8 @@ in preflight.
 | yolonas | pose | ✓ | ✓ | ✓ | available | ✓ | ✓ |  |  | ✓ |  |  |  |
 | yolox | detect | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ | ✓ | available | ✓ |
 | zipdepth | depth | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ |  |  | ✓ |
+| pe | classify | ✓ | ✓ | available | available | available |  |  |  |  |  |  |  |
+| pe | embed | ✓ | ✓ | available | available | available |  |  |  |  |  |  |  |
 
 ## Parity thresholds
 
@@ -429,6 +431,10 @@ A check mark applies only under any constraint listed here.
 - `zipdepth` / `depth` / `openvino`: fixed-resolution export canvas
 - `zipdepth` / `depth` / `ncnn`: PNNX/NCNN 20260526 CPU FP32 with a fixed-resolution export canvas; two-input raw parity, factory reload, metadata, and public predict parity
 - `zipdepth` / `depth` / `coreai`: fixed export canvas; permissively licensed trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `pe` / `classify` / `onnx`: fixed square input; dynamic batch only. Video graphs have a static frame count -- a dynamic F is not advertised. The classify graph freezes the class set present at export time.
+- `pe` / `classify` / `torchscript`: fixed square input; dynamic batch only. Video graphs have a static frame count -- a dynamic F is not advertised. The classify graph freezes the class set present at export time.
+- `pe` / `embed` / `onnx`: fixed square input; dynamic batch only. Video graphs have a static frame count -- a dynamic F is not advertised. The classify graph freezes the class set present at export time.
+- `pe` / `embed` / `torchscript`: fixed square input; dynamic batch only. Video graphs have a static frame count -- a dynamic F is not advertised. The classify graph freezes the class set present at export time.
 
 ## Available combinations
 
@@ -521,6 +527,12 @@ These converter paths are callable with the recorded validation context.
 - `yolox` / `detect` / `tensorrt`: The permissively licensed trained checkpoint exports, reloads, and passes public predict parity, but normalized raw error is 1.6% and image signal is only 2.1 times the conversion error.
 - `yolox` / `detect` / `coreml`: Conversion is available, but runtime parity requires a macOS runner.
 - `zipdepth` / `depth` / `tensorrt`: TensorRT 10.16 FP32 exports, reloads, and predicts, but repeated builds produced raw depth PSNR as low as 30.27 dB, below the 40 dB promotion gate.
+- `pe` / `classify` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `pe` / `classify` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `pe` / `classify` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
+- `pe` / `embed` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `pe` / `embed` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `pe` / `embed` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
 
 ## Blocked combinations
 
@@ -1278,3 +1290,17 @@ These converter paths are callable with the recorded validation context.
 - `zipdepth` / `depth` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `zipdepth` / `depth` / `tflite`: onnx2tf 2.6.7 flatbuffer-direct conversion does not support the edge-mode Pad operation in ZipDepth's convex upsampler.
 - `zipdepth` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `pe` / `classify` / `paddle`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
+- `pe` / `classify` / `rknn`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `classify` / `ncnn`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `classify` / `tflite`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `classify` / `coreml`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `classify` / `coreai`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `embed` / `paddle`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `embed` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
+- `pe` / `embed` / `rknn`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `embed` / `ncnn`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `embed` / `tflite`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `embed` / `coreml`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.
+- `pe` / `embed` / `coreai`: No parity-validated PE artifact exists for this runtime; the family ships only the ONNX and TorchScript graphs it was tested in.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -393,9 +393,11 @@ carry `Results.embeddings` with shape `(1, D)` and no boxes; region results use
 image path and is never inferred to be text. `Gallery` stores named references
 for any shape, while `FaceGallery` remains its compatibility alias.
 
-Dedicated embed checkpoints use `-embed`. Dual-task CLIP and SigLIP2 reuse
+Dedicated embed checkpoints use `-embed`. Dual-task CLIP, SigLIP2 and PE reuse
 their existing `-cls` two-tower artifact with an explicit `task="embed"`; no
-duplicate artifact is published for identical weights. DINOv2 likewise loads
+duplicate artifact is published for identical weights. PE additionally accepts a
+finite video under `task="embed"` and returns one row for the whole clip rather
+than one per frame. DINOv2 likewise loads
 an existing family checkpoint and bypasses its task head. Task aliases
 `facial-recognition`, `face-recognition`, `recognition`, `face`, `faceid`,
 `embedding`, and `reid` resolve to `embed` at the API boundary. See ADR 0013
@@ -693,6 +695,15 @@ LibreCLIPl14-cls.pt       # OpenCLIP ViT-L/14, LAION-2B (config + converter read
 # Use the same -cls artifact with task="embed"; size codes bake in resolution.
 LibreSigLIP2b16-cls.pt    # google/siglip2-base-patch16-256 (Apache-2.0 weights), 256 px
 LibreSigLIP2so400m-cls.pt # google/siglip2-so400m-patch14-384 (Apache-2.0 weights), 384 px
+
+# pe: Perception Encoder Core zero-shot classify, or image/text/whole-video
+# embedding. Use the same -cls artifact with task="embed"; size codes bake in
+# patch size, and resolution varies per size.
+LibrePEt16-cls.pt         # timm/PE-Core-T-16-384 (Apache-2.0 weights), 384 px, dim 512
+LibrePEs16-cls.pt         # timm/PE-Core-S-16-384 (Apache-2.0 weights), 384 px, dim 512
+LibrePEb16-cls.pt         # timm/PE-Core-B-16 (Apache-2.0 weights), 224 px, dim 1024
+LibrePEl14-cls.pt         # timm/PE-Core-L-14-336 (Apache-2.0 weights), 336 px, dim 1024
+LibrePEg14-cls.pt         # timm/PE-Core-bigG-14-448 (Apache-2.0 weights), 448 px, dim 1280
 ```
 
 ### VLM analysis (external snapshot tier)

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -109,6 +109,7 @@ the `alexnet` / `deit` / `mobilenetv4` / `convnext` / `efficientnetv2` /
 | `swin`      | `LibreSwin`      | Upstream brand casing preserved (`Swin Transformer V1`) — classify-only and inference-only |
 | `clip`      | `LibreCLIP`     | All-caps acronym (`CLIP` zero-shot classify + image/text embed) — inference-only |
 | `siglip2`   | `LibreSigLIP2`  | Upstream brand casing preserved (`SigLIP`) + version (`SigLIP 2` zero-shot classify + image/text embed); inference-only |
+| `pe`        | `LibrePE`       | All-caps acronym (`PE`, Perception Encoder) kept short so canonical filenames stay compact; zero-shot classify + image/text/video embed; inference-only |
 | `nafnet`    | `LibreNAFNet`   | All-caps acronym + CamelCase `Net`; restore-only image-restoration family |
 | `realesrgan` | `LibreRealESRGAN` | Upstream brand casing (`RealESRGAN`); restore-only super-resolution family |
 | `swinir`    | `LibreSwinIR`    | Upstream brand casing (`SwinIR`); restore-only transformer super-resolution family |
@@ -238,6 +239,7 @@ ships:
 | `ppocr`     | `t` (PP-OCRv5 mobile det + mobile rec, CPU tier), `l` (PP-OCRv5 server det + server rec, quality tier); detection long side 960 |
 | `clip`      | `b32`, `b16`, `l14` (ViT patch size baked in, all at 224) |
 | `siglip2`   | `b16` (base patch-16 at 256), `so400m` (shape-optimized 400M patch-14 at 384) |
+| `pe`        | `t16`, `s16` (patch-16 at 384), `b16` (patch-16 at 224), `l14` (patch-14 at 336), `g14` (gigantic patch-14 at 448) — ViT patch size baked in, resolution varies per size |
 
 VLM snapshot families use model-specific size names:
 
@@ -504,6 +506,7 @@ Detector-factory family support follows:
 | `swin`      | `("classify",)`             | classify | Swin Transformer V1 image classifier; t/s/b/l at 224; predict + top-1/top-5 `val` + ONNX/TorchScript/OpenVINO/TensorRT; inference-only |
 | `clip`      | `("classify", "embed")`     | classify | shared two-tower `-cls` weights; zero-shot classify or whole-image/text embeddings in one space |
 | `siglip2`   | `("classify", "embed")`     | classify | shared two-tower `-cls` weights; zero-shot classify or multilingual whole-image/text embeddings in one space |
+| `pe`        | `("classify", "embed")`     | classify | shared two-tower `-cls` weights; zero-shot classify, or image/text/whole-video embeddings in one space. The only family whose `embed` task pools a finite video into a single row (`VIDEO_EMBED_MODE = "clip"`) |
 | `facerec`   | `("embed",)`                | embed | two-stage face-region embeddings; rows align with face boxes; inference-only |
 
 Families that override `SUPPORTED_TASKS` also declare `TASK_INPUT_SIZES` so

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -80,6 +80,7 @@ _MODEL_EXPORTS = (
     "LibreAlexNet",
     "LibreCLIP",
     "LibreSigLIP2",
+    "LibrePE",
     "LibrePPOCR",
 )
 _RESULTS_EXPORTS = (
@@ -299,6 +300,7 @@ __all__ = [
     "LibreAlexNet",
     "LibreCLIP",
     "LibreSigLIP2",
+    "LibrePE",
     "LibrePPOCR",
     "LibreDINOv2",
     # VLM-as-detector tier (optional, requires libreyolo[vlm])

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -745,6 +745,18 @@ class BaseBackend(ABC):
                 interpolation="bilinear",
                 square_resize=True,
             )
+        elif self.model_family == "pe":
+            # Must mirror LibrePE._build_transform: symmetric [-1, 1]
+            # normalization and a bilinear square resize, NOT ImageNet stats.
+            from ..models.pe.nn import PE_MEAN, PE_STD
+
+            transform_kwargs.update(
+                mean=PE_MEAN,
+                std=PE_STD,
+                crop_pct=1.0,
+                interpolation="bilinear",
+                square_resize=True,
+            )
         elif self.model_family == "vit":
             from ..models.vit.utils import VIT_MEAN, VIT_STD
 

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import numpy as np
 
 from ..tasks import resolve_task
-from ..utils.serialization import warn_on_metadata_schema_version
+from ..utils.serialization import (
+    reject_unsupported_input_kind,
+    warn_on_metadata_schema_version,
+)
 from .base import (
     BaseBackend,
     ImageSize,
@@ -206,6 +209,9 @@ class OnnxBackend(BaseBackend):
                 meta,
                 artifact=f"ONNX metadata for {onnx_path}",
                 logger=logger,
+            )
+            reject_unsupported_input_kind(
+                meta, artifact=f"ONNX metadata for {onnx_path}"
             )
             parsed = parse_export_metadata(
                 meta,

--- a/libreyolo/backends/torchscript.py
+++ b/libreyolo/backends/torchscript.py
@@ -11,7 +11,10 @@ import torch
 
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.general import COCO_CLASSES
-from ..utils.serialization import warn_on_metadata_schema_version
+from ..utils.serialization import (
+    reject_unsupported_input_kind,
+    warn_on_metadata_schema_version,
+)
 from .base import (
     BaseBackend,
     _read_metadata_imgsz,
@@ -60,6 +63,9 @@ class TorchScriptBackend(BaseBackend):
             metadata,
             artifact=f"TorchScript metadata for {model_path}",
             logger=logger,
+        )
+        reject_unsupported_input_kind(
+            metadata, artifact=f"TorchScript metadata for {model_path}"
         )
 
         input_size = 640

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -1054,6 +1054,35 @@ _add(
     ),
 )
 _add(
+    "validated",
+    ("pe",),
+    ("classify", "embed"),
+    ("onnx", "torchscript"),
+    reason=(
+        "Fixed-input graphs are compared against native PyTorch in "
+        "tests/unit/test_pe_export.py: TorchScript reproduces native exactly "
+        "(max_abs_diff 0.0) for the image-embed, frozen-class and fixed-frame "
+        "video graphs; ONNX matches to 4.3e-07 (embed), 1.3e-07 (video) and "
+        "1.5e-05 (classify, on logit_scale-amplified logits)."
+    ),
+    since="1.6",
+    constraint=(
+        "fixed square input; dynamic batch only. Video graphs have a static "
+        "frame count -- a dynamic F is not advertised. The classify graph "
+        "freezes the class set present at export time."
+    ),
+)
+_add(
+    "blocked",
+    ("pe",),
+    ("classify", "embed"),
+    ("ncnn", "coreml", "coreai", "tflite", "paddle", "rknn"),
+    reason=(
+        "No parity-validated PE artifact exists for this runtime; the family "
+        "ships only the ONNX and TorchScript graphs it was tested in."
+    ),
+)
+_add(
     "blocked",
     ("clip",),
     ("classify",),

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -142,6 +142,13 @@ from .clip.model import LibreCLIP  # noqa: E402,F401  (import registers family)
 # matter. NB: SigLIP carries logit_bias, which CLIP lacks.
 from .siglip2.model import LibreSigLIP2  # noqa: E402,F401  (import registers family)
 
+# Native Perception Encoder Core towers (no timm / open_clip at runtime; the
+# OpenAI BPE tokenizer is reused from LibreCLIP), so it registers eagerly.
+# can_load is uniquely keyed on visual.trunk.attn_pool.latent +
+# visual.trunk.patch_embed.proj.weight + text.text_projection, a signature no
+# other family carries, so order does not matter.
+from .pe.model import LibrePE  # noqa: E402,F401  (import registers family)
+
 # PP-OCRv5 text detection + recognition pipeline. can_load is uniquely keyed
 # on the composite det.*/rec.* checkpoint layout, so order does not matter.
 from .ppocr.model import LibrePPOCR  # noqa: E402,F401  (import registers family)
@@ -837,6 +844,7 @@ __all__ = [
     "LibreAlexNet",
     "LibreCLIP",
     "LibreSigLIP2",
+    "LibrePE",
     "LibrePPOCR",
     "LibreFaceEmbedder",
     "try_ensure_rfdetr",

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -315,7 +315,7 @@ class InferenceRunner:
                     "they arrive."
                 )
             if source_spec.kind == SourceKind.VIDEO:
-                return self._predict_video_clip(
+                clip_results = self._predict_video_clip(
                     source_spec.source,
                     conf=conf,
                     iou=iou,
@@ -324,6 +324,10 @@ class InferenceRunner:
                     max_det=max_det,
                     **kwargs,
                 )
+                # Honor the streaming contract: callers passing stream=True
+                # expect an iterator, even though a whole clip collapses to a
+                # single Results.
+                return iter(clip_results) if stream else clip_results
 
         # Handle finite video input.
         if source_spec.kind == SourceKind.VIDEO:

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -315,6 +315,19 @@ class InferenceRunner:
                     "they arrive."
                 )
             if source_spec.kind == SourceKind.VIDEO:
+                if vid_stride != 1:
+                    raise ValueError(
+                        "vid_stride does not apply when a whole video is "
+                        "embedded as a single vector: frames are sampled "
+                        "uniformly across the entire clip. Use clip_frames= to "
+                        "control how many frames are sampled."
+                    )
+                if show:
+                    raise NotImplementedError(
+                        "show=True displays annotated frames as they are "
+                        "processed, which does not apply to a whole-clip "
+                        "embedding that yields one result for the entire video."
+                    )
                 clip_results = self._predict_video_clip(
                     source_spec.source,
                     conf=conf,
@@ -322,6 +335,9 @@ class InferenceRunner:
                     imgsz=imgsz,
                     classes=classes,
                     max_det=max_det,
+                    save=save,
+                    output_path=output_path,
+                    output_file_format=output_file_format,
                     **kwargs,
                 )
                 # Honor the streaming contract: callers passing stream=True
@@ -767,6 +783,9 @@ class InferenceRunner:
         imgsz=None,
         classes=None,
         max_det: int = 300,
+        save: bool = False,
+        output_path=None,
+        output_file_format=None,
         **kwargs,
     ) -> List[Results]:
         """Embed a finite video as a single row (``VIDEO_EMBED_MODE == "clip"``).
@@ -775,6 +794,10 @@ class InferenceRunner:
         temporal pooling belong to the family's ``_forward``. Returns a
         one-element list holding one ``Results`` for the whole clip, not one per
         frame.
+
+        ``save=True`` writes a single annotated image built from the first
+        sampled frame -- there is no per-frame video to render, because the
+        whole clip collapses to one result.
         """
         clip_frames = kwargs.pop(
             "clip_frames", getattr(self.model, "clip_frames", 8)
@@ -801,6 +824,12 @@ class InferenceRunner:
         )
         result = self._wrap_results(detections, original_size, str(source), classes)
         result.path = str(source)
+
+        if save:
+            save_file = resolve_save_path(
+                output_path, str(source), ext=output_file_format or "jpg"
+            )
+            self._save_annotated_image(result, frames[0], save_file)
         return [result]
 
     def _save_annotated_image(

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -75,6 +75,7 @@ from ...utils.video import (
     FrameSource,
     collect_video_results,
     run_video_inference,
+    sample_clip_frames,
 )
 from .cuda_graph import forward_maybe_graphed, with_cuda_graph_scope
 
@@ -245,7 +246,8 @@ class InferenceRunner:
             Results, list of Results, or generator of Results (stream=True).
         """
         kwargs = normalize_predict_kwargs(
-            kwargs, passthrough={"num_select", "gallery", "threshold"}
+            kwargs,
+            passthrough={"num_select", "gallery", "threshold", "clip_frames"},
         )
         if device is not None:
             self._set_device(device)
@@ -295,6 +297,33 @@ class InferenceRunner:
             )
 
         source_spec = classify_source(source)
+
+        # Whole-clip embedding. Opt-in per family: only when the resolved task
+        # is "embed", the family declares clip support, and the source is a
+        # finite video. Every other family keeps the frame-by-frame path below.
+        if (
+            getattr(self.model, "VIDEO_EMBED_MODE", "frames") == "clip"
+            and getattr(self.model, "task", None) == "embed"
+        ):
+            if source_spec.live or source_spec.kind == SourceKind.SCREEN:
+                raise ValueError(
+                    f"{type(self.model).__name__} embeds a whole video as a "
+                    "single vector, which requires a finite source with a known "
+                    "end. Live cameras, network streams and screen captures are "
+                    "unbounded and would have to be buffered indefinitely. Pass "
+                    "a video file, or use task='classify' to score frames as "
+                    "they arrive."
+                )
+            if source_spec.kind == SourceKind.VIDEO:
+                return self._predict_video_clip(
+                    source_spec.source,
+                    conf=conf,
+                    iou=iou,
+                    imgsz=imgsz,
+                    classes=classes,
+                    max_det=max_det,
+                    **kwargs,
+                )
 
         # Handle finite video input.
         if source_spec.kind == SourceKind.VIDEO:
@@ -724,6 +753,51 @@ class InferenceRunner:
                 self._save_annotated_image(result, original_img, save_path)
             results.append(result)
         return results
+
+    def _predict_video_clip(
+        self,
+        source,
+        *,
+        conf,
+        iou,
+        imgsz=None,
+        classes=None,
+        max_det: int = 300,
+        **kwargs,
+    ) -> List[Results]:
+        """Embed a finite video as a single row (``VIDEO_EMBED_MODE == "clip"``).
+
+        Decoding and uniform sampling are family-independent; tensor layout and
+        temporal pooling belong to the family's ``_forward``. Returns a
+        one-element list holding one ``Results`` for the whole clip, not one per
+        frame.
+        """
+        clip_frames = kwargs.pop(
+            "clip_frames", getattr(self.model, "clip_frames", 8)
+        )
+        clip_frames = int(clip_frames)
+        if clip_frames < 1:
+            raise ValueError(f"clip_frames must be positive; got {clip_frames}.")
+
+        frames = sample_clip_frames(source, clip_frames)
+        preprocessed = [
+            self.model._preprocess(frame, color_format="rgb", input_size=imgsz)
+            for frame in frames
+        ]
+        tensors = [item[0] for item in preprocessed]
+        original_size = preprocessed[0][2]
+
+        # (F, C, H, W) -> (1, F, C, H, W): one clip in the batch.
+        clip = torch.cat(tensors, dim=0).unsqueeze(0)
+        with torch.no_grad():
+            output = self.model._forward(clip)
+
+        detections = self.model._postprocess(
+            output, conf, iou, original_size, max_det=max_det, classes=classes, **kwargs
+        )
+        result = self._wrap_results(detections, original_size, str(source), classes)
+        result.path = str(source)
+        return [result]
 
     def _save_annotated_image(
         self, result: Results, original_img, save_path: Path

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -172,6 +172,16 @@ class BaseModel(ABC):
     # tensor), so families opt in only after a parity test covers them.
     SUPPORTS_CUDA_GRAPH: ClassVar[bool] = False
 
+    # How a family embeds a finite video under task="embed".
+    #   "frames" (default) — one Results per decoded frame, the historical
+    #       behavior every existing family keeps.
+    #   "clip"            — one Results for the whole clip: frames are sampled
+    #       uniformly, encoded, and pooled by the family into a single row.
+    # Families opt in explicitly; the generic runner takes the clip path only
+    # when the resolved task is "embed", the source is a finite video, and the
+    # family declares clip support.
+    VIDEO_EMBED_MODE: ClassVar[str] = "frames"
+
     # TTA policy — subclasses may override
     TTA_ENABLED: ClassVar[bool] = True
     # True for families that resize to a fixed square regardless of input size

--- a/libreyolo/models/pe/NOTICE.md
+++ b/libreyolo/models/pe/NOTICE.md
@@ -1,0 +1,71 @@
+# LibrePE - third-party notices
+
+The LibrePE family is a native LibreYOLO implementation of Meta's **Perception
+Encoder (PE) Core** dual-tower vision-language encoder
+(<https://arxiv.org/abs/2504.13181>). Neither `timm` nor `open_clip` is
+imported at runtime; both are used only as pinned adaptation sources and as the
+offline parity oracle.
+
+## Adapted code
+
+### huggingface/pytorch-image-models - Apache-2.0
+
+- Upstream: <https://github.com/huggingface/pytorch-image-models>
+- Pinned revision: tag `v1.0.28`, commit `8ef73809f622e0031bd7f4940265734aef8b9978`
+- Files referenced: `timm/models/eva.py`, `timm/layers/pos_embed_sincos.py`,
+  `timm/layers/attention_pool.py`
+- Adapted into `libreyolo/models/pe/nn.py` as `PEVisionTransformer`, `PEBlock`,
+  `PEAttentionRope`, `PEAttentionPoolLatent`, `PatchEmbed`, `Mlp`,
+  `RotaryEmbeddingCat`, `build_rotary_pos_embed`, `apply_rot_embed_cat` and the
+  frequency-band helpers.
+- This is the selected **architecture and configuration** source. The per-size
+  values in `PE_CONFIGS` are transcribed from the `vit_pe_core_*` model
+  definitions.
+
+Licensed under the Apache License, Version 2.0. A copy is available at
+<http://www.apache.org/licenses/LICENSE-2.0>.
+
+### mlfoundations/open_clip - MIT
+
+- Upstream: <https://github.com/mlfoundations/open_clip>
+- Pinned revision: tag `v3.2.0`, commit `6f939057c792a2f3d4d58df748de60ca47c4aed4`
+- File referenced: `src/open_clip/transformer.py`
+- Adapted into `libreyolo/models/pe/nn.py` as `PETextTransformer`,
+  `Transformer` and `ResidualAttentionBlock`.
+- This is the selected **text, projection, preprocessing and parity** source.
+
+### Tokenizer
+
+The OpenAI BPE tokenizer is **reused** from the existing in-tree
+`libreyolo/models/clip/` implementation. No vocabulary or tokenizer code is
+duplicated for this family; that file's own provenance applies.
+
+## Semantic upstream (documentation only)
+
+- `facebookresearch/perception_models`, commit
+  `3e352cca660658d4b5c90f42a7808b11469e4c66`.
+- The repository ships `LICENSE.PE` with Apache-2.0 terms and its root
+  documentation describes PE code and PE checkpoints as Apache-2.0, but the
+  same pinned revision's `setup.py` declares a noncommercial/proprietary
+  package license. **This inconsistency is unresolved.** No code was copied or
+  adapted from that repository; it was used only as behavioral and
+  documentation evidence. The independently permissive timm/OpenCLIP
+  conversion route was selected precisely to avoid the ambiguity.
+- The Perception Language Model (`LICENSE.PLM`, noncommercial), PE Spatial and
+  PE-AV are explicitly out of scope and were not inspected or adapted.
+
+## Weights
+
+Rehosted checkpoints are converted from the OpenCLIP-compatible `timm/PE-Core-*`
+repositories, each of whose model card declares Apache-2.0. Exact repository ids
+and revisions are recorded per checkpoint in `weights/LICENSE_NOTICE.txt` and in
+each checkpoint's own metadata (`source_repo`, `source_revision`,
+`source_license`). These are converted artifacts targeting the OpenCLIP-compatible
+modeling implementation, not unmodified official `facebook/PE-Core-*` package
+checkpoints.
+
+## Datasets
+
+No dataset is downloaded, bundled, mirrored, or required at runtime. In
+particular the published `facebook/PE-Video` dataset is CC-BY-NC-4.0 and is
+**not** used by any test, example, CI job, or download helper.

--- a/libreyolo/models/pe/__init__.py
+++ b/libreyolo/models/pe/__init__.py
@@ -1,0 +1,5 @@
+"""LibrePE - Perception Encoder Core zero-shot classification and embedding."""
+
+from .model import LibrePE
+
+__all__ = ["LibrePE"]

--- a/libreyolo/models/pe/export.py
+++ b/libreyolo/models/pe/export.py
@@ -1,0 +1,176 @@
+"""Task-aware export graphs for LibrePE.
+
+Three separate wrappers, because PE has three distinct exportable behaviors:
+
+* **image embed** - 4D image input to ``[B, D]`` unit rows, class-independent.
+* **frozen-class classify** - 4D image input to ``[B, K]`` logits with the
+  current ``set_classes`` text matrix baked into a final linear projection, so
+  the graph carries neither the text tower nor a tokenizer.
+* **video embed** - fixed-``F`` 5D ``(B, F, C, H, W)`` input to ``[B, D]`` unit
+  rows, pooling frames inside the graph.
+
+Text tokenization is never exported. The exported classify graph is fixed to the
+labels and resolution present at export time.
+
+PE has no ``logit_bias`` (that is a SigLIP concept), so the classify head is
+``logit_scale.exp() * L2norm(image) @ text.T``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class _PEImageEmbedder(nn.Module):
+    """Image tower -> L2-normalized ``[B, D]`` rows."""
+
+    def __init__(self, visual: nn.Module) -> None:
+        super().__init__()
+        self.visual = visual
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        return F.normalize(self.visual(images), dim=-1)
+
+
+class _FrozenPEClassifier(nn.Module):
+    """Image tower + baked text-embedding head -> ``[B, K]`` logits."""
+
+    def __init__(self, visual: nn.Module, weight: torch.Tensor) -> None:
+        super().__init__()
+        self.visual = visual
+        # weight = logit_scale.exp() * text_embeds, shape [K, D].
+        self.register_buffer("weight", weight)
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        feats = F.normalize(self.visual(images), dim=-1)
+        return feats @ self.weight.t()
+
+
+class _PEVideoEmbedder(nn.Module):
+    """Fixed-frame clip tower -> L2-normalized ``[B, D]`` rows.
+
+    Mirrors :meth:`LibrePEModel.encode_video`: flatten ``(B, F)`` into the batch,
+    encode every frame independently, average over ``F``, normalize once.
+    """
+
+    def __init__(self, visual: nn.Module) -> None:
+        super().__init__()
+        self.visual = visual
+
+    def forward(self, clips: torch.Tensor) -> torch.Tensor:
+        b, f = clips.shape[0], clips.shape[1]
+        frames = clips.reshape(b * f, clips.shape[2], clips.shape[3], clips.shape[4])
+        feats = self.visual(frames).reshape(b, f, -1)
+        return F.normalize(feats.mean(dim=1), dim=-1)
+
+
+def _prepare(model, imgsz: Optional[int]):
+    res = int(imgsz or model.input_size)
+    device = next(model.model.visual.parameters()).device
+    visual = model.model.visual.to("cpu").eval()
+    return res, device, visual
+
+
+def _classifier_weight(model) -> torch.Tensor:
+    if model._text_embeds is None:
+        raise RuntimeError("No classes set; call set_classes() before export().")
+    scale = float(model.model.logit_scale.exp().detach().cpu())
+    return scale * model._text_embeds.detach().to("cpu", torch.float32)
+
+
+def _default_name(model, suffix: str, ext: str) -> str:
+    return f"{model.FILENAME_PREFIX}{model.size}-{suffix}.{ext}"
+
+
+def build_export_module(model, kind: str, frames: int = 8):
+    """Build the CPU-resident export graph for ``kind``.
+
+    Returns ``(module, dummy_input, input_names, output_names, original_device)``.
+    The caller must move ``model.model.visual`` back to ``original_device``.
+    """
+    res, device, visual = _prepare(model, None)
+    if kind == "embed":
+        module = _PEImageEmbedder(visual).eval()
+        dummy = torch.zeros(1, 3, res, res)
+        return module, dummy, ["images"], ["embeddings"], device
+    if kind == "classify":
+        module = _FrozenPEClassifier(visual, _classifier_weight(model)).eval()
+        dummy = torch.zeros(1, 3, res, res)
+        return module, dummy, ["images"], ["logits"], device
+    if kind == "video":
+        module = _PEVideoEmbedder(visual).eval()
+        dummy = torch.zeros(1, int(frames), 3, res, res)
+        return module, dummy, ["clip"], ["embeddings"], device
+    raise ValueError(f"Unknown export kind {kind!r}.")
+
+
+def export_onnx(
+    model,
+    kind: str,
+    imgsz: Optional[int] = None,
+    opset: int = 17,
+    output: Optional[str] = None,
+    dynamic_batch: bool = True,
+    frames: int = 8,
+) -> str:
+    """Export one PE graph to ONNX.
+
+    Dynamic batch is enabled by default. The frame count of a video graph is
+    **static**: a dynamic ``F`` is not advertised because it has not been parity
+    tested in the target runtimes.
+    """
+    if opset < 14:
+        raise ValueError("LibrePE ONNX export needs opset >= 14 (ViT attention).")
+
+    module, dummy, input_names, output_names, device = build_export_module(
+        model, kind, frames=frames
+    )
+    suffix = {"embed": "embed", "classify": "cls", "video": "vembed"}[kind]
+    output = str(output or _default_name(model, suffix, "onnx"))
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+
+    dynamic_axes = None
+    if dynamic_batch:
+        dynamic_axes = {input_names[0]: {0: "batch"}, output_names[0]: {0: "batch"}}
+
+    try:
+        with torch.no_grad():
+            torch.onnx.export(
+                module,
+                dummy,
+                output,
+                input_names=input_names,
+                output_names=output_names,
+                opset_version=opset,
+                dynamic_axes=dynamic_axes,
+                dynamo=False,
+            )
+    finally:
+        model.model.visual.to(device)
+    return output
+
+
+def export_torchscript(
+    model,
+    kind: str,
+    imgsz: Optional[int] = None,
+    output: Optional[str] = None,
+    frames: int = 8,
+) -> str:
+    """Export one PE graph to TorchScript via tracing."""
+    module, dummy, _, _, device = build_export_module(model, kind, frames=frames)
+    suffix = {"embed": "embed", "classify": "cls", "video": "vembed"}[kind]
+    output = str(output or _default_name(model, suffix, "torchscript"))
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with torch.no_grad():
+            traced = torch.jit.trace(module, dummy, strict=False)
+            traced.save(output)
+    finally:
+        model.model.visual.to(device)
+    return output

--- a/libreyolo/models/pe/export.py
+++ b/libreyolo/models/pe/export.py
@@ -87,6 +87,61 @@ def _default_name(model, suffix: str, ext: str) -> str:
     return f"{model.FILENAME_PREFIX}{model.size}-{suffix}.{ext}"
 
 
+def build_metadata(model, kind: str, frames: int) -> dict:
+    """Metadata describing an exported PE graph.
+
+    Written into ONNX ``metadata_props`` and the TorchScript
+    ``libreyolo_metadata.json`` extra file, so a reloaded artifact knows its
+    family, task, resolution and -- for clip graphs -- its fixed frame count,
+    tensor layout and pooling rule, instead of falling back to detection
+    defaults.
+    """
+    cfg = model.model.cfg
+    task = "classify" if kind == "classify" else "embed"
+    metadata: dict[str, object] = {
+        "model_family": model.FAMILY,
+        "model_size": model.size,
+        "size": model.size,
+        "task": task,
+        "default_task": model.DEFAULT_TASK,
+        "supported_tasks": list(model.SUPPORTED_TASKS),
+        "imgsz": cfg.image_size,
+        "input_size": cfg.image_size,
+        "embedding_dim": cfg.projection_dim,
+        "pixel_mean": [0.5, 0.5, 0.5],
+        "pixel_std": [0.5, 0.5, 0.5],
+        "input_kind": "video" if kind == "video" else "image",
+    }
+    if kind == "video":
+        metadata.update(
+            {
+                "frames": int(frames),
+                "input_layout": "BFCHW",
+                "video_pool": "mean_frame_embeddings",
+                "video_sampling": (
+                    "uniform over the finite source, endpoints included; the "
+                    "last frame repeats only when decoding yields fewer frames "
+                    "than requested"
+                ),
+                "dynamic_frames": False,
+            }
+        )
+    if kind == "classify":
+        metadata["names"] = [model.names[i] for i in sorted(model.names)]
+        metadata["nc"] = len(model.names)
+    return metadata
+
+
+def _stringify(metadata: dict) -> dict:
+    """ONNX metadata_props values must be strings."""
+    import json
+
+    return {
+        key: value if isinstance(value, str) else json.dumps(value)
+        for key, value in metadata.items()
+    }
+
+
 def build_export_module(model, kind: str, frames: int = 8):
     """Build the CPU-resident export graph for ``kind``.
 
@@ -152,6 +207,10 @@ def export_onnx(
             )
     finally:
         model.model.visual.to(device)
+
+    from ...export.onnx import embed_onnx_metadata
+
+    embed_onnx_metadata(output, _stringify(build_metadata(model, kind, frames)))
     return output
 
 
@@ -168,9 +227,16 @@ def export_torchscript(
     output = str(output or _default_name(model, suffix, "torchscript"))
     Path(output).parent.mkdir(parents=True, exist_ok=True)
     try:
+        import json
+
         with torch.no_grad():
             traced = torch.jit.trace(module, dummy, strict=False)
-            traced.save(output)
+            extra_files = {
+                "libreyolo_metadata.json": json.dumps(
+                    build_metadata(model, kind, frames)
+                )
+            }
+            torch.jit.save(traced, output, _extra_files=extra_files)
     finally:
         model.model.visual.to(device)
     return output

--- a/libreyolo/models/pe/export.py
+++ b/libreyolo/models/pe/export.py
@@ -9,6 +9,14 @@ Three separate wrappers, because PE has three distinct exportable behaviors:
 * **video embed** - fixed-``F`` 5D ``(B, F, C, H, W)`` input to ``[B, D]`` unit
   rows, pooling frames inside the graph.
 
+  This graph is **direct-runtime only**. LibreYOLO's exported-backend
+  preprocessing builds 4D image tensors, so there is no shared 5D video-input
+  contract to drive it through ``LibreYOLO(<artifact>)`` yet. The artifact
+  records ``input_kind="video"`` and the backends refuse to load it with an
+  actionable message rather than failing on an opaque input-rank error; feed it
+  with ``onnxruntime`` / ``torch.jit`` directly. Native parity for the graph is
+  still verified (see ``tests/unit/test_pe_export.py``).
+
 Text tokenization is never exported. The exported classify graph is fixed to the
 labels and resolution present at export time.
 

--- a/libreyolo/models/pe/model.py
+++ b/libreyolo/models/pe/model.py
@@ -451,3 +451,51 @@ class LibrePE(BaseModel):
             "Use set_classes([...]) then predict()/val() for zero-shot "
             "classification, or task='embed' for retrieval."
         )
+
+    # =========================================================================
+    # Export
+    # =========================================================================
+
+    def export(
+        self,
+        format: str = "onnx",
+        video: bool = False,
+        clip_frames: Optional[int] = None,
+        **kwargs,
+    ) -> str:
+        """Export an image-embedding, frozen-class, or fixed-frame video graph.
+
+        The graph is chosen from the loaded task plus ``video=``:
+
+        * ``task='embed'``           -> class-independent ``[B, D]`` unit rows.
+        * ``task='classify'``        -> ``[B, K]`` logits with the current
+          ``set_classes`` matrix baked in (no text tower, no tokenizer).
+        * ``video=True``             -> fixed-``F`` 5D clip graph, ``[B, D]``.
+
+        Only ONNX and TorchScript are implemented; both were parity tested.
+        Other formats are rejected rather than silently advertised.
+        """
+        from .export import export_onnx, export_torchscript
+
+        if video and self.task != "embed":
+            raise ValueError(
+                "Video export produces embeddings; load the model with "
+                "task='embed' to export a clip graph."
+            )
+        kind = "video" if video else ("embed" if self.task == "embed" else "classify")
+        frames = self._validate_clip_frames(
+            clip_frames if clip_frames is not None else self.clip_frames
+        )
+
+        fmt = format.lower()
+        if fmt == "onnx":
+            kwargs.setdefault("opset", 17)
+            return export_onnx(self, kind, frames=frames, **kwargs)
+        if fmt == "torchscript":
+            kwargs.pop("opset", None)
+            kwargs.pop("dynamic_batch", None)
+            return export_torchscript(self, kind, frames=frames, **kwargs)
+        raise NotImplementedError(
+            f"LibrePE export to {format!r} is not implemented. PE ships ONNX and "
+            "TorchScript, the two formats its graphs were parity tested in."
+        )

--- a/libreyolo/models/pe/model.py
+++ b/libreyolo/models/pe/model.py
@@ -1,0 +1,453 @@
+"""LibrePE - Perception Encoder Core zero-shot classification and embedding.
+
+PE Core is Meta's dual-tower vision-language encoder
+(https://arxiv.org/abs/2504.13181). It maps images, finite videos, and text
+into one normalized embedding space::
+
+    from libreyolo import LibreYOLO
+
+    model = LibreYOLO("LibrePEb16-cls.pt")
+    model.set_classes(["a forklift", "an empty aisle", "a spill"])
+    r = model.predict("warehouse.jpg")[0]
+    print(model.names[r.probs.top1], float(r.probs.top1conf))
+
+With ``task="embed"`` image prediction returns one normalized ``(1, D)`` row and
+:meth:`embed_text` returns normalized text rows in the same space::
+
+    embedder = LibreYOLO("LibrePEb16-cls.pt", task="embed")
+    image_rows = embedder.predict("photo.jpg")[0].embeddings
+    text_rows = embedder.embed_text(["a dog", "a cat"])
+
+Unlike every other embedding family, PE also defines a **whole-clip** video
+embedding: frames are sampled uniformly over a finite video, encoded
+independently by the image tower, averaged, then L2-normalized exactly once::
+
+    clip_row = embedder.predict("clip.mp4", clip_frames=8)[0].embeddings
+
+That behavior is opt-in at the family level (``VIDEO_EMBED_MODE = "clip"``);
+every other family keeps its existing frame-by-frame video path. Image *lists*
+remain image batches and are never guessed to be a temporal clip. Live and
+otherwise unbounded sources are rejected rather than buffered.
+
+The towers are a native ``torch`` re-implementation (see :mod:`.nn`); neither
+``timm`` nor ``open_clip`` is imported at runtime. Weights are the Apache-2.0
+OpenCLIP-compatible ``timm/PE-Core-*`` conversions, converted with
+``weights/convert_pe_weights.py``.
+
+Zero-shot only: :meth:`train` raises. See the class docstring of
+:class:`LibrePE` for why PE Core has no supervised training path.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from PIL import Image
+
+from ...tasks import normalize_task
+from ...utils.image_loader import ImageInput, ImageLoader
+from ...utils.serialization import load_trusted_torch_file
+from ..base.model import BaseModel
+from ..clip.labels import (
+    DEFAULT_TEMPLATES,
+    imagenet1k_classnames,
+    openai_imagenet_templates,
+)
+from .nn import PE_CONFIGS, PE_MEAN, PE_STD, build_pe_model
+
+logger = logging.getLogger(__name__)
+
+# LibreYOLO operational default for uniform frame sampling over a finite video.
+# This is a LibreYOLO choice, not a claim about a unique upstream clip length.
+DEFAULT_CLIP_FRAMES = 8
+
+
+class LibrePE(BaseModel):
+    """Perception Encoder Core: zero-shot classifier and image/video/text embedder.
+
+    Inference-only by design, not by omission. PE Core exposes zero-shot
+    classification and foundation embeddings; it has no closed-set supervised
+    head, ``embed`` has no label or task loss in LibreYOLO, and the pinned
+    upstream provides no practical single-GPU PE Core fine-tuning recipe.
+    :meth:`train` therefore rejects immediately rather than silently routing to
+    the generic classification trainer.
+    """
+
+    FAMILY: ClassVar[str] = "pe"
+    FILENAME_PREFIX: ClassVar[str] = "LibrePE"
+    WEIGHT_EXT: ClassVar[str] = ".pt"
+
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {
+        size: cfg.image_size for size, cfg in PE_CONFIGS.items()
+    }
+    SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("classify", "embed")
+    WEIGHT_TASKS: ClassVar[Tuple[str, ...]] = ("classify",)
+    DEFAULT_TASK: ClassVar[str] = "classify"
+    REQUIRE_TASK_SUFFIX: ClassVar[bool] = True
+    TRAIN_CONFIG = None
+
+    # PE pools with a single attention latent over a fixed square resize, so
+    # multi-scale TTA is meaningless.
+    TTA_ENABLED: ClassVar[bool] = False
+
+    # Opt in to the shared finite-video clip-embedding path. Every other family
+    # keeps the default "frames" behavior.
+    VIDEO_EMBED_MODE: ClassVar[str] = "clip"
+
+    validator_class: ClassVar[Optional[type]] = None
+
+    # =========================================================================
+    # Registry classmethods
+    # =========================================================================
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        """PE checkpoints pair an EVA-style RoPE trunk with attention pooling
+        and an OpenCLIP text tower.
+
+        ``visual.trunk.attn_pool.latent`` plus the bias-free
+        ``visual.trunk.patch_embed.proj.weight`` is a signature no other
+        LibreYOLO family carries: CLIP uses ``visual.transformer.*``, SigLIP2
+        uses ``vision_model.embeddings.*``, and DINOv2 has no text tower.
+        """
+        return (
+            "visual.trunk.attn_pool.latent" in weights_dict
+            and "visual.trunk.patch_embed.proj.weight" in weights_dict
+            and "text.text_projection" in weights_dict
+            and "logit_scale" in weights_dict
+        )
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        """Infer size from (trunk width, patch size, context length).
+
+        Width alone is ambiguous-free across the released series, but patch
+        size and context length are checked too so a mismatched or hand-edited
+        checkpoint fails rather than loading as the wrong variant.
+        """
+        patch = weights_dict.get("visual.trunk.patch_embed.proj.weight")
+        pos = weights_dict.get("text.positional_embedding")
+        if patch is None or pos is None:
+            return None
+        width, patch_size, context = (
+            int(patch.shape[0]),
+            int(patch.shape[-1]),
+            int(pos.shape[0]),
+        )
+        for size, cfg in PE_CONFIGS.items():
+            if (
+                cfg.embed_dim == width
+                and cfg.patch_size == patch_size
+                and cfg.context_length == context
+            ):
+                return size
+        return None
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        # Open-vocabulary: no fixed head. The class count is whatever
+        # set_classes() defines (ImageNet-1k on construction).
+        return None
+
+    # =========================================================================
+    # Construction
+    # =========================================================================
+
+    def __init__(
+        self,
+        model_path: str | dict | None = None,
+        size: str | None = None,
+        nb_classes: int | None = None,
+        device: str = "auto",
+        task: str | None = None,
+        templates: Optional[Sequence[str]] = None,
+        classes: Optional[Sequence[str]] = None,
+        clip_frames: int = DEFAULT_CLIP_FRAMES,
+        **kwargs,
+    ) -> None:
+        resolved_task = normalize_task(task) if task is not None else "classify"
+        if resolved_task not in self.SUPPORTED_TASKS:
+            raise ValueError(
+                f"LibrePE supports task in {self.SUPPORTED_TASKS}; got {task!r}."
+            )
+
+        if isinstance(model_path, dict):
+            weight_source: str | dict = model_path
+            if size is None:
+                size = self.detect_size(self._extract_state(model_path))
+        elif isinstance(model_path, str):
+            weight_source = self._resolve_weights_path(model_path)
+            if size is None:
+                size = self.detect_size_from_filename(model_path)
+        else:
+            size = size or "b16"
+            weight_source = self._resolve_weights_path(
+                f"{self.FILENAME_PREFIX}{size}-cls.pt"
+            )
+        size = size or "b16"
+
+        self._default_templates = (
+            list(templates) if templates else list(DEFAULT_TEMPLATES)
+        )
+        self._text_embeds: Optional[torch.Tensor] = None
+        self.clip_frames = self._validate_clip_frames(clip_frames)
+        self.tokenizer = None  # built after super().__init__
+
+        super().__init__(
+            model_path=None,
+            size=size,
+            nb_classes=1000,
+            device=device,
+            task=resolved_task,
+            **kwargs,
+        )
+
+        self._load_weights(weight_source)
+        if isinstance(weight_source, str) and Path(weight_source).is_file():
+            self.model_path = str(weight_source)
+        self.model.eval()
+
+        from ..clip.tokenizer import SimpleTokenizer
+
+        self.tokenizer = SimpleTokenizer(context_length=self.model.context_length)
+
+        if self.task == "classify":
+            self.set_classes(
+                list(classes) if classes is not None else imagenet1k_classnames(),
+                templates=self._default_templates,
+            )
+        else:
+            self.names = {}
+
+    @staticmethod
+    def _validate_clip_frames(clip_frames: int) -> int:
+        frames = int(clip_frames)
+        if frames < 1:
+            raise ValueError(f"clip_frames must be positive; got {clip_frames!r}.")
+        return frames
+
+    @staticmethod
+    def _extract_state(ckpt: dict) -> dict:
+        for key in ("model", "state_dict"):
+            if key in ckpt and isinstance(ckpt[key], dict):
+                return ckpt[key]
+        return ckpt
+
+    # =========================================================================
+    # Open-vocabulary head
+    # =========================================================================
+
+    @torch.no_grad()
+    def _encode_texts(self, texts: List[str], chunk: int = 256) -> torch.Tensor:
+        out: List[torch.Tensor] = []
+        for start in range(0, len(texts), chunk):
+            tokens = self.tokenizer(texts[start : start + chunk]).to(self.device)
+            out.append(F.normalize(self.model.encode_text(tokens), dim=-1))
+        return torch.cat(out, dim=0)
+
+    def embed_text(self, texts: str | Sequence[str]) -> torch.Tensor:
+        """Embed text rows into the same space as image and video embeddings."""
+        items = [texts] if isinstance(texts, str) else list(texts)
+        if any(not isinstance(text, str) for text in items):
+            raise TypeError("embed_text() expects a string or a sequence of strings.")
+        if not items:
+            return torch.empty((0, self.model.embedding_dim), dtype=torch.float32)
+        return self._encode_texts(items).float().cpu()
+
+    def set_classes(
+        self,
+        labels: Sequence[str],
+        templates: Optional[Sequence[str]] = None,
+    ) -> "LibrePE":
+        """Define the (open) class set for zero-shot classification.
+
+        Each label is rendered through every template, encoded, L2-normalized,
+        averaged across templates, then re-normalized. The resulting ``[K, D]``
+        matrix *is* the classifier head and is cached, not recomputed per image.
+        """
+        labels = [str(label) for label in labels]
+        if not labels:
+            raise ValueError("set_classes() requires at least one label.")
+        if self.tokenizer is None:
+            raise RuntimeError("Tokenizer is not initialized; weights must load first.")
+        templates = list(templates) if templates else list(self._default_templates)
+
+        prompts = [tmpl.format(label) for label in labels for tmpl in templates]
+        feats = self._encode_texts(prompts)
+        feats = feats.view(len(labels), len(templates), -1).mean(dim=1)
+        self._text_embeds = F.normalize(feats, dim=-1).to(self.device)
+        self.nb_classes = len(labels)
+        self.names = {i: label for i, label in enumerate(labels)}
+        return self
+
+    @staticmethod
+    def imagenet_ensemble() -> List[str]:
+        """The 80-prompt OpenAI ImageNet template ensemble."""
+        return openai_imagenet_templates()
+
+    # =========================================================================
+    # BaseModel abstract surface
+    # =========================================================================
+
+    def _init_model(self) -> nn.Module:
+        return build_pe_model(self.size)
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        return {
+            "image_tower": self.model.visual,
+            "text_tower": self.model.text,
+        }
+
+    def _build_transform(self, imgsz: int):
+        from torchvision.transforms import InterpolationMode
+
+        from ...data.classify_dataset import build_classify_transforms
+
+        return build_classify_transforms(
+            imgsz,
+            augment=False,
+            mean=PE_MEAN,
+            std=PE_STD,
+            interpolation=InterpolationMode.BILINEAR,
+            crop_pct=1.0,
+            square_resize=True,
+        )
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        import numpy as _np
+        from torchvision.transforms import InterpolationMode
+
+        from ...data.classify_dataset import build_classify_transforms
+
+        def _preprocess_numpy(img_rgb_hwc, input_size=224):
+            res = input_size if isinstance(input_size, int) else input_size[0]
+            transform = build_classify_transforms(
+                res,
+                augment=False,
+                mean=PE_MEAN,
+                std=PE_STD,
+                interpolation=InterpolationMode.BILINEAR,
+                crop_pct=1.0,
+                square_resize=True,
+            )
+            pil = Image.fromarray(_np.asarray(img_rgb_hwc).astype("uint8"))
+            return transform(pil).numpy(), 1.0
+
+        return _preprocess_numpy
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
+        res = input_size if input_size is not None else self.input_size
+        img = ImageLoader.load(image, color_format=color_format)
+        orig_w, orig_h = img.size
+        return self._build_transform(res)(img).unsqueeze(0), img, (orig_w, orig_h), 1.0
+
+    def _forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        tensor = input_tensor.to(self.device)
+        if tensor.ndim == 5:
+            # Whole-clip path: (B, F, C, H, W) -> one normalized row per clip.
+            return self.model.encode_video(tensor).float()
+        image_features = self.model.encode_image(tensor)
+        if self.task == "embed":
+            return F.normalize(image_features.float(), dim=-1)
+        if self._text_embeds is None:
+            raise RuntimeError("No classes set; call set_classes() first.")
+        scale = self.model.logit_scale.exp().to(
+            device=image_features.device, dtype=image_features.dtype
+        )
+        text_embeds = self._text_embeds.to(
+            device=image_features.device, dtype=image_features.dtype
+        )
+        return scale * (F.normalize(image_features, dim=-1) @ text_embeds.t())
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        **kwargs,
+    ) -> Dict:
+        if self.task == "embed":
+            return self._postprocess_embeddings(
+                output,
+                gallery=kwargs.get("gallery"),
+                threshold=kwargs.get("threshold"),
+            )
+        logits = output[0] if isinstance(output, (list, tuple)) else output
+        return {"probs": torch.softmax(logits.float(), dim=-1)[0].cpu()}
+
+    # =========================================================================
+    # Weights I/O
+    # =========================================================================
+
+    def _strict_loading(self) -> bool:
+        return True
+
+    def _load_weights(self, model_path: str | dict) -> None:
+        if isinstance(model_path, dict):
+            loaded = model_path
+        else:
+            path = Path(model_path)
+            if not path.exists():
+                from ...utils.download import download_weights
+
+                download_weights(str(path), self.size)
+            loaded = load_trusted_torch_file(
+                str(model_path), map_location="cpu", context="LibrePE weights"
+            )
+
+        if not isinstance(loaded, dict):
+            raise TypeError("LibrePE checkpoints must be dictionaries.")
+
+        ckpt_family = loaded.get("model_family", "")
+        if ckpt_family and ckpt_family != self.FAMILY:
+            raise RuntimeError(
+                f"Checkpoint was trained with model_family='{ckpt_family}' but is "
+                f"being loaded into '{self.FAMILY}'."
+            )
+        ckpt_task = loaded.get("task")
+        if isinstance(ckpt_task, str) and normalize_task(ckpt_task) not in (
+            "classify",
+            "embed",
+        ):
+            raise RuntimeError(
+                f"Checkpoint task={normalize_task(ckpt_task)!r} is not compatible "
+                "with LibrePE."
+            )
+
+        state = self._extract_state(loaded)
+        if not self.can_load(state):
+            raise RuntimeError(
+                "Checkpoint does not look like a LibrePE model (missing the "
+                "'visual.trunk.attn_pool.latent' / 'text.text_projection' "
+                "signature)."
+            )
+        self.model.load_state_dict(state, strict=self._strict_loading())
+        self.model.to(self.device).eval()
+
+    # =========================================================================
+    # Training is out of scope (zero-shot foundation encoder)
+    # =========================================================================
+
+    def train(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibrePE is inference-only: PE Core exposes zero-shot classification "
+            "and foundation embeddings, not a closed-set supervised head, so "
+            "there is no LibreYOLO task loss to optimize (task='embed' has no "
+            "labels; task='classify' has no learned head). The pinned upstream "
+            "also ships no practical single-GPU PE Core fine-tuning recipe. "
+            "Use set_classes([...]) then predict()/val() for zero-shot "
+            "classification, or task='embed' for retrieval."
+        )

--- a/libreyolo/models/pe/nn.py
+++ b/libreyolo/models/pe/nn.py
@@ -1,0 +1,725 @@
+"""Native PyTorch Perception Encoder (PE) Core towers.
+
+PE Core is a dual-tower vision-language encoder from Meta
+(https://arxiv.org/abs/2504.13181). This module is a **native LibreYOLO
+re-implementation** -- neither ``timm`` nor ``open_clip`` is imported at
+runtime.
+
+Code provenance
+---------------
+The architecture is adapted from two permissively licensed sources, pinned to
+the exact revisions used to validate exact parity:
+
+* Vision tower (``PEVisionTransformer``, ``PEBlock``, ``PEAttentionRope``,
+  ``PEAttentionPoolLatent``, ``RotaryEmbeddingCat`` and the fourier/rope
+  helpers) is adapted from **huggingface/pytorch-image-models v1.0.28**
+  (commit ``8ef73809f622e0031bd7f4940265734aef8b9978``), Apache-2.0, files
+  ``timm/models/eva.py``, ``timm/layers/pos_embed_sincos.py`` and
+  ``timm/layers/attention_pool.py``.
+* Text tower (``PETextTransformer``, ``ResidualAttentionBlock``) is adapted
+  from **mlfoundations/open_clip v3.2.0** (commit
+  ``6f939057c792a2f3d4d58df748de60ca47c4aed4``), MIT, file
+  ``src/open_clip/transformer.py``.
+
+Module and parameter names deliberately mirror the upstream OpenCLIP-converted
+checkpoint layout (``visual.trunk.*`` / ``text.*`` / ``logit_scale``) so that
+conversion is a strict metadata-wrap with no key remapping.
+
+See ``libreyolo/models/pe/NOTICE.md`` for the full notice text.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = [
+    "PE_CONFIGS",
+    "PEConfig",
+    "LibrePEModel",
+    "build_pe_model",
+]
+
+
+# =============================================================================
+# Closed configuration table
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class PEConfig:
+    """Complete, closed configuration for one PE Core size.
+
+    Values are transcribed from the pinned timm model definitions
+    (``vit_pe_core_*`` in ``timm/models/eva.py`` v1.0.28) and the pinned
+    OpenCLIP model configs (``PE-Core-*`` in open_clip v3.2.0). The converter
+    asserts every field against the source config; an unknown or changed
+    upstream config must fail rather than silently produce a wrong model.
+    """
+
+    # vision trunk
+    image_size: int
+    patch_size: int
+    embed_dim: int
+    depth: int
+    num_heads: int
+    mlp_ratio: float
+    ref_feat_shape: Tuple[int, int]
+    rope_grid_offset: float
+    class_token: bool
+    attn_pool_num_heads: int
+    attn_pool_mlp_ratio: float
+    # shared projection dim (the joint image/text embedding space)
+    projection_dim: int
+    # text tower
+    text_width: int
+    text_heads: int
+    text_layers: int
+    context_length: int
+    vocab_size: int
+    # upstream identity
+    timm_model_name: str
+    open_clip_model_name: str
+
+    @property
+    def grid_size(self) -> Tuple[int, int]:
+        side = self.image_size // self.patch_size
+        return (side, side)
+
+    @property
+    def num_patches(self) -> int:
+        return self.grid_size[0] * self.grid_size[1]
+
+    @property
+    def num_prefix_tokens(self) -> int:
+        return 1 if self.class_token else 0
+
+    @property
+    def head_dim(self) -> int:
+        return self.embed_dim // self.num_heads
+
+
+PE_CONFIGS: Dict[str, PEConfig] = {
+    "t16": PEConfig(
+        image_size=384,
+        patch_size=16,
+        embed_dim=192,
+        depth=12,
+        num_heads=3,
+        mlp_ratio=4.0,
+        ref_feat_shape=(24, 24),
+        rope_grid_offset=1.0,
+        class_token=True,
+        attn_pool_num_heads=8,
+        attn_pool_mlp_ratio=4.0,
+        projection_dim=512,
+        text_width=512,
+        text_heads=8,
+        text_layers=12,
+        context_length=32,
+        vocab_size=49408,
+        timm_model_name="vit_pe_core_tiny_patch16_384",
+        open_clip_model_name="PE-Core-T-16-384",
+    ),
+    "s16": PEConfig(
+        image_size=384,
+        patch_size=16,
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        mlp_ratio=4.0,
+        ref_feat_shape=(24, 24),
+        rope_grid_offset=1.0,
+        class_token=True,
+        attn_pool_num_heads=8,
+        attn_pool_mlp_ratio=4.0,
+        projection_dim=512,
+        text_width=512,
+        text_heads=8,
+        text_layers=12,
+        context_length=32,
+        vocab_size=49408,
+        timm_model_name="vit_pe_core_small_patch16_384",
+        open_clip_model_name="PE-Core-S-16-384",
+    ),
+    "b16": PEConfig(
+        image_size=224,
+        patch_size=16,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        mlp_ratio=4.0,
+        ref_feat_shape=(14, 14),
+        rope_grid_offset=1.0,
+        class_token=True,
+        attn_pool_num_heads=8,
+        attn_pool_mlp_ratio=4.0,
+        projection_dim=1024,
+        text_width=1024,
+        text_heads=16,
+        text_layers=24,
+        context_length=32,
+        vocab_size=49408,
+        timm_model_name="vit_pe_core_base_patch16_224",
+        open_clip_model_name="PE-Core-B-16",
+    ),
+    "l14": PEConfig(
+        image_size=336,
+        patch_size=14,
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        mlp_ratio=4.0,
+        ref_feat_shape=(24, 24),
+        rope_grid_offset=1.0,
+        class_token=True,
+        attn_pool_num_heads=8,
+        attn_pool_mlp_ratio=4.0,
+        projection_dim=1024,
+        text_width=1024,
+        text_heads=16,
+        text_layers=24,
+        context_length=32,
+        vocab_size=49408,
+        timm_model_name="vit_pe_core_large_patch14_336",
+        open_clip_model_name="PE-Core-L-14-336",
+    ),
+    "g14": PEConfig(
+        image_size=448,
+        patch_size=14,
+        embed_dim=1536,
+        depth=50,
+        num_heads=16,
+        mlp_ratio=8960 / 1536,
+        ref_feat_shape=(32, 32),
+        # The gigantic variant is the one size that does NOT set
+        # rope_grid_offset upstream, and drops the class token.
+        rope_grid_offset=0.0,
+        class_token=False,
+        attn_pool_num_heads=8,
+        attn_pool_mlp_ratio=4.0,
+        projection_dim=1280,
+        text_width=1280,
+        text_heads=20,
+        text_layers=24,
+        context_length=72,
+        vocab_size=49408,
+        timm_model_name="vit_pe_core_gigantic_patch14_448",
+        open_clip_model_name="PE-Core-bigG-14-448",
+    ),
+}
+
+# PE preprocessing is symmetric [-1, 1], NOT ImageNet or CLIP statistics.
+PE_MEAN: Tuple[float, float, float] = (0.5, 0.5, 0.5)
+PE_STD: Tuple[float, float, float] = (0.5, 0.5, 0.5)
+
+
+# =============================================================================
+# Rotary position embedding (adapted from timm/layers/pos_embed_sincos.py)
+# =============================================================================
+
+
+def _freq_bands(num_bands: int, temperature: float = 10000.0) -> torch.Tensor:
+    exp = (
+        torch.arange(0, num_bands, 1, dtype=torch.int64).to(torch.float32) / num_bands
+    )
+    return 1.0 / (temperature**exp)
+
+
+def _swap_shape_xy(shape: Tuple[int, ...]) -> Tuple[int, ...]:
+    return tuple(reversed(shape))
+
+
+def build_rotary_pos_embed(
+    feat_shape: Tuple[int, int],
+    dim: int,
+    temperature: float = 10000.0,
+    ref_feat_shape: Optional[Tuple[int, int]] = None,
+    grid_offset: float = 0.0,
+    grid_indexing: str = "xy",
+    device: Optional[torch.device] = None,
+    dtype: torch.dtype = torch.float32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Concatenated sin/cos rotary embedding in EVA's "language" (non-pixel) mode.
+
+    Mirrors ``timm.layers.pos_embed_sincos.build_rotary_pos_embed`` with
+    ``in_pixels=False``, which is what ``attn_type='rope'`` EVA/PE models use.
+    """
+    num_bands = dim // 4
+    bands = _freq_bands(num_bands, temperature=temperature).to(device=device)
+
+    if grid_indexing == "xy":
+        feat_shape = _swap_shape_xy(feat_shape)
+        if ref_feat_shape is not None:
+            ref_feat_shape = _swap_shape_xy(ref_feat_shape)
+
+    t = [
+        torch.arange(s, device=device, dtype=torch.int64).to(torch.float32)
+        + grid_offset
+        for s in feat_shape
+    ]
+    if ref_feat_shape is not None:
+        # EVA's scheme for resizing rope embeddings (ref shape = pretrain shape).
+        t = [x / f * r for x, f, r in zip(t, feat_shape, ref_feat_shape)]
+
+    grid = torch.stack(torch.meshgrid(t, indexing=grid_indexing), dim=-1)
+    grid = grid.unsqueeze(-1)
+    pos = grid * bands
+
+    num_spatial_dim = 1
+    for x in feat_shape:
+        num_spatial_dim *= x
+
+    sin_emb = pos.sin().to(dtype=dtype).reshape(num_spatial_dim, -1)
+    cos_emb = pos.cos().to(dtype=dtype).reshape(num_spatial_dim, -1)
+    return sin_emb.repeat_interleave(2, -1), cos_emb.repeat_interleave(2, -1)
+
+
+def _rot(x: torch.Tensor) -> torch.Tensor:
+    """``[x0, x1, x2, x3] -> [-x1, x0, -x3, x2]`` (interleaved rotation)."""
+    return torch.stack([-x[..., 1::2], x[..., ::2]], -1).reshape(x.shape)
+
+
+def apply_rot_embed_cat(x: torch.Tensor, emb: torch.Tensor) -> torch.Tensor:
+    sin_emb, cos_emb = emb.chunk(2, -1)
+    return x * cos_emb + _rot(x) * sin_emb
+
+
+class RotaryEmbeddingCat(nn.Module):
+    """Rotary position embedding with concatenated sin/cos, cached for a fixed grid.
+
+    Adapted from ``timm.layers.pos_embed_sincos.RotaryEmbeddingCat``. PE always
+    uses a static feature shape (``dynamic_img_size`` is disabled upstream), so
+    only the cached-embedding path is implemented here.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        feat_shape: Tuple[int, int],
+        temperature: float = 10000.0,
+        ref_feat_shape: Optional[Tuple[int, int]] = None,
+        grid_offset: float = 0.0,
+        grid_indexing: str = "xy",
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.feat_shape = feat_shape
+        self.temperature = temperature
+        self.ref_feat_shape = ref_feat_shape
+        self.grid_offset = grid_offset
+        self.grid_indexing = grid_indexing
+
+        sin_emb, cos_emb = build_rotary_pos_embed(
+            feat_shape=feat_shape,
+            dim=dim,
+            temperature=temperature,
+            ref_feat_shape=ref_feat_shape,
+            grid_offset=grid_offset,
+            grid_indexing=grid_indexing,
+        )
+        # Non-persistent: the embedding is fully determined by the config, so it
+        # must not appear in (or be required by) the checkpoint state dict.
+        self.register_buffer(
+            "pos_embed_cat",
+            torch.cat([sin_emb, cos_emb], dim=-1),
+            persistent=False,
+        )
+
+    def get_embed(self) -> torch.Tensor:
+        return self.pos_embed_cat
+
+
+# =============================================================================
+# Vision tower (adapted from timm/models/eva.py)
+# =============================================================================
+
+
+class Mlp(nn.Module):
+    """Standard transformer MLP (timm ``Mlp`` with default GELU / no norm)."""
+
+    def __init__(self, in_features: int, hidden_features: int) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(hidden_features, in_features)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+class PatchEmbed(nn.Module):
+    """Image to patch embedding. PE uses a bias-free patch projection."""
+
+    def __init__(self, patch_size: int, in_chans: int, embed_dim: int) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.proj = nn.Conv2d(
+            in_chans, embed_dim, kernel_size=patch_size, stride=patch_size, bias=False
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.proj(x)
+        return x.flatten(2).transpose(1, 2)  # (B, N, C)
+
+
+class PEAttentionRope(nn.Module):
+    """Fused-QKV self-attention with rotary embeddings applied to non-prefix tokens.
+
+    Adapted from ``timm.models.eva.EvaAttention`` restricted to the
+    configuration PE uses: fused qkv with bias, no q/k norm, no attention
+    gating, no inner scale-norm, interleaved (non-half) rotation.
+    """
+
+    def __init__(self, dim: int, num_heads: int, num_prefix_tokens: int) -> None:
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError(f"dim {dim} not divisible by num_heads {num_heads}")
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.num_prefix_tokens = num_prefix_tokens
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=True)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor, rope: Optional[torch.Tensor]) -> torch.Tensor:
+        B, N, C = x.shape
+        qkv = (
+            self.qkv(x)
+            .reshape(B, N, 3, self.num_heads, self.head_dim)
+            .permute(2, 0, 3, 1, 4)
+        )
+        q, k, v = qkv.unbind(0)  # (B, heads, N, head_dim)
+
+        if rope is not None:
+            npt = self.num_prefix_tokens
+            q = torch.cat(
+                [q[:, :, :npt, :], apply_rot_embed_cat(q[:, :, npt:, :], rope)], dim=2
+            ).type_as(v)
+            k = torch.cat(
+                [k[:, :, :npt, :], apply_rot_embed_cat(k[:, :, npt:, :], rope)], dim=2
+            ).type_as(v)
+
+        x = F.scaled_dot_product_attention(q, k, v)
+        x = x.transpose(1, 2).reshape(B, N, C)
+        return self.proj(x)
+
+
+class PEBlock(nn.Module):
+    """Pre-norm transformer block (timm ``EvaBlock`` in its PE configuration)."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_ratio: float,
+        num_prefix_tokens: int,
+        norm_eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim, eps=norm_eps)
+        self.attn = PEAttentionRope(dim, num_heads, num_prefix_tokens)
+        self.norm2 = nn.LayerNorm(dim, eps=norm_eps)
+        self.mlp = Mlp(dim, int(round(dim * mlp_ratio)))
+
+    def forward(self, x: torch.Tensor, rope: Optional[torch.Tensor]) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), rope=rope)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class PEAttentionPoolLatent(nn.Module):
+    """Single-latent attention pooling head (timm ``AttentionPoolLatent``).
+
+    PE uses 8 pooling heads regardless of trunk width, one latent query, an
+    MLP residual, and token pooling of the single latent.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_ratio: float,
+        norm_eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError(f"dim {dim} not divisible by attn_pool heads {num_heads}")
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.latent_len = 1
+
+        self.latent = nn.Parameter(torch.zeros(1, self.latent_len, dim))
+        self.q = nn.Linear(dim, dim, bias=True)
+        self.kv = nn.Linear(dim, dim * 2, bias=True)
+        self.proj = nn.Linear(dim, dim)
+        self.norm = nn.LayerNorm(dim, eps=norm_eps)
+        self.mlp = Mlp(dim, int(round(dim * mlp_ratio)))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, N, C = x.shape
+        q_latent = self.latent.expand(B, -1, -1)
+        q = (
+            self.q(q_latent)
+            .reshape(B, self.latent_len, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        kv = (
+            self.kv(x)
+            .reshape(B, N, 2, self.num_heads, self.head_dim)
+            .permute(2, 0, 3, 1, 4)
+        )
+        k, v = kv.unbind(0)
+
+        x = F.scaled_dot_product_attention(q, k, v)
+        x = x.transpose(1, 2).reshape(B, self.latent_len, C)
+        x = self.proj(x)
+        x = x + self.mlp(self.norm(x))
+        return x[:, 0]
+
+
+class PEVisionTransformer(nn.Module):
+    """PE Core vision trunk: RoPE ViT with attention pooling and a linear head.
+
+    Mirrors the timm ``Eva`` submodule names so that OpenCLIP-converted PE
+    checkpoints (``visual.trunk.*``) load strictly with no key remapping.
+    """
+
+    def __init__(self, cfg: PEConfig, norm_eps: float = 1e-5) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.num_prefix_tokens = cfg.num_prefix_tokens
+
+        self.patch_embed = PatchEmbed(cfg.patch_size, 3, cfg.embed_dim)
+
+        self.cls_token = (
+            nn.Parameter(torch.zeros(1, 1, cfg.embed_dim)) if cfg.class_token else None
+        )
+        num_pos_tokens = cfg.num_patches + self.num_prefix_tokens
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_pos_tokens, cfg.embed_dim))
+
+        self.rope = RotaryEmbeddingCat(
+            dim=cfg.head_dim,
+            feat_shape=cfg.grid_size,
+            ref_feat_shape=cfg.ref_feat_shape,
+            grid_offset=cfg.rope_grid_offset,
+            grid_indexing="xy",
+        )
+
+        self.norm_pre = nn.LayerNorm(cfg.embed_dim, eps=norm_eps)
+        self.blocks = nn.ModuleList(
+            [
+                PEBlock(
+                    dim=cfg.embed_dim,
+                    num_heads=cfg.num_heads,
+                    mlp_ratio=cfg.mlp_ratio,
+                    num_prefix_tokens=self.num_prefix_tokens,
+                    norm_eps=norm_eps,
+                )
+                for _ in range(cfg.depth)
+            ]
+        )
+        self.norm = nn.LayerNorm(cfg.embed_dim, eps=norm_eps)
+
+        self.attn_pool = PEAttentionPoolLatent(
+            dim=cfg.embed_dim,
+            num_heads=cfg.attn_pool_num_heads,
+            mlp_ratio=cfg.attn_pool_mlp_ratio,
+            norm_eps=norm_eps,
+        )
+        self.head = nn.Linear(cfg.embed_dim, cfg.projection_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)
+        if self.cls_token is not None:
+            x = torch.cat([self.cls_token.expand(x.shape[0], -1, -1), x], dim=1)
+        x = x + self.pos_embed
+
+        rope = self.rope.get_embed()
+        x = self.norm_pre(x)
+        for blk in self.blocks:
+            x = blk(x, rope=rope)
+        x = self.norm(x)
+
+        x = self.attn_pool(x)
+        return self.head(x)
+
+
+class PEVisualWrapper(nn.Module):
+    """Thin ``visual.trunk`` container matching the OpenCLIP ``TimmModel`` layout."""
+
+    def __init__(self, cfg: PEConfig) -> None:
+        super().__init__()
+        self.trunk = PEVisionTransformer(cfg)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.trunk(x)
+
+
+# =============================================================================
+# Text tower (adapted from open_clip/transformer.py)
+# =============================================================================
+
+
+class ResidualAttentionBlock(nn.Module):
+    """OpenCLIP residual attention block.
+
+    Uses ``nn.MultiheadAttention`` exactly as upstream does, so the fused
+    attention kernel -- and therefore the numerics -- are identical.
+    """
+
+    def __init__(self, d_model: int, n_head: int, mlp_ratio: float = 4.0) -> None:
+        super().__init__()
+        self.ln_1 = nn.LayerNorm(d_model)
+        # batch_first=True matches open_clip v3.2.0, which keeps the sequence in
+        # NLD throughout. Running seq-first instead changes the attention kernel
+        # and costs exact parity (~6e-6).
+        self.attn = nn.MultiheadAttention(d_model, n_head, batch_first=True)
+        self.ln_2 = nn.LayerNorm(d_model)
+        mlp_width = int(d_model * mlp_ratio)
+        self.mlp = nn.Sequential()
+        self.mlp.add_module("c_fc", nn.Linear(d_model, mlp_width))
+        self.mlp.add_module("gelu", nn.GELU())
+        self.mlp.add_module("c_proj", nn.Linear(mlp_width, d_model))
+
+    def attention(
+        self, q_x: torch.Tensor, attn_mask: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        attn_mask = attn_mask.to(q_x.dtype) if attn_mask is not None else None
+        return self.attn(q_x, q_x, q_x, need_weights=False, attn_mask=attn_mask)[0]
+
+    def forward(
+        self, x: torch.Tensor, attn_mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        x = x + self.attention(self.ln_1(x), attn_mask=attn_mask)
+        x = x + self.mlp(self.ln_2(x))
+        return x
+
+
+class Transformer(nn.Module):
+    def __init__(self, width: int, layers: int, heads: int) -> None:
+        super().__init__()
+        self.resblocks = nn.ModuleList(
+            [ResidualAttentionBlock(width, heads) for _ in range(layers)]
+        )
+
+    def forward(
+        self, x: torch.Tensor, attn_mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        for blk in self.resblocks:
+            x = blk(x, attn_mask=attn_mask)
+        return x
+
+
+class PETextTransformer(nn.Module):
+    """OpenCLIP ``TextTransformer`` with argmax (EOT) pooling and a linear projection."""
+
+    def __init__(self, cfg: PEConfig) -> None:
+        super().__init__()
+        self.context_length = cfg.context_length
+        self.vocab_size = cfg.vocab_size
+
+        self.token_embedding = nn.Embedding(cfg.vocab_size, cfg.text_width)
+        self.positional_embedding = nn.Parameter(
+            torch.empty(cfg.context_length, cfg.text_width)
+        )
+        self.transformer = Transformer(cfg.text_width, cfg.text_layers, cfg.text_heads)
+        self.ln_final = nn.LayerNorm(cfg.text_width)
+        self.text_projection = nn.Parameter(
+            torch.empty(cfg.text_width, cfg.projection_dim)
+        )
+
+        self.register_buffer(
+            "attn_mask", self._build_causal_mask(cfg.context_length), persistent=False
+        )
+
+    @staticmethod
+    def _build_causal_mask(context_length: int) -> torch.Tensor:
+        mask = torch.empty(context_length, context_length)
+        mask.fill_(float("-inf"))
+        mask.triu_(1)
+        return mask
+
+    def forward(self, text: torch.Tensor) -> torch.Tensor:
+        seq_len = text.shape[1]
+        x = self.token_embedding(text)
+        x = x + self.positional_embedding[:seq_len]
+        # Sequence stays in NLD (batch-first) end to end, as upstream does.
+        x = self.transformer(x, attn_mask=self.attn_mask[:seq_len, :seq_len])
+        x = self.ln_final(x)
+        # EOT pooling: the highest token id in each row is the EOT marker.
+        pooled = x[torch.arange(x.shape[0], device=x.device), text.argmax(dim=-1)]
+        return pooled @ self.text_projection
+
+
+# =============================================================================
+# Full dual-tower model
+# =============================================================================
+
+
+class LibrePEModel(nn.Module):
+    """PE Core dual-tower model: image tower, text tower, learned logit scale."""
+
+    def __init__(self, cfg: PEConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.visual = PEVisualWrapper(cfg)
+        self.text = PETextTransformer(cfg)
+        self.logit_scale = nn.Parameter(torch.ones([]) * math.log(1 / 0.07))
+
+    # -- properties mirroring the sibling zero-shot families -----------------
+
+    @property
+    def context_length(self) -> int:
+        return self.cfg.context_length
+
+    @property
+    def embedding_dim(self) -> int:
+        return self.cfg.projection_dim
+
+    @property
+    def image_size(self) -> int:
+        return self.cfg.image_size
+
+    # -- encoders ------------------------------------------------------------
+
+    def encode_image(self, images: torch.Tensor) -> torch.Tensor:
+        """Un-normalized image embeddings ``(B, D)``."""
+        return self.visual(images)
+
+    def encode_text(self, tokens: torch.Tensor) -> torch.Tensor:
+        """Un-normalized text embeddings ``(B, D)``."""
+        return self.text(tokens)
+
+    def encode_video(self, clips: torch.Tensor) -> torch.Tensor:
+        """Whole-clip embeddings ``(B, D)`` from a ``(B, F, C, H, W)`` tensor.
+
+        PE defines a video embedding as the arithmetic mean of independently
+        encoded frame embeddings, L2-normalized exactly once at the end.
+        """
+        if clips.ndim != 5:
+            raise ValueError(
+                "encode_video expects a 5D (B, F, C, H, W) tensor; "
+                f"got shape {tuple(clips.shape)}."
+            )
+        b, f = clips.shape[:2]
+        frames = clips.reshape(b * f, *clips.shape[2:])
+        feats = self.encode_image(frames).reshape(b, f, -1)
+        return F.normalize(feats.mean(dim=1), dim=-1)
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        return self.encode_image(images)
+
+
+def build_pe_model(size: str) -> LibrePEModel:
+    """Instantiate a PE Core model from the closed configuration table."""
+    if size not in PE_CONFIGS:
+        raise ValueError(
+            f"Unknown PE size {size!r}; expected one of {tuple(PE_CONFIGS)}."
+        )
+    return LibrePEModel(PE_CONFIGS[size])

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -49,6 +49,8 @@ MODEL_GROUPS: dict[str, str] = {
     "mobilenetv4": "g2",
     "efficientnetv2": "g2",
     "domedetr": "g2",
+    # s - sibling / zero-shot APIs covered separately
+    "pe": "s",
     # g3 - inference-only specialists
     "lwdetr": "g3",
     "detr": "g3",

--- a/libreyolo/utils/serialization.py
+++ b/libreyolo/utils/serialization.py
@@ -325,6 +325,34 @@ def validate_checkpoint_metadata(
     return errors
 
 
+def reject_unsupported_input_kind(metadata: Any, *, artifact: str) -> None:
+    """Refuse to load an exported graph whose input rank the backends cannot feed.
+
+    Most exported artifacts take a 4D ``(B, C, H, W)`` image tensor, and the
+    shared preprocessing path builds exactly that. An artifact that records
+    ``input_kind="video"`` wants a 5D ``(B, F, C, H, W)`` clip instead. Until
+    the shared video-input backend contract exists, loading such a graph would
+    silently run frame-by-frame image preprocessing and fail with an opaque
+    input-rank error deep inside the runtime. Fail here instead, with the
+    reason and the working alternative.
+    """
+    if not isinstance(metadata, dict):
+        return
+    input_kind = metadata.get("input_kind")
+    if isinstance(input_kind, str) and input_kind.lower() == "video":
+        frames = metadata.get("frames")
+        raise NotImplementedError(
+            f"{artifact} is a fixed-frame video-embedding graph "
+            f"(input_kind='video'"
+            + (f", frames={frames}" if frames is not None else "")
+            + "), which expects a 5D (B, F, C, H, W) clip tensor. LibreYOLO's "
+            "exported-backend preprocessing currently builds 4D image tensors "
+            "only, so this artifact cannot be driven through LibreYOLO(...) "
+            "yet. Feed it directly with onnxruntime / torch.jit, or use the "
+            "image-embedding export and pool frames yourself."
+        )
+
+
 def warn_on_metadata_schema_version(
     metadata: Any,
     *,

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -3,7 +3,7 @@
 import logging
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Generator, Iterator, Protocol, Tuple, Union
+from typing import Any, Callable, Generator, Iterator, List, Protocol, Tuple, Union
 
 import numpy as np
 
@@ -275,6 +275,71 @@ class VideoWriter:
 # ---------------------------------------------------------------------------
 
 _LARGE_VIDEO_THRESHOLD = 500
+
+
+def uniform_frame_indices(total_frames: int, num_frames: int) -> List[int]:
+    """Deterministic uniform frame indices over a finite video.
+
+    The sampling rule is fixed so validation and inference agree:
+
+    * the temporal endpoints are always included when at least two frames are
+      requested and available;
+    * the last available frame is repeated **only** when the video yields fewer
+      frames than requested.
+
+    Args:
+        total_frames: Number of frames the video actually decodes.
+        num_frames: Number of frames to sample (must be positive).
+
+    Returns:
+        A list of ``num_frames`` frame indices in non-decreasing order.
+    """
+    if num_frames < 1:
+        raise ValueError(f"num_frames must be positive; got {num_frames}.")
+    if total_frames < 1:
+        raise ValueError("Video decoded zero frames.")
+    if num_frames == 1 or total_frames == 1:
+        return [0] * num_frames if total_frames == 1 else [0]
+    if total_frames >= num_frames:
+        step = (total_frames - 1) / (num_frames - 1)
+        return [int(round(i * step)) for i in range(num_frames)]
+    # Short video: take every frame, then hold the last one.
+    return list(range(total_frames)) + [total_frames - 1] * (num_frames - total_frames)
+
+
+def sample_clip_frames(path: Union[str, Path], num_frames: int) -> List:
+    """Uniformly sample ``num_frames`` RGB ``PIL.Image`` frames from a finite video.
+
+    Family-independent: decoding and sampling live here, while tensor layout,
+    preprocessing and temporal pooling stay family-local.
+    """
+    import cv2
+    from PIL import Image
+
+    with VideoSource(path) as source:
+        total = int(source.total_frames)
+        cap = source._cap
+        if total < 1:
+            # Some containers do not report a frame count; fall back to a scan.
+            total = 0
+            while cap.grab():
+                total += 1
+            cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+        if total < 1:
+            raise ValueError(f"Video decoded zero frames: {path}")
+
+        wanted = uniform_frame_indices(total, num_frames)
+        frames = []
+        for index in wanted:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, index)
+            ok, frame_bgr = cap.read()
+            if not ok:
+                if not frames:
+                    raise ValueError(f"Could not decode frame {index} of {path}.")
+                frames.append(frames[-1])
+                continue
+            frames.append(Image.fromarray(frame_bgr[:, :, ::-1].copy()))
+    return frames
 
 
 def collect_video_results(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -492,6 +492,7 @@ markers = [
     "modus: tests covering the external-weight LibreMODUS any-to-any family",
     "clip: tests covering the LibreCLIP zero-shot open-vocabulary classifier family",
     "siglip2: tests covering the LibreSigLIP2 zero-shot open-vocabulary classifier family",
+    "pe: tests covering the LibrePE Perception Encoder Core zero-shot / embedding family",
     "midas: tests covering the MiDaS relative-depth family",
     "distributed: multi-rank gloo tests that mp.spawn a process group. Linux-only in the PR gate: they exercise distributed-training math, which is platform-independent, while dist.init_process_group(backend='gloo') costs ~105s per test on the macOS runner (a bare 2-rank scalar all-reduce takes 109s there vs 3.9s on Linux). They also compare a parent-process reference gradient against child-process gradients at a BLAS-sensitive tolerance, so running them on every OS yields flakes rather than coverage. The spawn-plumbing tests are deliberately NOT marked: they cover spawn-only failure modes that Linux's fork never hits.",
     "rf1: RF1 training tests",

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -2034,5 +2034,32 @@
     "optional_extra": null,
     "available": true,
     "group": "g3"
+  },
+  "pe": {
+    "class": "libreyolo.models.pe.model.LibrePE",
+    "tasks": [
+      "classify",
+      "embed"
+    ],
+    "default_task": "classify",
+    "sizes": {
+      "t16": 384,
+      "s16": 384,
+      "b16": 224,
+      "l14": 336,
+      "g14": 448
+    },
+    "default_imgsz": {
+      "t16": 384,
+      "s16": 384,
+      "b16": 224,
+      "l14": 336,
+      "g14": 448
+    },
+    "task_sizes": {},
+    "export_override": "custom",
+    "optional_extra": null,
+    "available": true,
+    "group": "s"
   }
 }

--- a/skills/libreyolo-upload-hf-model/SKILL.md
+++ b/skills/libreyolo-upload-hf-model/SKILL.md
@@ -80,6 +80,7 @@ file = name + ".pt"
 | Swin | `LibreSwin` | `LibreSwint-cls.pt` (Swin V1; MIT weights; inference-only) |
 | CLIP | `LibreCLIP` | `LibreCLIPb32-cls.pt` (zero-shot, open-vocab classify) |
 | SigLIP2 | `LibreSigLIP2` | `LibreSigLIP2b16-cls.pt` (zero-shot, open-vocab classify) |
+| PE | `LibrePE` | `LibrePEb16-cls.pt` (Perception Encoder Core; zero-shot classify + image/text/video embed) |
 | NAFNet | `LibreNAFNet` | `LibreNAFNets-restore.pt` (restore-only; `-sidd` variant = SIDD denoise) |
 | BiRefNet | `LibreBiRefNet` | `LibreBiRefNetl-matte.pt` (matte / background-removal; `l` is MIT, `t`/lite has no explicit weights-license tag) |
 | FeyNobg | `LibreFeyNobg` | `LibreFeyNobgl-matte.pt` (matte / background-removal; Apache-2.0 code+weights; also ships `-fp8`/`-nvfp4` pre-quantized repos, see below) |
@@ -241,6 +242,9 @@ LibreCLIPb32-cls.pt, LibreCLIPb16-cls.pt, LibreCLIPl14-cls.pt,
 
 LibreSigLIP2b16-cls.pt, LibreSigLIP2so400m-cls.pt,
 
+LibrePEt16-cls.pt, LibrePEs16-cls.pt, LibrePEb16-cls.pt,
+LibrePEl14-cls.pt, LibrePEg14-cls.pt,
+
 LibreNAFNets-restore.pt, LibreNAFNetl-restore.pt,
 LibreNAFNetl-restore-sidd.pt,
 
@@ -348,6 +352,18 @@ use `pipeline_tag: zero-shot-image-classification`, `license: apache-2.0`
 upstream repo and commit pin), note the vendored SentencePiece tokenizer, and
 omit the VA Benchmarks section. Conversion is a metadata wrap
 (`weights/convert_siglip2_weights.py`); learned parameters are unchanged.
+
+LibrePE is the Perception Encoder Core zero-shot classifier and embedder. Its HF
+cards use `pipeline_tag: zero-shot-image-classification`, `license: apache-2.0`
+(weights derive from the Apache-2.0 OpenCLIP-compatible `timm/PE-Core-*`
+repositories — state the repo **and** the exact revision pin), and omit the VA
+Benchmarks section. The cards must say the artifact is a **converted
+OpenCLIP-compatible** PE Core checkpoint, not an unmodified official
+`facebook/PE-Core-*` package checkpoint, and must not repeat any claim from the
+official `perception_models` repository, whose `LICENSE.PE` (Apache-2.0)
+conflicts with its `setup.py` package license. Conversion is a metadata wrap
+(`weights/convert_pe_weights.py`); learned parameters are unchanged. Note the
+`g14` memory profile (1.88B-parameter vision tower) so users are not surprised.
 
 Common rule violations to reject before upload:
 

--- a/tests/unit/test_pe.py
+++ b/tests/unit/test_pe.py
@@ -1,0 +1,281 @@
+"""Focused unit tests for the LibrePE (Perception Encoder Core) family.
+
+These tests use synthetic tensors and the closed configuration table only. Exact
+parity against ``open_clip_torch==3.2.0`` lives in ``weights/parity_pe.py``, and
+cleared-cache download tests live in the network tier -- neither belongs here.
+
+No test in this file may fetch the ``facebook/PE-Video`` dataset.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.models.pe.model import DEFAULT_CLIP_FRAMES, LibrePE
+from libreyolo.models.pe.nn import PE_CONFIGS, build_pe_model
+from libreyolo.utils.video import uniform_frame_indices
+
+pytestmark = [pytest.mark.unit, pytest.mark.pe]
+
+# g14 is a 1.88B-parameter vision tower; constructing it is a slow-tier concern.
+LIGHT_SIZES = ("t16", "s16", "b16")
+ALL_SIZES = tuple(PE_CONFIGS)
+
+
+# =============================================================================
+# Configuration table
+# =============================================================================
+
+
+def test_expected_sizes_present():
+    assert ALL_SIZES == ("t16", "s16", "b16", "l14", "g14")
+
+
+@pytest.mark.parametrize(
+    ("size", "image_size", "embed_dim", "context"),
+    [
+        ("t16", 384, 512, 32),
+        ("s16", 384, 512, 32),
+        ("b16", 224, 1024, 32),
+        ("l14", 336, 1024, 32),
+        ("g14", 448, 1280, 72),
+    ],
+)
+def test_config_matches_published_series(size, image_size, embed_dim, context):
+    """Guards the per-size table against a silent edit."""
+    cfg = PE_CONFIGS[size]
+    assert cfg.image_size == image_size
+    assert cfg.projection_dim == embed_dim
+    assert cfg.context_length == context
+
+
+def test_gigantic_is_the_only_class_token_free_size():
+    """bigG drops the class token and the rope grid offset; the rest keep both."""
+    assert PE_CONFIGS["g14"].class_token is False
+    assert PE_CONFIGS["g14"].rope_grid_offset == 0.0
+    for size in ("t16", "s16", "b16", "l14"):
+        assert PE_CONFIGS[size].class_token is True
+        assert PE_CONFIGS[size].rope_grid_offset == 1.0
+
+
+def test_input_sizes_exposed_per_size():
+    assert LibrePE.INPUT_SIZES == {s: c.image_size for s, c in PE_CONFIGS.items()}
+
+
+def test_family_constants():
+    assert LibrePE.FAMILY == "pe"
+    assert LibrePE.FILENAME_PREFIX == "LibrePE"
+    assert LibrePE.SUPPORTED_TASKS == ("classify", "embed")
+    assert LibrePE.DEFAULT_TASK == "classify"
+    assert LibrePE.WEIGHT_TASKS == ("classify",)
+    assert LibrePE.REQUIRE_TASK_SUFFIX is True
+    assert LibrePE.TRAIN_CONFIG is None
+    assert LibrePE.VIDEO_EMBED_MODE == "clip"
+
+
+def test_registered_in_model_group_s():
+    from libreyolo.models.registry import MODEL_GROUPS
+
+    assert MODEL_GROUPS["pe"] == "s"
+
+
+def test_build_rejects_unknown_size():
+    with pytest.raises(ValueError, match="Unknown PE size"):
+        build_pe_model("xl99")
+
+
+# =============================================================================
+# Architecture / forward contracts
+# =============================================================================
+
+
+@pytest.mark.parametrize("size", LIGHT_SIZES)
+def test_forward_shapes(size):
+    cfg = PE_CONFIGS[size]
+    model = build_pe_model(size).eval()
+    res = cfg.image_size
+    with torch.no_grad():
+        img = model.encode_image(torch.zeros(2, 3, res, res))
+        txt = model.encode_text(torch.zeros(3, cfg.context_length, dtype=torch.long))
+    assert img.shape == (2, cfg.projection_dim)
+    assert txt.shape == (3, cfg.projection_dim)
+    assert img.dtype is torch.float32
+
+
+@pytest.mark.parametrize("size", LIGHT_SIZES)
+def test_encode_video_pools_and_normalizes_once(size):
+    cfg = PE_CONFIGS[size]
+    model = build_pe_model(size).eval()
+    res = cfg.image_size
+    clips = torch.randn(2, 3, 3, res, res)
+    with torch.no_grad():
+        out = model.encode_video(clips)
+        frame_feats = model.encode_image(clips.reshape(6, 3, res, res)).reshape(2, 3, -1)
+        expected = torch.nn.functional.normalize(frame_feats.mean(dim=1), dim=-1)
+    assert out.shape == (2, cfg.projection_dim)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        out.norm(dim=-1), torch.ones(2), rtol=0, atol=1e-5
+    )
+
+
+def test_encode_video_rejects_non_5d():
+    model = build_pe_model("t16").eval()
+    with pytest.raises(ValueError, match="5D"):
+        model.encode_video(torch.zeros(2, 3, 384, 384))
+
+
+def test_rope_buffer_is_not_persisted():
+    """RoPE tables are config-derived; they must not be required by a checkpoint."""
+    model = build_pe_model("t16")
+    assert not any("pos_embed_cat" in k for k in model.state_dict())
+    assert not any("attn_mask" in k for k in model.state_dict())
+
+
+# =============================================================================
+# Checkpoint recognition
+# =============================================================================
+
+
+def _reference_state(size: str) -> dict:
+    return build_pe_model(size).state_dict()
+
+
+@pytest.mark.parametrize("size", LIGHT_SIZES)
+def test_can_load_accepts_own_state(size):
+    assert LibrePE.can_load(_reference_state(size)) is True
+
+
+@pytest.mark.parametrize("size", LIGHT_SIZES)
+def test_detect_size_roundtrip(size):
+    assert LibrePE.detect_size(_reference_state(size)) == size
+
+
+def test_detect_size_returns_none_for_foreign_state():
+    assert LibrePE.detect_size({"visual.conv1.weight": torch.zeros(3)}) is None
+
+
+def test_can_load_rejects_sibling_families():
+    """A greedy recognizer would steal CLIP / SigLIP2 / DINOv2 checkpoints."""
+    clip_like = {
+        "visual.conv1.weight": torch.zeros(1),
+        "text_projection": torch.zeros(1),
+        "logit_scale": torch.zeros(()),
+    }
+    siglip_like = {
+        "vision_model.embeddings.patch_embedding.weight": torch.zeros(1),
+        "text_model.head.weight": torch.zeros(1),
+        "logit_bias": torch.zeros(()),
+        "logit_scale": torch.zeros(()),
+    }
+    dinov2_like = {"backbone.blocks.0.attn.qkv.weight": torch.zeros(1)}
+    for foreign in (clip_like, siglip_like, dinov2_like):
+        assert LibrePE.can_load(foreign) is False
+
+
+def test_detect_nb_classes_is_open_vocabulary():
+    assert LibrePE.detect_nb_classes(_reference_state("t16")) is None
+
+
+# =============================================================================
+# Converter guards
+# =============================================================================
+
+
+def test_converter_rejects_conflicting_size(tmp_path):
+    import safetensors.torch as st
+
+    from weights.convert_pe_weights import convert
+
+    src = tmp_path / "src.safetensors"
+    st.save_file(_reference_state("t16"), str(src))
+    with pytest.raises(ValueError, match="conflicts with the source config"):
+        convert(str(src), str(tmp_path / "out.pt"), size="b16")
+
+
+def test_converter_rejects_foreign_checkpoint(tmp_path):
+    import safetensors.torch as st
+
+    from weights.convert_pe_weights import infer_size
+
+    st.save_file({"visual.conv1.weight": torch.zeros(4)}, str(tmp_path / "x.safetensors"))
+    with pytest.raises(ValueError, match="does not look like"):
+        infer_size({"visual.conv1.weight": torch.zeros(4)})
+
+
+# =============================================================================
+# Deterministic uniform video sampling
+# =============================================================================
+
+
+def test_sampling_includes_both_endpoints():
+    idx = uniform_frame_indices(30, 8)
+    assert idx[0] == 0 and idx[-1] == 29
+    assert idx == sorted(idx)
+    assert len(idx) == 8
+
+
+def test_sampling_exact_length_is_identity():
+    assert uniform_frame_indices(8, 8) == list(range(8))
+
+
+def test_sampling_short_video_repeats_last_frame_only():
+    assert uniform_frame_indices(3, 8) == [0, 1, 2, 2, 2, 2, 2, 2]
+
+
+def test_sampling_single_frame_video():
+    assert uniform_frame_indices(1, 8) == [0] * 8
+
+
+def test_sampling_single_requested_frame():
+    assert uniform_frame_indices(30, 1) == [0]
+
+
+def test_sampling_long_video_is_uniform():
+    idx = uniform_frame_indices(1000, 5)
+    # step = 999/4 = 249.75, so the interior points round to 250/500/749.
+    assert idx == [0, 250, 500, 749, 999]
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_sampling_rejects_non_positive_request(bad):
+    with pytest.raises(ValueError, match="num_frames must be positive"):
+        uniform_frame_indices(30, bad)
+
+
+def test_sampling_rejects_empty_video():
+    with pytest.raises(ValueError, match="zero frames"):
+        uniform_frame_indices(0, 8)
+
+
+def test_default_clip_frames_is_eight():
+    assert DEFAULT_CLIP_FRAMES == 8
+
+
+# =============================================================================
+# No-regression: other families keep frame-by-frame video behavior
+# =============================================================================
+
+
+def test_other_families_default_to_frame_by_frame():
+    from libreyolo.models.base.model import BaseModel
+    from libreyolo.models.clip.model import LibreCLIP
+    from libreyolo.models.dinov2.model import LibreDINOv2
+    from libreyolo.models.siglip2.model import LibreSigLIP2
+
+    assert BaseModel.VIDEO_EMBED_MODE == "frames"
+    for family in (LibreCLIP, LibreSigLIP2, LibreDINOv2):
+        assert family.VIDEO_EMBED_MODE == "frames", family.__name__
+
+
+def test_pe_is_the_only_clip_mode_family():
+    from libreyolo.models.base.model import BaseModel
+
+    clip_families = [
+        cls.__name__
+        for cls in BaseModel.__subclasses__()
+        if getattr(cls, "VIDEO_EMBED_MODE", "frames") == "clip"
+    ]
+    assert clip_families == ["LibrePE"]

--- a/tests/unit/test_pe_clip_runtime.py
+++ b/tests/unit/test_pe_clip_runtime.py
@@ -78,6 +78,25 @@ def test_non_positive_clip_frames_rejected(embedder, clip_path):
         embedder.predict(clip_path, clip_frames=0)
 
 
+def test_save_writes_an_annotated_image(embedder, clip_path, tmp_path):
+    """save=True must be honored, not silently dropped."""
+    out = tmp_path / "saved"
+    embedder.predict(clip_path, save=True, output_path=str(out))
+    written = list(out.rglob("*.jpg")) + list(out.rglob("*.png"))
+    assert written, f"save=True wrote nothing under {out}"
+
+
+def test_vid_stride_rejected_as_inapplicable(embedder, clip_path):
+    """vid_stride conflicts with uniform whole-clip sampling; say so loudly."""
+    with pytest.raises(ValueError, match="clip_frames"):
+        embedder.predict(clip_path, vid_stride=2)
+
+
+def test_show_rejected_as_inapplicable(embedder, clip_path):
+    with pytest.raises(NotImplementedError, match="whole-clip"):
+        embedder.predict(clip_path, show=True)
+
+
 def test_live_source_rejected_without_buffering(embedder):
     with pytest.raises(ValueError, match="unbounded"):
         embedder.predict(0, stream=True)

--- a/tests/unit/test_pe_clip_runtime.py
+++ b/tests/unit/test_pe_clip_runtime.py
@@ -1,0 +1,128 @@
+"""Runtime behavior of the PE whole-clip path, against a real checkpoint.
+
+These need the converted ``LibrePEt16-cls.pt`` artifact, so they are marked
+``external_data`` and skip when it is not staged locally. What they cover
+cannot be checked with a randomly initialized tower: the wiring between
+``predict()``, the source classifier, and ``_predict_video_clip``.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.pe, pytest.mark.external_data]
+
+WEIGHT = Path("weights/LibrePEt16-cls.pt")
+pytest.importorskip("cv2")
+
+
+@pytest.fixture(scope="module")
+def embedder():
+    if not WEIGHT.exists():
+        pytest.skip(f"{WEIGHT} is not staged locally")
+    from libreyolo import LibreYOLO
+
+    return LibreYOLO(str(WEIGHT), task="embed")
+
+
+@pytest.fixture(scope="module")
+def clip_path(tmp_path_factory):
+    import cv2
+
+    path = tmp_path_factory.mktemp("pe") / "clip.mp4"
+    writer = cv2.VideoWriter(
+        str(path), cv2.VideoWriter_fourcc(*"mp4v"), 10, (128, 128)
+    )
+    rng = np.random.default_rng(0)
+    for _ in range(30):
+        writer.write((rng.random((128, 128, 3)) * 255).astype("uint8"))
+    writer.release()
+    return str(path)
+
+
+def test_finite_video_collapses_to_one_row(embedder, clip_path):
+    results = embedder.predict(clip_path)
+    assert len(results) == 1, "a whole clip must produce one Results, not one per frame"
+    row = np.asarray(results[0].embeddings.data)
+    assert row.shape == (1, 512)
+    assert np.isclose(np.linalg.norm(row, axis=-1)[0], 1.0, atol=1e-5)
+    assert results[0].path.endswith("clip.mp4")
+
+
+def test_stream_true_returns_an_iterator(embedder, clip_path):
+    """The streaming contract holds even though a clip collapses to one row."""
+    streamed = embedder.predict(clip_path, stream=True)
+    assert isinstance(streamed, types.GeneratorType) or hasattr(streamed, "__next__")
+    collected = list(streamed)
+    assert len(collected) == 1
+
+
+def test_clip_frames_changes_the_embedding(embedder, clip_path):
+    eight = np.asarray(embedder.predict(clip_path)[0].embeddings.data)
+    four = np.asarray(embedder.predict(clip_path, clip_frames=4)[0].embeddings.data)
+    assert np.abs(eight - four).max() > 0
+
+
+def test_clip_embedding_is_deterministic(embedder, clip_path):
+    first = np.asarray(embedder.predict(clip_path)[0].embeddings.data)
+    second = np.asarray(embedder.predict(clip_path)[0].embeddings.data)
+    assert np.abs(first - second).max() == 0.0
+
+
+def test_non_positive_clip_frames_rejected(embedder, clip_path):
+    with pytest.raises(ValueError, match="clip_frames must be positive"):
+        embedder.predict(clip_path, clip_frames=0)
+
+
+def test_live_source_rejected_without_buffering(embedder):
+    with pytest.raises(ValueError, match="unbounded"):
+        embedder.predict(0, stream=True)
+
+
+def test_image_list_stays_a_batch(embedder):
+    images = [
+        (np.random.default_rng(i).random((64, 64, 3)) * 255).astype("uint8")
+        for i in range(3)
+    ]
+    results = embedder.predict(images)
+    assert len(results) == 3, "an image list must not be guessed to be a clip"
+
+
+def test_export_metadata_round_trips(embedder, tmp_path):
+    """A reloaded clip graph must know its frame count and layout."""
+    import json
+
+    import onnx
+
+    out = str(tmp_path / "vembed.onnx")
+    embedder.export(format="onnx", video=True, clip_frames=4, output=out)
+    props = {p.key: p.value for p in onnx.load(out).metadata_props}
+    assert props["model_family"] == "pe"
+    assert props["task"] == "embed"
+    assert props["input_kind"] == "video"
+    assert json.loads(props["frames"]) == 4
+    assert props["input_layout"] == "BFCHW"
+    assert props["video_pool"] == "mean_frame_embeddings"
+    assert json.loads(props["dynamic_frames"]) is False
+
+
+def test_torchscript_metadata_round_trips(embedder, tmp_path):
+    import json
+
+    import torch
+
+    out = str(tmp_path / "embed.torchscript")
+    embedder.export(format="torchscript", output=out)
+    extra = {"libreyolo_metadata.json": ""}
+    torch.jit.load(out, _extra_files=extra)
+    meta = json.loads(extra["libreyolo_metadata.json"])
+    assert meta["model_family"] == "pe"
+    assert meta["model_size"] == "t16"
+    assert meta["task"] == "embed"
+    assert meta["imgsz"] == 384
+    assert meta["embedding_dim"] == 512
+    assert meta["input_kind"] == "image"

--- a/tests/unit/test_pe_clip_runtime.py
+++ b/tests/unit/test_pe_clip_runtime.py
@@ -162,6 +162,26 @@ def test_exported_backend_uses_pe_normalization(embedder, tmp_path):
     assert PE_MEAN == (0.5, 0.5, 0.5) and PE_STD == (0.5, 0.5, 0.5)
 
 
+def test_video_graph_reload_fails_loudly(embedder, tmp_path):
+    """A 5D clip graph must be refused with a reason, not an opaque rank error."""
+    from libreyolo.backends.torchscript import TorchScriptBackend
+
+    out = str(tmp_path / "vembed.torchscript")
+    embedder.export(format="torchscript", video=True, clip_frames=4, output=out)
+    with pytest.raises(NotImplementedError, match="5D"):
+        TorchScriptBackend(out, task="embed")
+
+
+def test_image_graph_reload_still_works(embedder, tmp_path):
+    """The guard must not catch ordinary 4D image graphs."""
+    from libreyolo.backends.torchscript import TorchScriptBackend
+
+    out = str(tmp_path / "embed.torchscript")
+    embedder.export(format="torchscript", output=out)
+    backend = TorchScriptBackend(out, task="embed")
+    assert backend.model_family == "pe"
+
+
 def test_torchscript_metadata_round_trips(embedder, tmp_path):
     import json
 

--- a/tests/unit/test_pe_clip_runtime.py
+++ b/tests/unit/test_pe_clip_runtime.py
@@ -110,6 +110,39 @@ def test_export_metadata_round_trips(embedder, tmp_path):
     assert json.loads(props["dynamic_frames"]) is False
 
 
+def test_exported_backend_uses_pe_normalization(embedder, tmp_path):
+    """A reloaded PE graph must preprocess with PE stats, not ImageNet stats.
+
+    Regression guard: without a ``pe`` branch in ``_preprocess_classify`` the
+    backend silently falls through to ImageNet normalization, so the exported
+    model sees different pixels than native PE and returns wrong embeddings.
+    """
+    import numpy as np_
+    import torch
+
+    from libreyolo.models.pe.nn import PE_MEAN, PE_STD
+
+    out = str(tmp_path / "embed.torchscript")
+    embedder.export(format="torchscript", output=out)
+
+    from libreyolo.backends.torchscript import TorchScriptBackend
+
+    backend = TorchScriptBackend(out, task="embed")
+    assert backend.model_family == "pe"
+
+    image = (np_.random.default_rng(0).random((240, 320, 3)) * 255).astype("uint8")
+    tensor, _, _, _ = backend._preprocess_classify(image, 384, "rgb")
+
+    # Reproduce the native transform and require an exact match.
+    native, _ = embedder._get_preprocess_numpy()(image, 384)
+    torch.testing.assert_close(
+        tensor[0], torch.from_numpy(native), rtol=0, atol=0
+    )
+
+    # And sanity-check the stats really are symmetric, not ImageNet.
+    assert PE_MEAN == (0.5, 0.5, 0.5) and PE_STD == (0.5, 0.5, 0.5)
+
+
 def test_torchscript_metadata_round_trips(embedder, tmp_path):
     import json
 

--- a/tests/unit/test_pe_export.py
+++ b/tests/unit/test_pe_export.py
@@ -1,0 +1,183 @@
+"""Export-graph parity for LibrePE.
+
+These tests build the export wrappers directly on a randomly initialized tower,
+so they need no downloaded weights: what is under test is the *graph* -- that
+ONNX and TorchScript reproduce the native PyTorch computation, including the
+frozen-class head and the fixed-frame video pooling.
+
+Tolerances are asserted rather than hard-coded to zero for ONNX because its
+kernels legitimately differ in accumulation order; TorchScript runs the same
+kernels and must match exactly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.models.pe.export import (
+    _FrozenPEClassifier,
+    _PEImageEmbedder,
+    _PEVideoEmbedder,
+)
+from libreyolo.models.pe.nn import PE_CONFIGS, build_pe_model
+
+pytestmark = [pytest.mark.unit, pytest.mark.pe]
+
+SIZE = "t16"
+RES = PE_CONFIGS[SIZE].image_size
+DIM = PE_CONFIGS[SIZE].projection_dim
+# ONNX fp32 graphs of this depth land well inside 1e-4; the classify graph is
+# amplified by logit_scale (~100x), so it gets the same absolute budget on a
+# much larger signal.
+ONNX_ATOL = 1e-4
+
+
+@pytest.fixture(scope="module")
+def visual():
+    torch.manual_seed(0)
+    return build_pe_model(SIZE).eval().visual
+
+
+def _onnx_run(module, dummy, input_name, tmp_path, name):
+    onnxruntime = pytest.importorskip("onnxruntime")
+    path = str(tmp_path / f"{name}.onnx")
+    with torch.no_grad():
+        torch.onnx.export(
+            module,
+            dummy,
+            path,
+            input_names=[input_name],
+            output_names=["out"],
+            opset_version=17,
+            dynamic_axes={input_name: {0: "batch"}, "out": {0: "batch"}},
+            dynamo=False,
+        )
+    session = onnxruntime.InferenceSession(path)
+    return session.run(None, {input_name: dummy.numpy()})[0]
+
+
+# =============================================================================
+# Image embedding graph
+# =============================================================================
+
+
+def test_image_embed_graph_is_unit_norm(visual):
+    module = _PEImageEmbedder(visual).eval()
+    with torch.no_grad():
+        out = module(torch.randn(2, 3, RES, RES))
+    assert out.shape == (2, DIM)
+    torch.testing.assert_close(out.norm(dim=-1), torch.ones(2), rtol=0, atol=1e-5)
+
+
+@pytest.mark.onnx
+def test_image_embed_onnx_matches_native(visual, tmp_path):
+    module = _PEImageEmbedder(visual).eval()
+    x = torch.randn(1, 3, RES, RES)
+    with torch.no_grad():
+        native = module(x).numpy()
+    got = _onnx_run(module, x, "images", tmp_path, "embed")
+    assert np.abs(got - native).max() < ONNX_ATOL
+
+
+@pytest.mark.torchscript
+def test_image_embed_torchscript_is_exact(visual, tmp_path):
+    module = _PEImageEmbedder(visual).eval()
+    x = torch.randn(1, 3, RES, RES)
+    with torch.no_grad():
+        native = module(x)
+        traced = torch.jit.trace(module, x, strict=False)
+    torch.testing.assert_close(traced(x), native, rtol=0, atol=0)
+
+
+# =============================================================================
+# Frozen-class classify graph
+# =============================================================================
+
+
+@pytest.fixture
+def frozen(visual):
+    torch.manual_seed(1)
+    weight = torch.nn.functional.normalize(torch.randn(3, DIM), dim=-1) * 100.0
+    return _FrozenPEClassifier(visual, weight).eval()
+
+
+def test_frozen_classifier_shape(frozen):
+    with torch.no_grad():
+        assert frozen(torch.randn(2, 3, RES, RES)).shape == (2, 3)
+
+
+@pytest.mark.onnx
+def test_frozen_classify_onnx_matches_native(frozen, tmp_path):
+    x = torch.randn(1, 3, RES, RES)
+    with torch.no_grad():
+        native = frozen(x).numpy()
+    got = _onnx_run(frozen, x, "images", tmp_path, "cls")
+    # Logits are logit_scale-amplified, so compare on the same absolute budget
+    # relative to the signal magnitude.
+    assert np.abs(got - native).max() < ONNX_ATOL * max(1.0, np.abs(native).max())
+
+
+@pytest.mark.torchscript
+def test_frozen_classify_torchscript_is_exact(frozen):
+    x = torch.randn(1, 3, RES, RES)
+    with torch.no_grad():
+        native = frozen(x)
+        traced = torch.jit.trace(frozen, x, strict=False)
+    torch.testing.assert_close(traced(x), native, rtol=0, atol=0)
+
+
+# =============================================================================
+# Fixed-frame video graph
+# =============================================================================
+
+
+def test_video_graph_matches_encode_video(visual):
+    """The exported clip graph must agree with the eager encode_video path."""
+    model = build_pe_model(SIZE).eval()
+    module = _PEVideoEmbedder(model.visual).eval()
+    clips = torch.randn(1, 3, 3, RES, RES)
+    with torch.no_grad():
+        torch.testing.assert_close(
+            module(clips), model.encode_video(clips), rtol=0, atol=0
+        )
+
+
+@pytest.mark.onnx
+def test_video_onnx_matches_native(visual, tmp_path):
+    module = _PEVideoEmbedder(visual).eval()
+    clips = torch.randn(1, 2, 3, RES, RES)
+    with torch.no_grad():
+        native = module(clips).numpy()
+    got = _onnx_run(module, clips, "clip", tmp_path, "vembed")
+    assert np.abs(got - native).max() < ONNX_ATOL
+
+
+@pytest.mark.torchscript
+def test_video_torchscript_is_exact(visual):
+    module = _PEVideoEmbedder(visual).eval()
+    clips = torch.randn(1, 2, 3, RES, RES)
+    with torch.no_grad():
+        native = module(clips)
+        traced = torch.jit.trace(module, clips, strict=False)
+    torch.testing.assert_close(traced(clips), native, rtol=0, atol=0)
+
+
+# =============================================================================
+# Declared support must match what is actually implemented
+# =============================================================================
+
+
+def test_declared_validated_formats_are_onnx_and_torchscript():
+    from libreyolo.export.support import validated_alternatives
+
+    for task in ("classify", "embed"):
+        assert set(validated_alternatives("pe", task)) == {"onnx", "torchscript"}
+
+
+def test_unvalidated_runtimes_are_blocked_not_advertised():
+    from libreyolo.export.support import get_support
+
+    for fmt in ("ncnn", "coreml", "coreai", "tflite", "paddle", "rknn"):
+        assert get_support("pe", "embed", fmt).tier == "blocked", fmt

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -274,6 +274,21 @@ project the weights were derived from. Per-family summary:
              google/siglip2-so400m-patch14-384 (Hugging Face).
              Convert with weights/convert_siglip2_weights.py.
 
+    Perception Encoder Core                            Apache-2.0
+             (LibrePE{t16,s16,b16,l14,g14}-cls)
+             upstream: the OpenCLIP-compatible converted repositories
+             timm/PE-Core-T-16-384 @ 7fe539ed578ac49a1c2b4f946e4b0747704c825a,
+             timm/PE-Core-S-16-384 @ 3249a38eb1c432ec19231c6fe1774acb6a4e4efe,
+             timm/PE-Core-B-16     @ 0038414f37721c5eafc1a5e0da802d291c909de3,
+             timm/PE-Core-L-14-336 @ 8eff41b3f687e50a323662c2dda5eb3588c6dd35,
+             timm/PE-Core-bigG-14-448 @ 17aa0c25addfa14198fa2ff73d845a22d433432e.
+             These are converted artifacts targeting the OpenCLIP-compatible
+             modeling implementation, NOT unmodified official
+             facebook/PE-Core-* package checkpoints. Each source model card
+             declares Apache-2.0. Convert with weights/convert_pe_weights.py;
+             see libreyolo/models/pe/NOTICE.md for the unresolved license
+             inconsistency in the official perception_models repository.
+
     OMDet-Turbo (LibreOMDetTurbot)                     Apache-2.0
              upstream: omlab/omdet-turbo-swin-tiny-hf
              pinned revision:

--- a/weights/convert_pe_weights.py
+++ b/weights/convert_pe_weights.py
@@ -32,9 +32,10 @@ from pathlib import Path
 
 import torch
 
-from _conversion_utils import save_checkpoint, wrap_libreyolo_checkpoint
-
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from _conversion_utils import save_checkpoint, wrap_libreyolo_checkpoint  # noqa: E402
 
 from libreyolo.models.pe.nn import PE_CONFIGS, build_pe_model  # noqa: E402
 

--- a/weights/convert_pe_weights.py
+++ b/weights/convert_pe_weights.py
@@ -1,0 +1,270 @@
+"""Convert pinned OpenCLIP-compatible PE Core weights to LibreYOLO format.
+
+The native LibreYOLO PE towers mirror the upstream converted-checkpoint layout
+(``visual.trunk.*`` / ``text.*`` / ``logit_scale``) exactly, so conversion is a
+strict metadata-wrap with **no key remapping**. Every architectural field is
+asserted against the closed configuration table before writing; an unknown or
+changed upstream config fails loudly rather than silently producing a wrong
+model.
+
+Network fetching is a separate, explicit step (``--download``) from tensor
+mapping, so a conversion can always be run against a pinned local snapshot.
+
+Usage::
+
+    # From an explicit local snapshot
+    python weights/convert_pe_weights.py open_clip_model.safetensors \\
+        weights/LibrePEt16-cls.pt --size t16
+
+    # Fetch the pinned revision first, then convert
+    python weights/convert_pe_weights.py --download --size t16 \\
+        weights/LibrePEt16-cls.pt
+
+    # All five canonical artifacts
+    python weights/convert_pe_weights.py --download --all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+
+from _conversion_utils import save_checkpoint, wrap_libreyolo_checkpoint
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from libreyolo.models.pe.nn import PE_CONFIGS, build_pe_model  # noqa: E402
+
+# Pinned weight sources. Both id and revision are recorded into the checkpoint
+# metadata and the weight notice.
+PINNED_SOURCES = {
+    "t16": ("timm/PE-Core-T-16-384", "7fe539ed578ac49a1c2b4f946e4b0747704c825a"),
+    "s16": ("timm/PE-Core-S-16-384", "3249a38eb1c432ec19231c6fe1774acb6a4e4efe"),
+    "b16": ("timm/PE-Core-B-16", "0038414f37721c5eafc1a5e0da802d291c909de3"),
+    "l14": ("timm/PE-Core-L-14-336", "8eff41b3f687e50a323662c2dda5eb3588c6dd35"),
+    "g14": ("timm/PE-Core-bigG-14-448", "17aa0c25addfa14198fa2ff73d845a22d433432e"),
+}
+SOURCE_LICENSE = "Apache-2.0"
+SOURCE_WEIGHT_FILE = "open_clip_model.safetensors"
+
+
+def download_pinned(size: str) -> str:
+    """Fetch the pinned revision of one source snapshot. Network step only."""
+    from huggingface_hub import hf_hub_download
+
+    repo, revision = PINNED_SOURCES[size]
+    return hf_hub_download(repo, SOURCE_WEIGHT_FILE, revision=revision)
+
+
+def load_source_state(path: str) -> dict:
+    if str(path).endswith(".safetensors"):
+        import safetensors.torch as st
+
+        return st.load_file(path)
+    from _conversion_utils import extract_state_dict, load_checkpoint
+
+    return extract_state_dict(load_checkpoint(path), prefer_ema=True)
+
+
+def infer_size(state: dict) -> str:
+    """Infer the LibreYOLO size from the source tensors alone."""
+    patch = state.get("visual.trunk.patch_embed.proj.weight")
+    pos = state.get("text.positional_embedding")
+    if patch is None or pos is None:
+        raise ValueError(
+            "Source does not look like an OpenCLIP-compatible PE Core checkpoint "
+            "(missing 'visual.trunk.patch_embed.proj.weight' / "
+            "'text.positional_embedding')."
+        )
+    width, patch_size, context = (
+        int(patch.shape[0]),
+        int(patch.shape[-1]),
+        int(pos.shape[0]),
+    )
+    for size, cfg in PE_CONFIGS.items():
+        if (
+            cfg.embed_dim == width
+            and cfg.patch_size == patch_size
+            and cfg.context_length == context
+        ):
+            return size
+    raise ValueError(
+        f"No PE size matches the source config (width={width}, "
+        f"patch={patch_size}, context={context}). Refusing to guess."
+    )
+
+
+def assert_config(state: dict, size: str) -> None:
+    """Validate every architectural invariant before writing a checkpoint."""
+    cfg = PE_CONFIGS[size]
+    checks = {
+        "vision width": (
+            int(state["visual.trunk.patch_embed.proj.weight"].shape[0]),
+            cfg.embed_dim,
+        ),
+        "patch size": (
+            int(state["visual.trunk.patch_embed.proj.weight"].shape[-1]),
+            cfg.patch_size,
+        ),
+        "context length": (
+            int(state["text.positional_embedding"].shape[0]),
+            cfg.context_length,
+        ),
+        "text width": (int(state["text.positional_embedding"].shape[1]), cfg.text_width),
+        "vocab size": (
+            int(state["text.token_embedding.weight"].shape[0]),
+            cfg.vocab_size,
+        ),
+        "embedding dim": (
+            int(state["text.text_projection"].shape[1]),
+            cfg.projection_dim,
+        ),
+        "projection head": (int(state["visual.trunk.head.weight"].shape[0]),
+                            cfg.projection_dim),
+        "positional tokens": (
+            int(state["visual.trunk.pos_embed"].shape[1]),
+            cfg.num_patches + cfg.num_prefix_tokens,
+        ),
+        "attn pool latent": (
+            int(state["visual.trunk.attn_pool.latent"].shape[-1]),
+            cfg.embed_dim,
+        ),
+    }
+    for label, (found, expected) in checks.items():
+        if found != expected:
+            raise ValueError(
+                f"{label} mismatch for size={size}: source has {found}, "
+                f"config expects {expected}."
+            )
+
+    depth = 1 + max(
+        int(k.split(".")[3])
+        for k in state
+        if k.startswith("visual.trunk.blocks.")
+    )
+    if depth != cfg.depth:
+        raise ValueError(
+            f"vision depth mismatch for size={size}: source has {depth}, "
+            f"config expects {cfg.depth}."
+        )
+    text_layers = 1 + max(
+        int(k.split(".")[3])
+        for k in state
+        if k.startswith("text.transformer.resblocks.")
+    )
+    if text_layers != cfg.text_layers:
+        raise ValueError(
+            f"text depth mismatch for size={size}: source has {text_layers}, "
+            f"config expects {cfg.text_layers}."
+        )
+
+    has_cls = "visual.trunk.cls_token" in state
+    if has_cls != cfg.class_token:
+        raise ValueError(
+            f"class-token mismatch for size={size}: source has cls_token="
+            f"{has_cls}, config expects {cfg.class_token}."
+        )
+
+
+def convert(input_path: str, output_path: str, size: str | None = None) -> None:
+    state = load_source_state(input_path)
+    inferred = infer_size(state)
+    if size is not None and size != inferred:
+        raise ValueError(
+            f"--size {size!r} conflicts with the source config, which is "
+            f"{inferred!r}. Refusing to mislabel the checkpoint."
+        )
+    size = inferred
+    cfg = PE_CONFIGS[size]
+    assert_config(state, size)
+
+    # Strict dry-load: no missing, unexpected, or silently dropped keys.
+    model = build_pe_model(size)
+    result = model.load_state_dict(state, strict=True)
+    assert not result.missing_keys, f"missing: {result.missing_keys}"
+    assert not result.unexpected_keys, f"unexpected: {result.unexpected_keys}"
+    print(f"Strict load OK for size={size}: {len(state)} tensors, no key diff.")
+
+    repo, revision = PINNED_SOURCES[size]
+    cpu_state = {k: v.detach().cpu() for k, v in model.state_dict().items()}
+
+    wrapped = wrap_libreyolo_checkpoint(
+        cpu_state,
+        model_family="pe",
+        size=size,
+        # Open-vocabulary: there is no fixed head. 1000 records the ImageNet-1k
+        # class set the family defaults to on construction; set_classes()
+        # replaces it freely.
+        nc=1000,
+        task="classify",
+        supported_tasks=("classify", "embed"),
+        default_task="classify",
+    )
+    wrapped.update(
+        {
+            "source_repo": repo,
+            "source_revision": revision,
+            "source_weight_file": SOURCE_WEIGHT_FILE,
+            "source_license": SOURCE_LICENSE,
+            "input_size": cfg.image_size,
+            "embedding_dim": cfg.projection_dim,
+            "text_context_length": cfg.context_length,
+            "video_pool": "mean_frame_embeddings",
+            "pixel_mean": [0.5, 0.5, 0.5],
+            "pixel_std": [0.5, 0.5, 0.5],
+        }
+    )
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(out.suffix + ".tmp")
+    save_checkpoint(wrapped, tmp)
+    tmp.replace(out)  # atomic
+    size_mb = out.stat().st_size / 1e6
+    print(f"Wrote {out} (size={size}, {size_mb:.1f} MB)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", nargs="?", help="source .safetensors / .pt snapshot")
+    parser.add_argument("output", nargs="?", help="destination LibreYOLO .pt")
+    parser.add_argument("--size", choices=list(PE_CONFIGS))
+    parser.add_argument(
+        "--download",
+        action="store_true",
+        help="fetch the pinned revision instead of taking a local input path",
+    )
+    parser.add_argument(
+        "--all", action="store_true", help="convert all five canonical artifacts"
+    )
+    parser.add_argument("--out-dir", default="weights")
+    args = parser.parse_args()
+
+    torch.set_grad_enabled(False)
+
+    if args.all:
+        for size in PE_CONFIGS:
+            dest = Path(args.out_dir) / f"LibrePE{size}-cls.pt"
+            convert(download_pinned(size), str(dest), size)
+        return
+
+    if args.download:
+        if not args.size:
+            parser.error("--download requires --size")
+        source = download_pinned(args.size)
+        dest = args.output or str(
+            Path(args.out_dir) / f"LibrePE{args.size}-cls.pt"
+        )
+    else:
+        if not args.input or not args.output:
+            parser.error("input and output are required without --download/--all")
+        source, dest = args.input, args.output
+
+    convert(source, dest, args.size)
+
+
+if __name__ == "__main__":
+    main()

--- a/weights/parity_pe.py
+++ b/weights/parity_pe.py
@@ -1,0 +1,132 @@
+"""Exact-parity gate for the PE Core port.
+
+Cross-loads each pinned OpenCLIP-compatible PE Core snapshot into the native
+LibreYOLO implementation and asserts ``max_abs_diff == 0.0`` against
+unmodified ``open_clip_torch==3.2.0`` on fixed float32 CPU inputs, for:
+
+* image embeddings
+* text embeddings
+* zero-shot logits
+* fixed-frame video embeddings (mean of frame embeddings, normalized once)
+
+Usage::
+
+    python weights/parity_pe.py                 # all sizes
+    python weights/parity_pe.py --sizes t16 s16 # a subset
+
+``g14`` needs roughly 20 GB of RAM to hold both the port and the oracle in
+float32; it is excluded from ``--sizes all-small``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from libreyolo.models.pe.nn import PE_CONFIGS, build_pe_model  # noqa: E402
+
+# Pinned source snapshots. Both repo id and revision are part of the gate:
+# a moved revision must fail loudly rather than silently re-parity.
+PINNED_SOURCES = {
+    "t16": ("timm/PE-Core-T-16-384", "7fe539ed578ac49a1c2b4f946e4b0747704c825a"),
+    "s16": ("timm/PE-Core-S-16-384", "3249a38eb1c432ec19231c6fe1774acb6a4e4efe"),
+    "b16": ("timm/PE-Core-B-16", "0038414f37721c5eafc1a5e0da802d291c909de3"),
+    "l14": ("timm/PE-Core-L-14-336", "8eff41b3f687e50a323662c2dda5eb3588c6dd35"),
+    "g14": ("timm/PE-Core-bigG-14-448", "17aa0c25addfa14198fa2ff73d845a22d433432e"),
+}
+
+WEIGHT_FILE = "open_clip_model.safetensors"
+
+
+def fetch(size: str) -> str:
+    from huggingface_hub import hf_hub_download
+
+    repo, revision = PINNED_SOURCES[size]
+    return hf_hub_download(repo, WEIGHT_FILE, revision=revision)
+
+
+def check_size(size: str, frames: int = 4, batch: int = 2) -> bool:
+    import open_clip
+    import safetensors.torch as st
+
+    cfg = PE_CONFIGS[size]
+    path = fetch(size)
+
+    ours = build_pe_model(size)
+    result = ours.load_state_dict(st.load_file(path), strict=True)
+    assert not result.missing_keys and not result.unexpected_keys
+    ours.eval()
+
+    oracle, _, _ = open_clip.create_model_and_transforms(
+        cfg.open_clip_model_name, pretrained=path
+    )
+    oracle.eval()
+
+    res = cfg.image_size
+    torch.manual_seed(0)
+    images = torch.randn(batch, 3, res, res)
+    tokens = torch.randint(0, 49000, (3, cfg.context_length))
+    tokens[:, -1] = 49407  # EOT marker drives argmax pooling
+    clips = torch.randn(batch, frames, 3, res, res)
+
+    ok = True
+    with torch.no_grad():
+        ours_img, ref_img = ours.encode_image(images), oracle.encode_image(images)
+        ours_txt, ref_txt = ours.encode_text(tokens), oracle.encode_text(tokens)
+
+        def logits(img, txt, scale):
+            return scale.exp() * (
+                F.normalize(img, dim=-1) @ F.normalize(txt, dim=-1).T
+            )
+
+        ours_log = logits(ours_img, ours_txt, ours.logit_scale)
+        ref_log = logits(ref_img, ref_txt, oracle.logit_scale)
+
+        ours_vid = ours.encode_video(clips)
+        flat = clips.reshape(batch * frames, 3, res, res)
+        ref_vid = F.normalize(
+            oracle.encode_image(flat).reshape(batch, frames, -1).mean(dim=1), dim=-1
+        )
+
+    for label, a, b in (
+        ("image", ours_img, ref_img),
+        ("text", ours_txt, ref_txt),
+        ("logits", ours_log, ref_log),
+        ("video", ours_vid, ref_vid),
+    ):
+        diff = (a - b).abs().max().item()
+        status = "OK " if diff == 0.0 else "FAIL"
+        print(
+            f"  [{status}] {size:>4s} {label:<7s} shape={tuple(a.shape)} "
+            f"max_abs_diff={diff:.6g}"
+        )
+        ok = ok and diff == 0.0
+
+    del ours, oracle
+    gc.collect()
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sizes", nargs="*", default=list(PE_CONFIGS))
+    args = parser.parse_args()
+
+    torch.set_grad_enabled(False)
+    failures = [size for size in args.sizes if not check_size(size)]
+    if failures:
+        print(f"PARITY FAILED for: {', '.join(failures)}")
+        return 1
+    print(f"PARITY OK for: {', '.join(args.sizes)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/weights/parity_pe.py
+++ b/weights/parity_pe.py
@@ -52,49 +52,61 @@ def fetch(size: str) -> str:
     return hf_hub_download(repo, WEIGHT_FILE, revision=revision)
 
 
+def _logits(img: torch.Tensor, txt: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return scale.exp() * (F.normalize(img, dim=-1) @ F.normalize(txt, dim=-1).T)
+
+
 def check_size(size: str, frames: int = 4, batch: int = 2) -> bool:
+    """Compare the port against the oracle on identical fixed inputs.
+
+    The oracle is built, run, and *freed* before the port is built. Holding both
+    in float32 at once costs ~20 GB for g14 and segfaults on a 32 GB machine.
+    """
     import open_clip
     import safetensors.torch as st
 
     cfg = PE_CONFIGS[size]
     path = fetch(size)
-
-    ours = build_pe_model(size)
-    result = ours.load_state_dict(st.load_file(path), strict=True)
-    assert not result.missing_keys and not result.unexpected_keys
-    ours.eval()
-
-    oracle, _, _ = open_clip.create_model_and_transforms(
-        cfg.open_clip_model_name, pretrained=path
-    )
-    oracle.eval()
-
     res = cfg.image_size
+
+    # g14 is a 1.88B vision tower at 448px; keep the fixtures small.
+    if size == "g14":
+        batch, frames = 1, 2
+
     torch.manual_seed(0)
     images = torch.randn(batch, 3, res, res)
     tokens = torch.randint(0, 49000, (3, cfg.context_length))
     tokens[:, -1] = 49407  # EOT marker drives argmax pooling
     clips = torch.randn(batch, frames, 3, res, res)
 
-    ok = True
+    # --- oracle pass, then free ------------------------------------------
+    oracle, _, _ = open_clip.create_model_and_transforms(
+        cfg.open_clip_model_name, pretrained=path
+    )
+    oracle.eval()
     with torch.no_grad():
-        ours_img, ref_img = ours.encode_image(images), oracle.encode_image(images)
-        ours_txt, ref_txt = ours.encode_text(tokens), oracle.encode_text(tokens)
-
-        def logits(img, txt, scale):
-            return scale.exp() * (
-                F.normalize(img, dim=-1) @ F.normalize(txt, dim=-1).T
-            )
-
-        ours_log = logits(ours_img, ours_txt, ours.logit_scale)
-        ref_log = logits(ref_img, ref_txt, oracle.logit_scale)
-
-        ours_vid = ours.encode_video(clips)
+        ref_img = oracle.encode_image(images)
+        ref_txt = oracle.encode_text(tokens)
+        ref_log = _logits(ref_img, ref_txt, oracle.logit_scale)
         flat = clips.reshape(batch * frames, 3, res, res)
         ref_vid = F.normalize(
             oracle.encode_image(flat).reshape(batch, frames, -1).mean(dim=1), dim=-1
         )
+    del oracle
+    gc.collect()
 
+    # --- port pass --------------------------------------------------------
+    ours = build_pe_model(size)
+    result = ours.load_state_dict(st.load_file(path), strict=True)
+    assert not result.missing_keys and not result.unexpected_keys
+    ours.eval()
+    with torch.no_grad():
+        ours_img = ours.encode_image(images)
+        ours_txt = ours.encode_text(tokens)
+        ours_log = _logits(ours_img, ours_txt, ours.logit_scale)
+        ours_vid = ours.encode_video(clips)
+
+    ok = True
     for label, a, b in (
         ("image", ours_img, ref_img),
         ("text", ours_txt, ref_txt),
@@ -109,7 +121,7 @@ def check_size(size: str, frames: int = 4, batch: int = 2) -> bool:
         )
         ok = ok and diff == 0.0
 
-    del ours, oracle
+    del ours
     gc.collect()
     return ok
 


### PR DESCRIPTION
Adds **Perception Encoder (PE) Core** as the `pe` / `LibrePE` family: Meta's dual-tower vision-language encoder, in all five released sizes, for zero-shot `classify` and `embed` over images, text, and **whole videos**.

Implements the handoff `HANDOFF_perception_encoder_embed.md`. Inference-only by design.

## What this gives users

```python
from libreyolo import LibreYOLO

# zero-shot classification
model = LibreYOLO("LibrePEb16-cls.pt")
model.set_classes(["a forklift", "an empty aisle", "a spill"])
model.predict("warehouse.jpg")

# one embedding space for images, text and whole clips
embedder = LibreYOLO("LibrePEb16-cls.pt", task="embed")
embedder.predict("photo.jpg")    # (1, D) image row
embedder.embed_text(["a dog"])   # (1, D) text row
embedder.predict("clip.mp4")     # (1, D) row for the ENTIRE clip
```

PE is the first family to embed a finite video as a **single vector** instead of one result per frame.

## Code provenance

All code in this PR is either original work for LibreYOLO or adapted from permissively licensed upstreams. No GPL/AGPL/LGPL, non-commercial, proprietary, or unknown-license code is included, in any form.

**Adapted — vision tower** (`libreyolo/models/pe/nn.py`: `PEVisionTransformer`, `PEBlock`, `PEAttentionRope`, `PEAttentionPoolLatent`, `PatchEmbed`, `Mlp`, `RotaryEmbeddingCat`, `build_rotary_pos_embed`, `apply_rot_embed_cat`, frequency-band helpers)
- Upstream: [huggingface/pytorch-image-models](https://github.com/huggingface/pytorch-image-models), tag `v1.0.28`, commit `8ef73809f622e0031bd7f4940265734aef8b9978`
- Files: `timm/models/eva.py`, `timm/layers/pos_embed_sincos.py`, `timm/layers/attention_pool.py`
- License: **Apache-2.0**

**Adapted — text tower** (`libreyolo/models/pe/nn.py`: `PETextTransformer`, `Transformer`, `ResidualAttentionBlock`)
- Upstream: [mlfoundations/open_clip](https://github.com/mlfoundations/open_clip), tag `v3.2.0`, commit `6f939057c792a2f3d4d58df748de60ca47c4aed4`
- File: `src/open_clip/transformer.py`
- License: **MIT**

**Original for this PR**: `libreyolo/models/pe/model.py`, `libreyolo/models/pe/export.py`, `weights/convert_pe_weights.py`, `weights/parity_pe.py`, the `VIDEO_EMBED_MODE` hook and clip-sampling path (`libreyolo/models/base/model.py`, `libreyolo/models/base/inference.py`, `libreyolo/utils/video.py`), tests, and all documentation.

**Reused, not duplicated**: the OpenAI BPE tokenizer comes from the existing in-tree `libreyolo/models/clip/tokenizer.py`. No second copy of the vocabulary ships.

**Neither `timm` nor `open_clip` is imported at runtime.** Both are adaptation sources; `open_clip` is additionally the offline parity oracle.

**Deliberately NOT used**: no code was copied or adapted from `facebookresearch/perception_models`. That repository ships `LICENSE.PE` with Apache-2.0 terms while the same revision's `setup.py` declares a noncommercial/proprietary package license. That inconsistency is unresolved, which is exactly why the independently permissive timm/OpenCLIP route was selected. The Perception Language Model (`LICENSE.PLM`, noncommercial), PE Spatial, and PE-AV are out of scope and were not adapted.

**Weights**: Apache-2.0, converted from the OpenCLIP-compatible `timm/PE-Core-*` repositories at pinned revisions (recorded per checkpoint in metadata, in `weights/LICENSE_NOTICE.txt`, and in each HF `NOTICE`). These are converted artifacts, not unmodified official `facebook/PE-Core-*` package checkpoints.

**Datasets**: none. `facebook/PE-Video` (CC-BY-NC-4.0) is not used by any test, example, CI job, or download helper.

## Exact parity — the gate

Against unmodified `open_clip_torch==3.2.0`, float32 CPU, fixed inputs (`python weights/parity_pe.py`):

| size | image | text | zero-shot logits | fixed-frame video |
| --- | --- | --- | --- | --- |
| `t16` | `0.0` | `0.0` | `0.0` | `0.0` |
| `s16` | `0.0` | `0.0` | `0.0` | `0.0` |
| `b16` | `0.0` | `0.0` | `0.0` | `0.0` |
| `l14` | `0.0` | `0.0` | `0.0` | `0.0` |
| `g14` | `0.0` | `0.0` | `0.0` | `0.0` |

`max_abs_diff == 0.0` on every gate for every size, with a strict `load_state_dict` reporting no missing and no unexpected keys.

Two things were needed to reach exact (not merely close) parity, both commented in the code:
- The PE vision tower is timm's **EVA** (RoPE + attention pooling), not a plain ViT.
- open_clip v3.2.0 runs its text tower **batch-first with no NLD→LND transpose**. Running it seq-first instead changes the attention kernel and costs parity (~6e-6).

## Variant matrix

| size | upstream | source repo @ revision | input | dim | ctx | weights |
| --- | --- | --- | ---: | ---: | ---: | --- |
| `t16` | PE-Core-T/16-384 | `timm/PE-Core-T-16-384` @ `7fe539ed` | 384 | 512 | 32 | Apache-2.0 |
| `s16` | PE-Core-S/16-384 | `timm/PE-Core-S-16-384` @ `3249a38e` | 384 | 512 | 32 | Apache-2.0 |
| `b16` | PE-Core-B/16-224 | `timm/PE-Core-B-16` @ `0038414f` | 224 | 1024 | 32 | Apache-2.0 |
| `l14` | PE-Core-L/14-336 | `timm/PE-Core-L-14-336` @ `8eff41b3` | 336 | 1024 | 32 | Apache-2.0 |
| `g14` | PE-Core-G/14-448 | `timm/PE-Core-bigG-14-448` @ `17aa0c25` | 448 | 1280 | 72 | Apache-2.0 |

`g14` has a 1.88B-parameter vision tower (~8 GB float32 for weights alone); its model card says so. Holding the port and the oracle simultaneously needs ~20 GB, so `weights/parity_pe.py` runs the oracle and frees it before building the port.

## Whole-clip video embedding

New `BaseModel.VIDEO_EMBED_MODE`, default `"frames"`. Every existing family keeps its current frame-by-frame video behavior; PE alone sets `"clip"`. The generic runner takes the clip path only when **all** of: the resolved task is `embed`, the family declares clip support, and the source is a finite video.

- Deterministic uniform sampling (`uniform_frame_indices`): endpoints always included; the last frame is repeated **only** when the video yields fewer frames than requested.
- Pooling is the upstream rule: mean of independently encoded frame embeddings, L2-normalized exactly once.
- `clip_frames=` (default 8) is caller-settable and must be positive.
- Live cameras, network streams, and screen captures are **rejected with an actionable error**, never buffered without bound.
- Image lists stay image batches and are never guessed to be a temporal clip.

Decoding and sampling are family-independent (`libreyolo/utils/video.py`); tensor layout and temporal pooling stay family-local. A regression test asserts CLIP, SigLIP2, DINOv2, and `BaseModel` all still report `"frames"`, and that PE is the only `"clip"` family.

## Exports

Three task-aware graphs: image embed (class-independent), frozen-class classify (text matrix baked in — no text tower, no tokenizer), and fixed-frame 5D video embed.

| graph | TorchScript | ONNX |
| --- | --- | --- |
| image embed | `0.0` | 4.3e-07 |
| frozen classify | `0.0` | 1.5e-05 (on logit_scale-amplified logits) |
| video embed | `0.0` | 1.3e-07 |

**Scope note on the video graph.** The image-embed and frozen-class graphs reload through `LibreYOLO(<artifact>)` normally. The fixed-frame 5D clip graph is **direct-runtime only**: LibreYOLO's exported-backend preprocessing builds 4D image tensors, and the shared 5D video-input backend contract the handoff describes is not implemented here. Rather than ship a graph that dies on an opaque rank error, the artifact records `input_kind="video"` and the backends refuse it with an actionable message pointing at `onnxruntime`/`torch.jit` or the image-embed export. Its native parity is still verified. Per the handoff's own conditional ("a fixed-frame 5D video embedding export is required only after the shared video-input backend contract is implemented"), this is a deliberate scope boundary, not an oversight.

Support is declared explicitly in `libreyolo/export/support.py` rather than inheriting the permissive default: ONNX and TorchScript are `validated`; **ncnn, CoreML, Core AI, TFLite, Paddle and RKNN are `blocked`, not advertised as available**, because they were not run. TensorRT/OpenVINO keep the honest default (`available` = converter exists, parity not recorded). Video frame count is static — a dynamic `F` is deliberately not advertised, since it was not parity tested in the target runtimes.

## Training

Rejected immediately and tested. PE Core has no closed-set supervised head: `embed` has no labels or task loss in LibreYOLO, `classify` has no learned head, and the pinned upstream ships no practical single-GPU PE Core fine-tuning recipe. `train()` raises with that explanation rather than silently routing to the generic classification trainer.

## Weights

Published to the LibreYOLO org, each with the full 5-file contract (`.gitattributes`, `README.md`, `LICENSE`, `NOTICE`, the `.pt`), Apache-2.0 plus a NOTICE recording the exact upstream repo and revision:

- [`LibreYOLO/LibrePEt16-cls`](https://huggingface.co/LibreYOLO/LibrePEt16-cls) — published, 5-file contract verified
- [`LibreYOLO/LibrePEs16-cls`](https://huggingface.co/LibreYOLO/LibrePEs16-cls) — published, 5-file contract verified
- [`LibreYOLO/LibrePEb16-cls`](https://huggingface.co/LibreYOLO/LibrePEb16-cls) — published, 5-file contract verified
- [`LibreYOLO/LibrePEl14-cls`](https://huggingface.co/LibreYOLO/LibrePEl14-cls) — published, 5-file contract verified
- [`LibreYOLO/LibrePEg14-cls`](https://huggingface.co/LibreYOLO/LibrePEg14-cls) — published, 5-file contract verified (9.7 GB, strict load, 915 tensors, no key diff)

All five repos were re-queried after upload and each contains exactly the five contracted files, nothing more.

Clean-cache auto-download verified: the local file was removed and `LibreYOLO("LibrePEt16-cls.pt")` downloaded it from the new repo by bare canonical filename and ran a prediction.

## Integration

CHANGELOG `Unreleased / Added`; `docs/nomenclature.md` (naming, size codes, task table); `MODEL_GROUPS["pe"] = "s"` alongside the other zero-shot siblings; regenerated `reports/export_inventory.json` and `docs/export_support.md`; `pe` pytest marker; `weights/LICENSE_NOTICE.txt` and `THIRD_PARTY_NOTICES.txt` entries; family `NOTICE.md`; upload-skill filename whitelist.

**README**: one row only (**Embeddings**), per the repository's constrained README policy. The cell notes the zero-shot classify capability so nothing is hidden. No new section was added.

**e2e registration**: PE is deliberately **not** in `MODEL_CATALOG`, which is detect-only and whose mAP gate fails a classify/embed family by construction. It follows the CLIP/SigLIP2 pattern instead, which carry no `MODEL_CATALOG` row either.

## Review feedback addressed

Greptile raised seven findings across five passes. Six were real and are fixed; one is a scoped follow-up, rebutted [in this comment](https://github.com/LibreYOLO/libreyolo/pull/746#issuecomment-5234122089).

**Rebutted (not a defect of this PR).** Greptile's final pass asks the backends to *construct* a 5D clip input rather than reject it. That is the shared video-input backend contract, which the handoff explicitly scopes as a precondition ("required only after the shared video-input backend contract in section 7 is implemented"), which is shared with the forthcoming V-JEPA 2 port, and which the handoff says needs its own ADR amendment. It is cross-cutting on `BaseBackend.__call__` and would change the inference path for every exported model. Nothing here advertises the video graph as reloadable, the failure is now explicit and tested rather than an opaque rank error, and ordinary 4D graphs are provably unaffected. Offered as a follow-up PR.

0. **A reloaded video graph failed on input rank** (P1, `7d1dd7f8`). Exported-backend preprocessing builds 4D image tensors, so a fixed-frame 5D clip graph driven through `LibreYOLO(...)` silently ran frame-by-frame image preprocessing and died on an opaque rank error. The ONNX and TorchScript backends now refuse an artifact recording `input_kind="video"` with the reason and the working alternative. See the scope note under **Exports** — the shared 5D video-input backend contract is out of scope for this PR, so the video graph is documented as direct-runtime only rather than advertised as reloadable. Ordinary 4D graphs are unaffected (285 backend/serialization tests still pass).

1. **Clip path dropped video options** (P1, `e818f2c5`). The early return ignored `save`, `show`, `output_path` and `vid_stride`. Now `save`/`output_path`/`output_file_format` are forwarded and write one annotated image built from the first sampled frame; `vid_stride` raises (uniform whole-clip sampling has no per-frame stride — `clip_frames` is the control that applies); and `show` raises (there is no frame stream to display). Silently ignoring a caller's option was the real defect.
2. **Reloaded exports used the wrong normalization** (P1, `bf616818`). `BaseBackend._preprocess_classify` dispatches normalization per family and had no `pe` branch, so a reloaded PE artifact fell through to ImageNet stats. PE uses symmetric `[-1, 1]` with a bilinear square resize, so the exported model was fed different pixels than native and returned wrong embeddings and logits. The regression test asserts the backend's preprocessed tensor matches the native transform **exactly**.
3. **Exported graphs carried no metadata** (P1, `8ca08389`). ONNX `metadata_props` and the TorchScript `libreyolo_metadata.json` extra file now record family, size, task, resolution, embedding dim and preprocessing — and for clip graphs the fixed frame count, `BFCHW` layout, pooling rule and `dynamic_frames=false`. A reloaded artifact no longer falls back to detection defaults. This also closes the handoff's explicit requirement to store `input_kind`/`frames`/layout in video export metadata.
4. **Clip path ignored the streaming contract** (P1, `8ca08389`). `predict(..., stream=True)` on a finite video returned a bare list; it now returns an iterator, even though a whole clip collapses to one `Results`.
5. **README listed PE in two rows** (P2, `8ca08389`). Reduced to one, as described above.

`tests/unit/test_pe_clip_runtime.py` covers all of them: the stream contract, both metadata round-trips, exact backend-vs-native preprocessing, the save/vid_stride/show behavior, and the runtime clip wiring.

## Tests

`tests/unit/test_pe.py`, `tests/unit/test_pe_export.py`, and `tests/unit/test_pe_clip_runtime.py` — config table, forward/video contracts, checkpoint recognition including explicit rejection of CLIP/SigLIP2/DINOv2 lookalikes, converter guards, the full frame-sampling rule set, export-graph parity, export metadata round-trips, the streaming contract, and the no-regression assertions above.

`test_pe.py` and `test_pe_export.py` build on a randomly initialized tower, so they need no downloaded weights. `test_pe_clip_runtime.py` needs the converted `LibrePEt16-cls.pt` and is marked `external_data`, skipping when it is not staged.

Full `tests/unit` suite passes. One unrelated pre-existing flake (`test_darknet_edge_export_matrix.py::test_yolo1_raw_parity[openvino]`) appears only in whole-suite ordering and passes in isolation both with and without this branch.

## UI smoke

Ran through the UI's own result path (`libreyolo/ui/server.py`) with a converted `t16` checkpoint, `save=True`:

| flow | summary | annotated image |
| --- | --- | --- |
| zero-shot classify, two user classes | `('classify', 'a cat 65%')` | written |
| image embedding | `('embed', '1 image')` | written |
| finite-video embedding | `('embed', '1 image')` | written |

Summaries are task-appropriate rather than a fallback "0 objects", and inference needs no kwargs the UI cannot supply. PE introduces no new `Results` slot — it reuses `probs` and `embeddings` — so `_summarize_result` needed no extension.

## Not done

- The `greptile` CLI is not installed on this machine, so no local `greptile review --agent -b dev` was run. The PR bot review is the coverage instead; its three findings are addressed above.
- No benchmark numbers are claimed. No zero-shot accuracy figure is reported, because none was reproduced.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds the LibrePE model family for zero-shot classification and image, text, and whole-video embeddings, together with export and backend integration.
- Adds five PE architecture variants, checkpoint conversion, registration, and documentation.
- Adds deterministic finite-video sampling and clip-level embedding inference.
- Adds ONNX and TorchScript image, classification, and direct-runtime video export graphs with metadata.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because frozen-class TorchScript reload fails and non-native PE image-size overrides still reach a fixed-grid tensor mismatch.

Classification exports serialize names as a list while TorchScript reload calls items() on that value, and PE preprocessing still accepts arbitrary imgsz values even though the vision tower's positional and rotary embeddings are fixed to the native grid.

**Files Needing Attention:** libreyolo/models/pe/export.py, libreyolo/backends/torchscript.py, libreyolo/models/pe/model.py, libreyolo/models/pe/nn.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/pe/export.py | Adds task-aware PE export wrappers and metadata, but frozen-class TorchScript metadata stores names in a shape its loader cannot parse. |
| libreyolo/backends/torchscript.py | Adds video-input rejection and metadata reload support; classification-name parsing remains incompatible with PE's list metadata. |
| libreyolo/backends/onnx.py | Reads PE export metadata and explicitly rejects unsupported 5D video artifacts without affecting image artifacts. |
| libreyolo/backends/base.py | Adds PE-specific symmetric normalization and square bilinear resizing for exported image and classification graphs. |
| libreyolo/models/base/inference.py | Adds finite-video clip embedding while preserving iterator, save, and explicit unsupported-option behavior. |
| libreyolo/models/pe/model.py | Implements PE inference and preprocessing, but the previously reported non-native imgsz path remains incompatible with the fixed vision grid. |
| libreyolo/models/pe/nn.py | Implements the PE vision and text towers with fixed positional and rotary grids matching native model resolution. |
| libreyolo/utils/serialization.py | Adds narrowly scoped, actionable rejection for direct-runtime-only video export metadata. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Source[Image, text, or finite video] --> PE[LibrePE]
  PE --> Image[Image encoder]
  PE --> Text[Text encoder]
  PE --> Video[Uniform frame sampling]
  Video --> FrameEncode[Encode frames]
  FrameEncode --> Pool[Mean and L2 normalize]
  Image --> Embed[Shared embedding space]
  Text --> Embed
  Pool --> Embed
  Embed --> Classify[Zero-shot classification]
  Embed --> Export[ONNX or TorchScript export]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fpe%2Fexport.py%3A138%0A**TorchScript%20class%20metadata%20crashes%20reload**%0A%0AWhen%20a%20frozen-class%20PE%20TorchScript%20artifact%20is%20reloaded%2C%20%60build_metadata%60%20has%20serialized%20%60names%60%20as%20a%20list%20but%20%60TorchScriptBackend%60%20calls%20%60.items%28%29%60%20on%20the%20deserialized%20value%2C%20causing%20backend%20initialization%20to%20raise%20%60AttributeError%60%20instead%20of%20loading%20the%20classifier.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=746&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22637-port-pe-embed%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22637-port-pe-embed%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fpe%2Fexport.py%3A138%0A**TorchScript%20class%20metadata%20crashes%20reload**%0A%0AWhen%20a%20frozen-class%20PE%20TorchScript%20artifact%20is%20reloaded%2C%20%60build_metadata%60%20has%20serialized%20%60names%60%20as%20a%20list%20but%20%60TorchScriptBackend%60%20calls%20%60.items%28%29%60%20on%20the%20deserialized%20value%2C%20causing%20backend%20initialization%20to%20raise%20%60AttributeError%60%20instead%20of%20loading%20the%20classifier.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=746&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (7): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/libreyolo/libreyolo/commit/06b8553040b87f94e68e7b2c4dc36d0aa66e7113) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51642278)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)

<!-- /greptile_comment -->