### PR TITLE
Port V-JEPA 2.0 as the vjepa2 video embedding and classification family (both milestones)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Releases
 before 1.4.0 are documented in the
 [GitHub Releases](https://github.com/LibreYOLO/libreyolo/releases) only.
 
+## [Unreleased]
+
+### Added
+
+- **V-JEPA 2** (`vjepa2`), a self-supervised video encoder, under the generic
+  `embed` task plus `classify` for its released attentive probes. Sizes
+  `l256`, `h256`, `g256` and `g384`; canonical checkpoints
+  `LibreVJEPA2<size>-embed.pt` and `LibreVJEPA2<size>-cls-<ssv2|diving48>.pt`.
+  The encoder is a native pure-PyTorch port, so inference and export do not
+  depend on `transformers` at runtime.
+
+  This is the first family to consume a *clip* rather than a frame. A finite
+  video produces one result per sampled clip, with one clip by default;
+  every other family keeps its per-frame video result cardinality. An image
+  is accepted as an explicitly documented single-frame input, which is a
+  static appearance representation and not a motion one.
+
+  The public embedding is a LibreYOLO pooling contract, defined as the
+  arithmetic mean of the final encoder tokens followed by L2 normalization.
+  Upstream designates no global retrieval vector, and no retrieval benchmark
+  is claimed for it. The native spatiotemporal token grid is available
+  separately through `model.embed_tokens(...)` as `(B, T', H', W', D)`.
+
+  Encoder token and pooled-vector parity against unmodified
+  `transformers==5.1.0` is exact (`max_abs_diff == 0.0`) on float32 CPU for
+  `l256` and `h256`, as is single-view logit parity for the `l256` SSv2 probe.
+  ONNX and TorchScript ship fixed-frame 5D graphs with dynamic batch.
+
+  Self-supervised encoder pretraining is not implemented and rejects with an
+  actionable message; the attentive probe is the supported training path.
+
 ## [1.5.0] - 2026-08-09
 
 The largest release so far: 28 new model families, four new tasks (`edge`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,21 @@ before 1.4.0 are documented in the
 
   Encoder token and pooled-vector parity against unmodified
   `transformers==5.1.0` is exact (`max_abs_diff == 0.0`) on float32 CPU for
-  `l256` and `h256`, as is single-view logit parity for the `l256` SSv2 probe.
-  ONNX and TorchScript ship fixed-frame 5D graphs with dynamic batch.
+  all four sizes, as is single-view logit parity for three of the four
+  released probes. The `g384` Diving48 probe differs by one float32 ULP
+  (9.54e-07 absolute, 1.1e-07 relative); it is documented rather than papered
+  over, and the parity script still asserts `== 0.0`. ONNX and TorchScript
+  ship fixed-frame 5D graphs with dynamic batch.
 
-  Self-supervised encoder pretraining is not implemented and rejects with an
-  actionable message; the attentive probe is the supported training path.
+  A frozen attentive-probe trainer ships behind the normal
+  `model.train(data="video_dataset.yaml")` entry point. The encoder is frozen
+  and kept in eval mode; only the three-layer attentive pooler and the linear
+  classifier are optimized, and best checkpoints are selected by top-1
+  accuracy. Datasets are entirely user-supplied: manifests are validated in
+  full before the first epoch, and no video corpus is ever downloaded.
+
+  Self-supervised encoder pretraining, predictor pretraining and full encoder
+  fine-tuning all reject with actionable messages before a dataset is built.
 
 ## [1.5.0] - 2026-08-09
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Surface normals** | MoGe-2 |
 | **Edges** | DexiNed, TEED |
 | **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, DINOv2 |
+| **Video embeddings** | V-JEPA 2 (clip-level embedding and video classification) |
 | **Body mesh** | SAM 3D Body |
 | **Restoration** | NAFNet, Real-ESRGAN, SwinIR |
 | **Background removal** | BiRefNet, FeyNobg |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Surface normals** | MoGe-2 |
 | **Edges** | DexiNed, TEED |
 | **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, DINOv2 |
-| **Video embeddings** | V-JEPA 2 (clip-level embedding and video classification) |
+| **Video embeddings** | V-JEPA 2 (clip-level embedding, plus video classification with a trainable attentive probe) |
 | **Body mesh** | SAM 3D Body |
 | **Restoration** | NAFNet, Real-ESRGAN, SwinIR |
 | **Background removal** | BiRefNet, FeyNobg |

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -98,6 +98,8 @@ in preflight.
 | teed | edge | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
 | vgg | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | vit | classify | ✓ | available | available | available | available |  |  |  | available |  |  |  |
+| vjepa2 | embed | ✓ | ✓ | available | available | available |  |  |  |  |  |  |  |
+| vjepa2 | classify | available | available | available | available | available |  |  |  |  |  |  |  |
 | yolo1 | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
 | yolo2 | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  | ✓ |
 | yolo3 | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
@@ -369,6 +371,8 @@ A check mark applies only under any constraint listed here.
 - `vgg` / `classify` / `tensorrt`: FP32, batch 1, fixed 224x224 input
 - `vgg` / `classify` / `openvino`: FP32, batch 1, fixed 224x224 input
 - `vit` / `classify` / `onnx`: FP32, fixed 224x224 input
+- `vjepa2` / `embed` / `onnx`: FP32, dynamic batch, fixed frame count / crop / tubelet geometry per graph; ONNX needs opset >= 14 for scaled_dot_product_attention
+- `vjepa2` / `embed` / `torchscript`: FP32, dynamic batch, fixed frame count / crop / tubelet geometry per graph; ONNX needs opset >= 14 for scaled_dot_product_attention
 - `yolo1` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo1` / `detect` / `tensorrt`: TensorRT 10.16 FP32 with a fixed canvas; YOLO1 requires 448x448
 - `yolo1` / `detect` / `openvino`: fixed export canvas; YOLO1 requires 448x448
@@ -508,6 +512,14 @@ These converter paths are callable with the recorded validation context.
 - `vit` / `classify` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
 - `vit` / `classify` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
 - `vit` / `classify` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vjepa2` / `embed` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vjepa2` / `embed` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `vjepa2` / `embed` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
+- `vjepa2` / `classify` / `onnx`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vjepa2` / `classify` / `torchscript`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vjepa2` / `classify` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vjepa2` / `classify` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `vjepa2` / `classify` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
 - `yolo7` / `detect` / `tensorrt`: TensorRT 10.16 FP32 exports and reloads, but the permissively licensed trained checkpoint changes the public top-k class membership.
 - `yolo9` / `detect` / `rknn`: Exact small variants passed RKNN Toolkit2 2.3.2 compilation, RK3588 PC-simulator raw-output gates, and matched post-NMS detections on a real image. Support is limited to YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s; on-device latency and parity have not been measured. Constraint: RKNN Toolkit2 2.3.2, RK3588 PC simulator, vendor floating build, batch 1, fixed square input
 - `yolo9` / `detect` / `coreml`: Conversion is available, but runtime parity requires a macOS runner.
@@ -1233,6 +1245,20 @@ These converter paths are callable with the recorded validation context.
 - `vit` / `classify` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `vit` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `vit` / `classify` / `coreai`: This family and task have not been validated for Core AI export.
+- `vjepa2` / `embed` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
+- `vjepa2` / `embed` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
+- `vjepa2` / `embed` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
+- `vjepa2` / `embed` / `ncnn`: Both toolchains are built around rank-4 image tensors; a rank-5 clip input has no supported conversion path.
+- `vjepa2` / `embed` / `tflite`: Both toolchains are built around rank-4 image tensors; a rank-5 clip input has no supported conversion path.
+- `vjepa2` / `embed` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `vjepa2` / `embed` / `coreai`: This family and task have not been validated for Core AI export.
+- `vjepa2` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
+- `vjepa2` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
+- `vjepa2` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
+- `vjepa2` / `classify` / `ncnn`: Both toolchains are built around rank-4 image tensors; a rank-5 clip input has no supported conversion path.
+- `vjepa2` / `classify` / `tflite`: Both toolchains are built around rank-4 image tensors; a rank-5 clip input has no supported conversion path.
+- `vjepa2` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `vjepa2` / `classify` / `coreai`: This family and task have not been validated for Core AI export.
 - `yolo1` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
 - `yolo1` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolo1` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -371,8 +371,8 @@ A check mark applies only under any constraint listed here.
 - `vgg` / `classify` / `tensorrt`: FP32, batch 1, fixed 224x224 input
 - `vgg` / `classify` / `openvino`: FP32, batch 1, fixed 224x224 input
 - `vit` / `classify` / `onnx`: FP32, fixed 224x224 input
-- `vjepa2` / `embed` / `onnx`: FP32, dynamic batch, fixed frame count / crop / tubelet geometry per graph; ONNX needs opset >= 14 for scaled_dot_product_attention
-- `vjepa2` / `embed` / `torchscript`: FP32, dynamic batch, fixed frame count / crop / tubelet geometry per graph; ONNX needs opset >= 14 for scaled_dot_product_attention
+- `vjepa2` / `embed` / `onnx`: FP32, dynamic batch, fixed frame count / crop / tubelet geometry per graph; ONNX needs opset >= 14 for scaled_dot_product_attention. The graph must be driven with a 5D clip: LibreYOLO's exported-backend path still preprocesses to a 4D image batch and raises NotImplementedError for this family.
+- `vjepa2` / `embed` / `torchscript`: FP32, dynamic batch, fixed frame count / crop / tubelet geometry per graph; ONNX needs opset >= 14 for scaled_dot_product_attention. The graph must be driven with a 5D clip: LibreYOLO's exported-backend path still preprocesses to a 4D image batch and raises NotImplementedError for this family.
 - `yolo1` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo1` / `detect` / `tensorrt`: TensorRT 10.16 FP32 with a fixed canvas; YOLO1 requires 448x448
 - `yolo1` / `detect` / `openvino`: fixed export canvas; YOLO1 requires 448x448

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -109,6 +109,7 @@ the `alexnet` / `deit` / `mobilenetv4` / `convnext` / `efficientnetv2` /
 | `swin`      | `LibreSwin`      | Upstream brand casing preserved (`Swin Transformer V1`) — classify-only and inference-only |
 | `clip`      | `LibreCLIP`     | All-caps acronym (`CLIP` zero-shot classify + image/text embed) — inference-only |
 | `siglip2`   | `LibreSigLIP2`  | Upstream brand casing preserved (`SigLIP`) + version (`SigLIP 2` zero-shot classify + image/text embed); inference-only |
+| `vjepa2`    | `LibreVJEPA2`   | All-caps acronym + version (`V-JEPA 2`), hyphen dropped; video clip embedding (`embed`) + attentive-probe video classification (`classify`) |
 | `nafnet`    | `LibreNAFNet`   | All-caps acronym + CamelCase `Net`; restore-only image-restoration family |
 | `realesrgan` | `LibreRealESRGAN` | Upstream brand casing (`RealESRGAN`); restore-only super-resolution family |
 | `swinir`    | `LibreSwinIR`    | Upstream brand casing (`SwinIR`); restore-only transformer super-resolution family |
@@ -690,6 +691,25 @@ LibreCLIPl14-cls.pt       # OpenCLIP ViT-L/14, LAION-2B (config + converter read
 # Use the same -cls artifact with task="embed"; size codes bake in resolution.
 LibreSigLIP2b16-cls.pt    # google/siglip2-base-patch16-256 (Apache-2.0 weights), 256 px
 LibreSigLIP2so400m-cls.pt # google/siglip2-so400m-patch14-384 (Apache-2.0 weights), 384 px
+
+# vjepa2: V-JEPA 2 self-supervised video encoder. Consumes a CLIP, not a frame.
+# Size codes bake in the crop, because g256 and g384 are the same network at
+# different input resolutions. Every artifact carries a task suffix: a bare
+# LibreVJEPA2l256.pt is not canonical.
+LibreVJEPA2l256-embed.pt        # facebook/vjepa2-vitl-fpc64-256 (MIT weights), 256 px, 64 frames
+LibreVJEPA2h256-embed.pt        # facebook/vjepa2-vith-fpc64-256 (MIT weights), 256 px, 64 frames
+LibreVJEPA2g256-embed.pt        # facebook/vjepa2-vitg-fpc64-256 (Apache-2.0 weights), 256 px, 64 frames
+LibreVJEPA2g384-embed.pt        # facebook/vjepa2-vitg-fpc64-384 (Apache-2.0 weights), 384 px, 64 frames
+
+# Published attentive probes place the dataset variant AFTER the task suffix.
+# Only these four size/variant pairs exist; -cls without a variant, and any
+# other size/variant combination, are rejected even though the filename regex
+# can parse them. A locally trained probe loads from its explicit path and is
+# never assigned a published variant.
+LibreVJEPA2l256-cls-ssv2.pt     # 16 frames, 174 classes (MIT weights)
+LibreVJEPA2l256-cls-diving48.pt # 32 frames,  48 classes (MIT weights)
+LibreVJEPA2g384-cls-ssv2.pt     # 64 frames, 174 classes (MIT weights)
+LibreVJEPA2g384-cls-diving48.pt # 32 frames,  48 classes (MIT weights)
 ```
 
 ### VLM analysis (external snapshot tier)

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -81,6 +81,7 @@ _MODEL_EXPORTS = (
     "LibreCLIP",
     "LibreSigLIP2",
     "LibrePPOCR",
+    "LibreVJEPA2",
 )
 _RESULTS_EXPORTS = (
     "Results",
@@ -300,6 +301,7 @@ __all__ = [
     "LibreCLIP",
     "LibreSigLIP2",
     "LibrePPOCR",
+    "LibreVJEPA2",
     "LibreDINOv2",
     # VLM-as-detector tier (optional, requires libreyolo[vlm])
     "LibreVLM",

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -553,6 +553,21 @@ class BaseBackend(ABC):
                 input_size=effective_imgsz,
                 color_format=color_format,
             )
+        if self.model_family == "vjepa2":
+            # Every V-JEPA 2 graph takes a rank-5 clip (B, F, C, H, W). The
+            # image preprocessing below produces a rank-4 batch, which the
+            # runtime rejects with an opaque "Invalid rank" error. Fail here
+            # with something actionable instead. Feeding these graphs a clip
+            # through the exported-backend path is not wired up yet.
+            raise NotImplementedError(
+                "Exported V-JEPA 2 graphs take a 5D video clip "
+                "(B, F, C, H, W), and LibreYOLO's exported-backend "
+                "preprocessing currently supplies a 4D image batch, so "
+                f"{self.task!r} inference through this path is not supported "
+                "yet. Use the PyTorch checkpoint "
+                "(LibreYOLO('LibreVJEPA2<size>-embed.pt')) for clip inference, "
+                "or drive the exported graph directly with your own 5D input."
+            )
         if self.task in {"classify", "embed"}:
             return self._preprocess_classify(image, effective_imgsz, color_format)
         if self.task == "point" and self.model_family == "fomo":

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -236,6 +236,23 @@ class _ImageEmbeddingExportWrapper(torch.nn.Module):
         return torch.nn.functional.normalize(self.image_tower(x).float(), dim=-1)
 
 
+class _VideoEmbeddingExportWrapper(torch.nn.Module):
+    """Trace a V-JEPA 2 encoder as a fixed-frame clip embedding graph.
+
+    Input is the public 5D video layout ``(B, F, C, H, W)``; output is the
+    pooled, L2-normalized ``(B, D)`` row. The raw token grid is deliberately
+    not an export target.
+    """
+
+    def __init__(self, encoder: torch.nn.Module):
+        super().__init__()
+        self.encoder = encoder
+
+    def forward(self, x):
+        tokens = self.encoder(x)
+        return torch.nn.functional.normalize(tokens.mean(dim=1).float(), dim=-1)
+
+
 class _YOLONASExportWrapper(torch.nn.Module):
     """Expose decoded YOLO-NAS tensors without training-only auxiliaries."""
 
@@ -824,6 +841,8 @@ class BaseExporter(ABC):
         # model is restored on exit.
         dfine_wrapped = False
         rfdetr_export_activated = False
+        # Non-None only for families whose graph consumes a 5D video clip.
+        video_export_frames = None
         rfdetr_export_snapshots = []
         rfdetr_inner = None
         family = self.model._get_model_name()
@@ -1034,6 +1053,15 @@ class BaseExporter(ABC):
             nn_model = _ImageEmbeddingExportWrapper(image_tower).to(device)
             nn_model.eval()
             dfine_wrapped = True
+        elif family == "vjepa2":
+            # Every V-JEPA 2 graph takes a 5D clip. The embed graph pools to a
+            # normalized row; the classify graph already ends at logits, so it
+            # only needs the 5D dummy below.
+            if task == "embed":
+                nn_model = _VideoEmbeddingExportWrapper(nn_model).to(device)
+            nn_model.eval()
+            video_export_frames = int(getattr(self.model, "clip_frames", 64))
+            dfine_wrapped = True
         elif family in {"clip", "siglip2"} and task == "classify":
             text_embeds = getattr(self.model, "_text_embeds", None)
             if text_embeds is None:
@@ -1116,7 +1144,12 @@ class BaseExporter(ABC):
                 pass
 
         h, w = imgsz
-        dummy = torch.randn(batch, 3, h, w, device=device)
+        if video_export_frames is not None:
+            # Public clip layout (B, F, C, H, W). Frame count, crop and tubelet
+            # geometry are fixed per graph; only batch may be dynamic.
+            dummy = torch.randn(batch, video_export_frames, 3, h, w, device=device)
+        else:
+            dummy = torch.randn(batch, 3, h, w, device=device)
 
         if half and not int8 and self.apply_model_half:
             nn_model.half()

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -50,6 +50,9 @@ def _requires_onnx_opset17(model_family) -> bool:
         "deit",
         "midas",
         "moge2",
+        # V-JEPA 2 attention lowers to aten::scaled_dot_product_attention,
+        # which ONNX only supports from opset 14.
+        "vjepa2",
     }
 
 

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -3671,3 +3671,36 @@ __all__ = [
     "iter_validated",
     "validated_alternatives",
 ]
+
+
+# --- V-JEPA 2 -------------------------------------------------------------
+#
+# Every V-JEPA 2 graph consumes a 5D video clip, so only the formats whose
+# toolchains were actually exercised on a rank-5 input are claimed here.
+_add(
+    "validated",
+    ("vjepa2",),
+    ("embed",),
+    ("onnx", "torchscript"),
+    reason=(
+        "Fixed-frame 5D clip graphs are covered by export, runtime reload, "
+        "torch-vs-runtime embedding parity, unit-norm output, and a "
+        "temporal-order sensitivity check that fails a graph which ignores "
+        "frame order."
+    ),
+    since="1.6",
+    constraint=(
+        "FP32, dynamic batch, fixed frame count / crop / tubelet geometry per "
+        "graph; ONNX needs opset >= 14 for scaled_dot_product_attention"
+    ),
+)
+_add(
+    "blocked",
+    ("vjepa2",),
+    ("embed", "classify"),
+    ("ncnn", "tflite"),
+    reason=(
+        "Both toolchains are built around rank-4 image tensors; a rank-5 clip "
+        "input has no supported conversion path."
+    ),
+)

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -3686,12 +3686,16 @@ _add(
         "Fixed-frame 5D clip graphs are covered by export, runtime reload, "
         "torch-vs-runtime embedding parity, unit-norm output, and a "
         "temporal-order sensitivity check that fails a graph which ignores "
-        "frame order."
+        "frame order. Parity is measured by driving the runtime directly "
+        "with a 5D clip."
     ),
     since="1.6",
     constraint=(
         "FP32, dynamic batch, fixed frame count / crop / tubelet geometry per "
-        "graph; ONNX needs opset >= 14 for scaled_dot_product_attention"
+        "graph; ONNX needs opset >= 14 for scaled_dot_product_attention. "
+        "The graph must be driven with a 5D clip: LibreYOLO's exported-backend "
+        "path still preprocesses to a 4D image batch and raises "
+        "NotImplementedError for this family."
     ),
 )
 _add(

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -146,6 +146,13 @@ from .siglip2.model import LibreSigLIP2  # noqa: E402,F401  (import registers fa
 # on the composite det.*/rec.* checkpoint layout, so order does not matter.
 from .ppocr.model import LibrePPOCR  # noqa: E402,F401  (import registers family)
 
+# V-JEPA 2 video encoder + attentive probe: a native pure-torch port (no
+# transformers at runtime), so it registers eagerly. can_load is keyed on a 5D
+# Conv3d tubelet patch embedding, which no image family can produce, so
+# registration order does not matter. OpenCV is imported lazily inside the clip
+# sampler, keeping video decoding off the global import path.
+from .vjepa2.model import LibreVJEPA2  # noqa: E402,F401  (import registers family)
+
 
 def _ensure_rfdetr():
     """Lazily register RF-DETR and LibreDINOv2 if their dependencies are installed."""

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -1422,21 +1422,43 @@ class InferenceRunner:
         try:
             total = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
             if total <= 0:
-                # Some containers do not report a frame count; fall back to a
-                # bounded decode rather than trusting the header.
-                frames_all = []
-                while True:
-                    ok, frame = capture.read()
-                    if not ok:
-                        break
-                    frames_all.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-                if not frames_all:
+                # Some containers do not report a frame count. Count in a first
+                # pass without retaining pixels, then decode only the frames the
+                # clip needs. Buffering the whole video here would make memory
+                # grow with its length and can exhaust RAM on a long file; the
+                # clip is bounded, so the decode should be too.
+                counted = 0
+                while capture.grab():  # grab() advances without decoding pixels
+                    counted += 1
+                if counted == 0:
                     raise ValueError(
                         f"Decoded no frames from {path}; refusing to treat a "
                         "corrupt or empty video as a black clip."
                     )
-                indices = self.model.sample_clip_indices(len(frames_all), vid_stride)
-                frames = [frames_all[i] for i in indices]
+                indices = self.model.sample_clip_indices(counted, vid_stride)
+                wanted = set(indices)
+                capture.release()
+                capture = cv2.VideoCapture(path)
+                decoded = {}
+                position = 0
+                highest = max(wanted)
+                while position <= highest:
+                    ok, frame = capture.read()
+                    if not ok:
+                        break
+                    if position in wanted:
+                        decoded[position] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                    position += 1
+                if not decoded:
+                    raise ValueError(
+                        f"Could not decode any frame from {path}; refusing to "
+                        "treat it as a black clip."
+                    )
+                held = decoded[min(decoded)]
+                frames = []
+                for index in indices:
+                    held = decoded.get(index, held)
+                    frames.append(held)
             else:
                 indices = self.model.sample_clip_indices(total, vid_stride)
                 frames = []

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -1338,8 +1338,27 @@ class InferenceRunner:
         source_label: Optional[str] = None,
         **kwargs,
     ) -> Generator[Results, None, None]:
-        """Run inference on a video file, yielding per-frame Results."""
+        """Run inference on a video file, yielding per-frame Results.
+
+        Families that declare ``VIDEO_EMBED_MODE = "clip"`` consume a clip
+        rather than a frame, and yield one result per sampled clip instead of
+        one per frame. Every other family keeps the per-frame path below.
+        """
         source_label = str(source) if source_label is None else source_label
+
+        if getattr(self.model, "VIDEO_EMBED_MODE", "frames") == "clip":
+            yield self._predict_video_clip(
+                source,
+                conf=conf,
+                iou=iou,
+                classes=classes,
+                max_det=max_det,
+                source_label=source_label,
+                vid_stride=vid_stride,
+                **kwargs,
+            )
+            return
+
         yield from run_video_inference(
             source,
             self._frame_predictor(
@@ -1356,6 +1375,86 @@ class InferenceRunner:
             show=show,
             output_path=output_path,
         )
+
+    def _predict_video_clip(
+        self,
+        source: Union[str, Path, FrameSource],
+        *,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        source_label: str = "",
+        vid_stride: int = 1,
+        **kwargs,
+    ) -> Results:
+        """Decode one clip from a finite video and run a single forward pass.
+
+        Temporal sampling is family-local: the model owns the frame count,
+        stride and clip position. Decoding and error handling stay here so
+        every clip-mode family shares them.
+        """
+        import cv2
+
+        if not isinstance(source, (str, Path)):
+            raise ValueError(
+                "Clip-mode inference needs a finite video path. An unbounded "
+                "source cannot be sampled into a centered clip without "
+                "buffering it, which this path deliberately refuses to do."
+            )
+
+        path = str(source)
+        capture = cv2.VideoCapture(path)
+        if not capture.isOpened():
+            raise ValueError(f"Could not open video: {path}")
+
+        try:
+            total = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+            if total <= 0:
+                # Some containers do not report a frame count; fall back to a
+                # bounded decode rather than trusting the header.
+                frames_all = []
+                while True:
+                    ok, frame = capture.read()
+                    if not ok:
+                        break
+                    frames_all.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+                if not frames_all:
+                    raise ValueError(
+                        f"Decoded no frames from {path}; refusing to treat a "
+                        "corrupt or empty video as a black clip."
+                    )
+                indices = self.model.sample_clip_indices(len(frames_all), vid_stride)
+                frames = [frames_all[i] for i in indices]
+            else:
+                indices = self.model.sample_clip_indices(total, vid_stride)
+                frames = []
+                for index in indices:
+                    capture.set(cv2.CAP_PROP_POS_FRAMES, int(index))
+                    ok, frame = capture.read()
+                    if not ok:
+                        if not frames:
+                            raise ValueError(
+                                f"Could not decode any frame from {path}; "
+                                "refusing to treat it as a black clip."
+                            )
+                        # Past the real end: hold the last decoded frame.
+                        frames.append(frames[-1])
+                        continue
+                    frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+        finally:
+            capture.release()
+
+        input_tensor, _, original_size, ratio = self.model._preprocess(frames, "rgb")
+        with torch.no_grad():
+            output = forward_maybe_graphed(
+                self.model, input_tensor.to(self.model.device)
+            )
+        detections = self.model._postprocess(
+            output, conf, iou, original_size, max_det=max_det, ratio=ratio,
+            classes=classes, **kwargs,
+        )
+        return self._wrap_results(detections, original_size, source_label, classes)
 
     def _frame_predictor(
         self,

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -1347,6 +1347,17 @@ class InferenceRunner:
         source_label = str(source) if source_label is None else source_label
 
         if getattr(self.model, "VIDEO_EMBED_MODE", "frames") == "clip":
+            # Clip mode collapses the video to a single result, so there is no
+            # per-frame stream to annotate, write or display. Say so rather
+            # than accepting the flag and silently producing nothing.
+            if save or show:
+                raise NotImplementedError(
+                    "save=True / show=True are not supported for clip-mode "
+                    "video inference: the video collapses to one result per "
+                    "clip, so there is no annotated frame stream to write or "
+                    "display. Use the returned Results (for example "
+                    "result.embeddings) directly."
+                )
             yield self._predict_video_clip(
                 source,
                 conf=conf,

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -160,6 +160,13 @@ class BaseModel(ABC):
     # Hugging Face repo name in ``get_download_url``.
     WEIGHT_VARIANTS: ClassVar[tuple[str, ...]] = ()
 
+    # How a finite video is consumed. "frames" (the default) runs the model on
+    # each decoded frame and yields one result per frame, which is what every
+    # image-native family wants. "clip" opts a family into sampling one
+    # temporal clip and yielding one result per clip; the family then owns
+    # temporal sampling via ``sample_clip_indices``.
+    VIDEO_EMBED_MODE: ClassVar[str] = "frames"
+
     # Batched-predict policy: True when ``_preprocess`` yields stackable
     # (1, C, H, W) tensors and every tensor in the ``_forward`` output keeps
     # a leading batch dim (the contract batched validation already relies

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -49,6 +49,7 @@ MODEL_GROUPS: dict[str, str] = {
     "mobilenetv4": "g2",
     "efficientnetv2": "g2",
     "domedetr": "g2",
+    "vjepa2": "g2",
     # g3 - inference-only specialists
     "lwdetr": "g3",
     "detr": "g3",

--- a/libreyolo/models/vjepa2/NOTICE
+++ b/libreyolo/models/vjepa2/NOTICE
@@ -1,0 +1,75 @@
+LibreYOLO V-JEPA 2 family
+=========================
+
+This directory contains a native PyTorch port of V-JEPA 2.0 (encoder,
+attentive pooler and video classification probe).
+
+Code provenance
+---------------
+
+1. Hugging Face Transformers -- Apache License 2.0
+   Source: https://github.com/huggingface/transformers
+   Pinned: tag v5.1.0, commit 3fa4da70f5d1da3ab1a8304bd2339eab7004b157
+   File:   src/transformers/models/vjepa2/modeling_vjepa2.py
+   Used by: libreyolo/models/vjepa2/nn.py
+
+   `nn.py` is adapted from the above file. Copyright 2025 The HuggingFace
+   Inc. team. All rights reserved. Licensed under the Apache License,
+   Version 2.0 (the "License"); you may not use that file except in
+   compliance with the License. You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   This is Apache-2.0 licensed code vendored into an MIT-licensed project.
+   It is NOT relicensed as MIT. The Apache-2.0 terms above continue to
+   govern the adapted portions of `nn.py`.
+
+2. facebookresearch/vjepa2 -- MIT License
+   Source: https://github.com/facebookresearch/vjepa2
+   Pinned: commit 204698b45b3712590f06245fbfba32d3be539812
+   Copyright (c) Meta Platforms, Inc. and affiliates.
+
+   Used as the semantic upstream (architecture behaviour, preprocessing
+   evidence, attentive-probe recipe) and as the independent parity oracle.
+
+   Three files in that repository are Apache-2.0 rather than MIT:
+       src/datasets/utils/video/randaugment.py
+       src/datasets/utils/video/randerase.py
+       src/datasets/utils/video/worker_init_fn.py
+   None of them are adapted, imported or vendored by this port.
+
+Weight provenance
+-----------------
+
+Weight licenses are per artifact and are deliberately NOT collapsed into a
+single family-wide claim. See `weights/LICENSE_NOTICE.txt` for the full table
+with exact source revisions.
+
+  Encoders
+    facebook/vjepa2-vitl-fpc64-256 @ b3c1679b7c34d3255ef3547f27c7b226aefab26f  MIT
+    facebook/vjepa2-vith-fpc64-256 @ b5eac8703e3efdc1547fbb6ddfbeb133dc0bdee5  MIT
+    facebook/vjepa2-vitg-fpc64-256 @ 875c192b7b704b87d1e1d99345769632dd5f739a  Apache-2.0
+    facebook/vjepa2-vitg-fpc64-384 @ 12ca91694b230e0d4b5b0078af6f4ae1d51e933d  Apache-2.0
+
+  Attentive probes
+    facebook/vjepa2-vitl-fpc16-256-ssv2      @ 4aa02df83918538fc21cfaf576382fa20e489a80  MIT
+    facebook/vjepa2-vitl-fpc32-256-diving48  @ 71ae2a8b1ff5a297aeeaae9b5e64c7a2e5e6a633  MIT
+    facebook/vjepa2-vitg-fpc64-384-ssv2      @ 9f5fd615cb6f79065a28edcf1cc3ef25010dddfa  MIT
+    facebook/vjepa2-vitg-fpc32-384-diving48  @ 0b48243375319bd8e03e3cd5560d957095429189  MIT
+
+Dataset boundary
+----------------
+
+No dataset content or annotations are vendored. Something-Something V2 is
+distributed under a research-use agreement and must remain user-supplied.
+Diving48's redistribution terms are not clearly established by the selected
+official source and it is treated as unknown-license for redistribution.
+Neither, nor Kinetics, is downloaded, mirrored or bundled by LibreYOLO.
+Dataset names recorded per checkpoint are provenance only and do not imply
+that dataset terms apply to the code or the converted weights.

--- a/libreyolo/models/vjepa2/__init__.py
+++ b/libreyolo/models/vjepa2/__init__.py
@@ -5,6 +5,7 @@ port is adapted from Apache-2.0 Hugging Face Transformers and is not
 relicensed as MIT.
 """
 
+from .model import LibreVJEPA2
 from .nn import (
     VJEPA2_CONFIGS,
     LibreVJEPA2Classifier,
@@ -14,6 +15,7 @@ from .nn import (
 
 __all__ = [
     "VJEPA2_CONFIGS",
+    "LibreVJEPA2",
     "LibreVJEPA2Classifier",
     "LibreVJEPA2Encoder",
     "VJEPA2Config",

--- a/libreyolo/models/vjepa2/__init__.py
+++ b/libreyolo/models/vjepa2/__init__.py
@@ -1,0 +1,20 @@
+"""LibreVJEPA2 family: V-JEPA 2.0 video encoder and attentive-probe classifier.
+
+See ``NOTICE`` in this directory for code and weight provenance. The encoder
+port is adapted from Apache-2.0 Hugging Face Transformers and is not
+relicensed as MIT.
+"""
+
+from .nn import (
+    VJEPA2_CONFIGS,
+    LibreVJEPA2Classifier,
+    LibreVJEPA2Encoder,
+    VJEPA2Config,
+)
+
+__all__ = [
+    "VJEPA2_CONFIGS",
+    "LibreVJEPA2Classifier",
+    "LibreVJEPA2Encoder",
+    "VJEPA2Config",
+]

--- a/libreyolo/models/vjepa2/dataset.py
+++ b/libreyolo/models/vjepa2/dataset.py
@@ -1,0 +1,261 @@
+"""User-supplied video classification dataset for the V-JEPA 2 attentive probe.
+
+The dataset is entirely user-supplied. Nothing here downloads, mirrors or
+bundles Something-Something V2, Diving48, Kinetics or any other corpus.
+
+Data YAML keeps the usual LibreYOLO shape::
+
+    path: /path/to/dataset
+    train: train.txt
+    val: val.txt
+    names:
+      0: class_a
+      1: class_b
+
+Each manifest line is ``<relative-video-path> <integer-class-id>``. Paths may
+contain spaces: the class id is parsed from the **last** whitespace-separated
+field and everything before it is the path. A tab, if present, is treated as
+the delimiter instead, which makes paths with trailing spaces representable.
+Quoting the path also works.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from .preprocess import clip_frame_indices, preprocess_frames
+
+
+class ManifestError(ValueError):
+    """Raised for malformed dataset YAML or manifest rows."""
+
+
+def parse_manifest_line(line: str, lineno: int) -> Tuple[str, int]:
+    """Parse one ``<path> <class-id>`` row.
+
+    The class id is taken from the last field so that unquoted paths with
+    spaces still parse. A malformed row is an error, never a silent skip.
+    """
+    raw = line.rstrip("\n").rstrip("\r")
+    if not raw.strip():
+        raise ManifestError(f"line {lineno}: blank line")
+
+    if "\t" in raw:
+        path_part, _, label_part = raw.rpartition("\t")
+    else:
+        path_part, _, label_part = raw.rpartition(" ")
+
+    if not path_part.strip():
+        raise ManifestError(
+            f"line {lineno}: expected '<video-path> <class-id>', got {raw!r}"
+        )
+
+    path_part = path_part.strip()
+    if len(path_part) >= 2 and path_part[0] == path_part[-1] and path_part[0] in "\"'":
+        path_part = path_part[1:-1]
+
+    try:
+        label = int(label_part.strip())
+    except ValueError:
+        raise ManifestError(
+            f"line {lineno}: class id {label_part.strip()!r} is not an integer"
+        ) from None
+
+    return path_part, label
+
+
+def load_video_dataset(data_yaml: str | Path) -> Dict:
+    """Validate the YAML and both manifests before any training starts.
+
+    Every failure mode is reported up front rather than at the first bad batch:
+    missing keys, missing files, duplicate class ids, out-of-range labels and a
+    names/label mismatch.
+    """
+    import yaml
+
+    yaml_path = Path(data_yaml)
+    if not yaml_path.exists():
+        raise ManifestError(f"dataset YAML not found: {yaml_path}")
+
+    with yaml_path.open(encoding="utf-8") as handle:
+        config = yaml.safe_load(handle)
+    if not isinstance(config, dict):
+        raise ManifestError(f"{yaml_path}: expected a YAML mapping")
+
+    names = config.get("names")
+    if not isinstance(names, dict) or not names:
+        raise ManifestError(f"{yaml_path}: 'names' must be a non-empty mapping")
+
+    try:
+        names = {int(k): str(v) for k, v in names.items()}
+    except (TypeError, ValueError):
+        raise ManifestError(f"{yaml_path}: 'names' keys must be integers") from None
+
+    expected = set(range(len(names)))
+    if set(names) != expected:
+        raise ManifestError(
+            f"{yaml_path}: 'names' keys must be contiguous 0..{len(names) - 1}, "
+            f"got {sorted(names)}"
+        )
+
+    root = Path(config.get("path", yaml_path.parent))
+    if not root.is_absolute():
+        root = (yaml_path.parent / root).resolve()
+
+    splits: Dict[str, List[Tuple[Path, int]]] = {}
+    for split in ("train", "val"):
+        rel = config.get(split)
+        if rel is None:
+            if split == "train":
+                raise ManifestError(f"{yaml_path}: missing required '{split}' manifest")
+            continue
+        manifest = Path(rel)
+        if not manifest.is_absolute():
+            manifest = root / manifest
+        if not manifest.exists():
+            raise ManifestError(f"{yaml_path}: {split} manifest not found: {manifest}")
+
+        entries: List[Tuple[Path, int]] = []
+        with manifest.open(encoding="utf-8") as handle:
+            for lineno, line in enumerate(handle, start=1):
+                if not line.strip():
+                    continue
+                rel_path, label = parse_manifest_line(line, lineno)
+                if not 0 <= label < len(names):
+                    raise ManifestError(
+                        f"{manifest}:{lineno}: class id {label} out of range for "
+                        f"{len(names)} classes"
+                    )
+                video = Path(rel_path)
+                if not video.is_absolute():
+                    video = root / video
+                if not video.exists():
+                    raise ManifestError(f"{manifest}:{lineno}: video not found: {video}")
+                entries.append((video, label))
+
+        if not entries:
+            raise ManifestError(f"{manifest}: no usable rows")
+        splits[split] = entries
+
+    labels_seen = {label for entries in splits.values() for _, label in entries}
+    unused = set(names) - labels_seen
+    if unused:
+        raise ManifestError(
+            f"{yaml_path}: classes {sorted(unused)} appear in 'names' but in no "
+            "manifest row; fix the names mapping or the manifests"
+        )
+
+    return {"root": root, "names": names, "nc": len(names), **splits}
+
+
+def decode_clip(
+    path: Path,
+    clip_frames: int,
+    frame_stride: int,
+    crop_size: int,
+    *,
+    train: bool,
+    rng: random.Random | None = None,
+) -> torch.Tensor:
+    """Decode one clip as ``(F, C, H, W)``.
+
+    Validation is deterministic (centered). Training takes a random temporal
+    crop, which is the only augmentation the pinned probe recipe requires.
+    """
+    import cv2
+
+    capture = cv2.VideoCapture(str(path))
+    if not capture.isOpened():
+        raise ManifestError(f"could not open video: {path}")
+    try:
+        total = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+        if total <= 0:
+            total = 0
+            while capture.grab():
+                total += 1
+            capture.release()
+            capture = cv2.VideoCapture(str(path))
+        if total <= 0:
+            raise ManifestError(f"decoded no frames from {path}")
+
+        indices = clip_frame_indices(total, clip_frames, frame_stride)
+        if train and rng is not None:
+            span = (clip_frames - 1) * frame_stride + 1
+            if total > span:
+                start = rng.randint(0, total - span)
+                indices = [start + i * frame_stride for i in range(clip_frames)]
+
+        wanted = set(indices)
+        decoded: Dict[int, np.ndarray] = {}
+        position = 0
+        highest = max(wanted)
+        while position <= highest:
+            ok, frame = capture.read()
+            if not ok:
+                break
+            if position in wanted:
+                decoded[position] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            position += 1
+        if not decoded:
+            raise ManifestError(f"could not decode any frame from {path}")
+
+        held = decoded[min(decoded)]
+        frames = []
+        for index in indices:
+            held = decoded.get(index, held)
+            frames.append(held)
+    finally:
+        capture.release()
+
+    # preprocess_frames returns (1, F, C, H, W); the dataset item drops batch.
+    return preprocess_frames(frames, crop_size)[0]
+
+
+class VideoClipDataset(Dataset):
+    """Returns ``((F, C, H, W), int)``; the collate keeps time out of batch."""
+
+    def __init__(
+        self,
+        entries: Sequence[Tuple[Path, int]],
+        clip_frames: int,
+        frame_stride: int,
+        crop_size: int,
+        *,
+        train: bool,
+        seed: int = 0,
+    ):
+        self.entries = list(entries)
+        self.clip_frames = clip_frames
+        self.frame_stride = frame_stride
+        self.crop_size = crop_size
+        self.train = train
+        self._seed = seed
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def __getitem__(self, index: int):
+        path, label = self.entries[index]
+        rng = random.Random(self._seed + index) if self.train else None
+        clip = decode_clip(
+            path,
+            self.clip_frames,
+            self.frame_stride,
+            self.crop_size,
+            train=self.train,
+            rng=rng,
+        )
+        return clip, label
+
+
+def collate_clips(batch):
+    """``(B, F, C, H, W)`` plus labels. Time must never fold into batch."""
+    clips = torch.stack([item[0] for item in batch], dim=0)
+    labels = torch.as_tensor([item[1] for item in batch], dtype=torch.long)
+    return clips, labels

--- a/libreyolo/models/vjepa2/model.py
+++ b/libreyolo/models/vjepa2/model.py
@@ -237,6 +237,37 @@ class LibreVJEPA2(BaseModel):
         # dict); loading from a file is the family's job, as in every sibling.
         if isinstance(model_path, (str, Path)):
             self._load_weights(str(model_path))
+            self._adopt_checkpoint_clip_geometry(str(model_path))
+
+    def _adopt_checkpoint_clip_geometry(self, model_path: str) -> None:
+        """Recover the dataset variant and frame count from checkpoint metadata.
+
+        A probe must run at the frame count it was trained for -- an SSv2 L/256
+        probe is a 16-frame artifact, and silently running it at the encoder's
+        64 frames would change its pooled statistics and its logits. The
+        factory does not thread ``variant`` through, so it is read back here
+        rather than guessed from the size.
+        """
+        try:
+            from ...utils.serialization import load_trusted_torch_file
+
+            checkpoint = load_trusted_torch_file(model_path, map_location="cpu")
+        except Exception:  # pragma: no cover - metadata is best-effort
+            return
+        if not isinstance(checkpoint, dict):
+            return
+
+        variant = checkpoint.get("variant")
+        if isinstance(variant, str) and variant in self.WEIGHT_VARIANTS:
+            self.variant = variant
+
+        frames = checkpoint.get("frames_per_clip")
+        if isinstance(frames, int) and frames > 0:
+            self._requested_clip_frames = frames
+
+        stride = checkpoint.get("frame_stride")
+        if isinstance(stride, int) and stride > 0:
+            self.frame_stride = stride
 
     @property
     def clip_frames(self) -> int:

--- a/libreyolo/models/vjepa2/model.py
+++ b/libreyolo/models/vjepa2/model.py
@@ -422,8 +422,34 @@ class LibreVJEPA2(BaseModel):
     # Training
     # =========================================================================
 
-    def train(self, *args, **kwargs):
-        """Reject self-supervised training before any dataset is constructed."""
+    def train(
+        self,
+        data: str,
+        *,
+        epochs: int = 10,
+        batch: int = 2,
+        lr0: float = 1e-3,
+        device: str = "",
+        workers: int = 0,
+        seed: int = 0,
+        project: str = "runs",
+        name: str = "train",
+        exist_ok: bool = False,
+        resume: bool = False,
+        amp: bool = True,
+        patience: int = 50,
+        freeze: int = 1,
+        callbacks=None,
+        **kwargs: Any,
+    ) -> dict:
+        """Train the attentive probe on a user-supplied video dataset.
+
+        The encoder is frozen and kept in eval mode; only the three-layer
+        attentive pooler and the linear classifier are optimized. ``data`` is a
+        dataset YAML whose manifests are validated in full before the first
+        epoch. Nothing is downloaded: the videos are yours.
+        """
+        # Reject the unsupported training stories before building a dataset.
         if self.task == "embed":
             raise NotImplementedError(
                 "V-JEPA 2 embedding training is self-supervised pretraining: it "
@@ -433,4 +459,42 @@ class LibreVJEPA2(BaseModel):
                 "    model = LibreYOLO('LibreVJEPA2l256-embed.pt', task='classify')\n"
                 "    model.train(data='video_dataset.yaml')"
             )
-        return super().train(*args, **kwargs)
+        if kwargs.pop("pretrain", False) or kwargs.pop("predictor", False):
+            raise NotImplementedError(
+                "V-JEPA 2 predictor / self-supervised pretraining is not "
+                "implemented and is out of scope for this family."
+            )
+        if freeze == 0:
+            raise NotImplementedError(
+                "Full encoder fine-tuning (freeze=0) is not wired for V-JEPA 2. "
+                "The supported recipe trains the attentive pooler and classifier "
+                "with the encoder frozen; unfreezing a 1B-parameter video "
+                "encoder needs far more memory than the probe recipe and has no "
+                "validated schedule here."
+            )
+
+        from .trainer import VJEPA2Trainer
+
+        trainer = VJEPA2Trainer(
+            model=self.model,
+            wrapper_model=self,
+            size=self.size,
+            num_classes=self.nb_classes,
+            data=data,
+            epochs=epochs,
+            batch=batch,
+            imgsz=self.crop_size,
+            lr0=lr0,
+            device=device if device else "auto",
+            workers=workers,
+            seed=seed,
+            project=project,
+            name=name,
+            exist_ok=exist_ok,
+            resume=resume,
+            amp=amp,
+            patience=patience,
+            callbacks=callbacks,
+            **kwargs,
+        )
+        return trainer.train()

--- a/libreyolo/models/vjepa2/model.py
+++ b/libreyolo/models/vjepa2/model.py
@@ -383,7 +383,7 @@ class LibreVJEPA2(BaseModel):
                 "embed_tokens() requires task='embed'; this model is "
                 f"task={self.task!r}."
             )
-        tensor = self._preprocess(source, **kwargs)
+        tensor, _, _, _ = self._preprocess(source, **kwargs)
         with torch.no_grad():
             encoder = self.model
             tokens = encoder(tensor)

--- a/libreyolo/models/vjepa2/model.py
+++ b/libreyolo/models/vjepa2/model.py
@@ -1,0 +1,371 @@
+"""LibreVJEPA2: V-JEPA 2.0 video embedding and attentive-probe classification.
+
+V-JEPA 2 is a self-supervised *video* encoder. It is not a text-image model and
+provides no text embeddings, so there is no shared text space and no retrieval
+benchmark is claimed for the vector this family returns.
+
+Three different representations are involved and are deliberately kept
+distinct:
+
+* **Native tokens** -- the encoder's spatiotemporal patch tokens, shaped
+  ``(B, T', H', W', D)``. Reached only through :meth:`LibreVJEPA2.embed_tokens`,
+  never through the generic ``Embeddings`` container, which is a 2D contract.
+* **The LibreYOLO global vector** -- ``normalize(tokens.mean(dim=1), dim=-1)``.
+  This is a LibreYOLO *pooling contract*, not an upstream retrieval head;
+  upstream designates no global vector.
+* **Attentive-probe logits** -- from the released classification heads.
+
+Image input is supported as an explicitly documented single-frame
+representation. Every frame is identical in that case, so it is a static
+appearance embedding and must not be described as a motion representation.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, ClassVar, Dict, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...tasks import normalize_task
+from ..base.model import BaseModel
+from .nn import (
+    VJEPA2_CONFIGS,
+    LibreVJEPA2Classifier,
+    LibreVJEPA2Encoder,
+    VJEPA2Config,
+)
+from .preprocess import (
+    DEFAULT_FRAME_STRIDE,
+    image_to_clip,
+    preprocess_frames,
+    validate_clip_tensor,
+)
+
+logger = logging.getLogger(__name__)
+
+# Frames per clip for each *released* artifact. The encoders are all 64-frame;
+# the probes vary, and a probe must be run at the frame count it was trained
+# for or its pooled statistics are wrong.
+ENCODER_FRAMES: int = 64
+PROBE_FRAMES: Dict[Tuple[str, str], int] = {
+    ("l256", "ssv2"): 16,
+    ("l256", "diving48"): 32,
+    ("g384", "ssv2"): 64,
+    ("g384", "diving48"): 32,
+}
+PROBE_CLASSES: Dict[str, int] = {"ssv2": 174, "diving48": 48}
+
+
+class LibreVJEPA2(BaseModel):
+    """V-JEPA 2.0 video encoder (``embed``) and attentive probe (``classify``)."""
+
+    FAMILY: ClassVar[str] = "vjepa2"
+    FILENAME_PREFIX: ClassVar[str] = "LibreVJEPA2"
+    WEIGHT_EXT: ClassVar[str] = ".pt"
+
+    # Sizes encode the crop, because g256 and g384 share a width and differ
+    # only in input resolution.
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {
+        "l256": 256,
+        "h256": 256,
+        "g256": 256,
+        "g384": 384,
+    }
+    SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("embed", "classify")
+    WEIGHT_TASKS: ClassVar[Tuple[str, ...]] = ("embed", "classify")
+    DEFAULT_TASK: ClassVar[str] = "embed"
+    # Every published artifact carries a task suffix; a bare ``LibreVJEPA2l256.pt``
+    # is not canonical and must not resolve.
+    REQUIRE_TASK_SUFFIX: ClassVar[bool] = True
+    WEIGHT_VARIANTS: ClassVar[Tuple[str, ...]] = ("ssv2", "diving48")
+
+    # Self-supervised pretraining is out of scope; the probe trainer is wired
+    # separately in trainer.py.
+    TRAIN_CONFIG: ClassVar[Optional[type]] = None
+
+    # Opt this family into clip-mode finite-video handling. Every other family
+    # keeps the default "frames" behaviour and its per-frame result cardinality.
+    VIDEO_EMBED_MODE: ClassVar[str] = "clip"
+
+    # =========================================================================
+    # Registry classmethods
+    # =========================================================================
+
+    # An ``-embed`` checkpoint is rooted at the encoder itself, while a
+    # ``-cls`` checkpoint nests it under ``encoder.``. Both roots are accepted
+    # so one discriminator serves both artifact shapes.
+    _PATCH_EMBED_KEYS = (
+        "embeddings.patch_embeddings.proj.weight",
+        "encoder.embeddings.patch_embeddings.proj.weight",
+    )
+    _FINAL_NORM_KEYS = ("layernorm.weight", "encoder.layernorm.weight")
+
+    @classmethod
+    def _lookup(cls, weights_dict: dict, keys: Tuple[str, ...]):
+        for key in keys:
+            value = weights_dict.get(key)
+            if value is not None:
+                return value
+        return None
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        """Match on the 3D tubelet patch embedding, which is unique to V-JEPA 2.
+
+        A 5D conv weight under this key does not occur in any other registered
+        family: the image ViTs all use a 4D Conv2d patch embedding, so the
+        rank check is what makes this safe rather than the name alone.
+        """
+        weight = cls._lookup(weights_dict, cls._PATCH_EMBED_KEYS)
+        if weight is None:
+            return False
+        # Guard the structure too, not just the name.
+        return getattr(weight, "ndim", 0) == 5
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        """Infer size from encoder width.
+
+        Width alone cannot separate ``g256`` from ``g384`` -- they are the same
+        network at different input resolutions. That pair is resolved from
+        checkpoint metadata or the filename, never guessed here.
+        """
+        weight = cls._lookup(weights_dict, cls._FINAL_NORM_KEYS)
+        if weight is None:
+            return None
+        hidden = int(weight.shape[0])
+        if hidden == 1024:
+            return "l256"
+        if hidden == 1280:
+            return "h256"
+        # 1408 is ambiguous between g256 and g384 by design.
+        return None
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        weight = weights_dict.get("classifier.weight")
+        if weight is None:
+            return None
+        return int(weight.shape[0])
+
+    @classmethod
+    def detect_task_from_state_dict(cls, weights_dict: dict) -> Optional[str]:
+        if any(k.startswith("pooler.") for k in weights_dict):
+            return "classify"
+        if cls.can_load(weights_dict):
+            return "embed"
+        return None
+
+    @classmethod
+    def validate_artifact_name(cls, size: str, task: str, variant: Optional[str]) -> None:
+        """Reject impossible size/task/variant combinations.
+
+        The base filename regex can parse combinations that no released
+        artifact provides. Parsing is not the same as existing, so the valid
+        matrix is enforced here on top of it.
+        """
+        task = normalize_task(task)
+        if size not in cls.INPUT_SIZES:
+            raise ValueError(
+                f"unknown V-JEPA 2 size {size!r}; expected one of "
+                f"{sorted(cls.INPUT_SIZES)}"
+            )
+        if task == "embed":
+            if variant:
+                raise ValueError(
+                    f"'-embed' artifacts carry no dataset variant, got {variant!r}. "
+                    f"Canonical name: LibreVJEPA2{size}-embed.pt"
+                )
+            return
+        if task == "classify":
+            if not variant:
+                raise ValueError(
+                    "published '-cls' artifacts require a dataset variant "
+                    f"({' or '.join(cls.WEIGHT_VARIANTS)}), e.g. "
+                    f"LibreVJEPA2{size}-cls-ssv2.pt. A locally trained probe "
+                    "should be loaded from its explicit path instead."
+                )
+            if (size, variant) not in PROBE_FRAMES:
+                published = ", ".join(
+                    f"LibreVJEPA2{s}-cls-{v}.pt" for s, v in sorted(PROBE_FRAMES)
+                )
+                raise ValueError(
+                    f"no released V-JEPA 2 probe for size={size!r} variant={variant!r}. "
+                    f"Published probes are: {published}"
+                )
+            return
+        raise ValueError(f"V-JEPA 2 supports 'embed' and 'classify'; got {task!r}")
+
+    # =========================================================================
+    # Construction
+    # =========================================================================
+
+    def __init__(
+        self,
+        model_path=None,
+        size: str = "l256",
+        nb_classes: int = 174,
+        device: str = "auto",
+        task: str | None = None,
+        variant: str | None = None,
+        clip_frames: int | None = None,
+        frame_stride: int = DEFAULT_FRAME_STRIDE,
+        **kwargs,
+    ) -> None:
+        resolved_task = normalize_task(task) if task is not None else self.DEFAULT_TASK
+        if resolved_task not in self.SUPPORTED_TASKS:
+            raise ValueError(
+                f"LibreVJEPA2 supports task in {self.SUPPORTED_TASKS}; got {task!r}."
+            )
+        self.variant = variant
+        self._requested_clip_frames = clip_frames
+        self.frame_stride = frame_stride
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=nb_classes,
+            device=device,
+            task=resolved_task,
+            **kwargs,
+        )
+        # BaseModel.__init__ only records the path (and loads an inline state
+        # dict); loading from a file is the family's job, as in every sibling.
+        if isinstance(model_path, (str, Path)):
+            self._load_weights(str(model_path))
+
+    @property
+    def clip_frames(self) -> int:
+        """Frames the loaded artifact expects for one clip."""
+        if self._requested_clip_frames is not None:
+            return int(self._requested_clip_frames)
+        if self.task == "classify" and self.variant:
+            return PROBE_FRAMES.get((self.size, self.variant), ENCODER_FRAMES)
+        return ENCODER_FRAMES
+
+    @property
+    def crop_size(self) -> int:
+        return self.INPUT_SIZES[self.size]
+
+    @property
+    def embedding_dim(self) -> int:
+        return VJEPA2_CONFIGS[self.size]["hidden_size"]
+
+    def _build_config(self) -> VJEPA2Config:
+        return VJEPA2Config.for_size(self.size, frames_per_clip=self.clip_frames)
+
+    def _init_model(self) -> nn.Module:
+        config = self._build_config()
+        if self.task == "classify":
+            return LibreVJEPA2Classifier(config, nc=self.nb_classes)
+        return LibreVJEPA2Encoder(config)
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        if self.task == "classify":
+            return {
+                "encoder": self.model.encoder,
+                "pooler": self.model.pooler,
+                "classifier": self.model.classifier,
+            }
+        return {"encoder": self.model}
+
+    # =========================================================================
+    # Preprocess / forward / postprocess
+    # =========================================================================
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        return preprocess_frames
+
+    def _preprocess(self, image, *, color_format=None, **kwargs):
+        """Accept a still image, a list of frames, or an explicit 5D clip."""
+        if isinstance(image, torch.Tensor) and image.ndim == 5:
+            return validate_clip_tensor(image, self.crop_size).to(self.device)
+        if isinstance(image, (list, tuple)):
+            frames = [np.asarray(f) for f in image]
+            return preprocess_frames(frames, self.crop_size).to(self.device)
+        frame = np.asarray(image)
+        return image_to_clip(frame, self.crop_size, self.clip_frames).to(self.device)
+
+    def _forward(self, input_tensor: torch.Tensor) -> Any:
+        if self.task == "classify":
+            return self.model(input_tensor)
+        tokens = self.model(input_tensor)
+        return self.pool_tokens(tokens)
+
+    @staticmethod
+    def pool_tokens(tokens: torch.Tensor) -> torch.Tensor:
+        """The LibreYOLO pooling contract: mean over all tokens, then L2.
+
+        Averaging is over every temporal *and* spatial position, so the result
+        is a single float32 row per clip.
+        """
+        return F.normalize(tokens.mean(dim=1), dim=-1).float()
+
+    def embed_tokens(self, source, **kwargs) -> torch.Tensor:
+        """Family escape hatch returning native tokens as ``(B, T', H', W', D)``.
+
+        Ordering is upstream's: time-major, then height, then width. This is
+        deliberately not routed through ``Embeddings``, which is a 2D contract
+        and cannot represent a token grid.
+        """
+        if self.task != "embed":
+            raise ValueError(
+                "embed_tokens() requires task='embed'; this model is "
+                f"task={self.task!r}."
+            )
+        tensor = self._preprocess(source, **kwargs)
+        with torch.no_grad():
+            encoder = self.model
+            tokens = encoder(tensor)
+        config = self._build_config()
+        grid = config.grid_size
+        depth = tensor.shape[1] // config.tubelet_size
+        batch, num_tokens, dim = tokens.shape
+        expected = depth * grid * grid
+        if num_tokens != expected:
+            raise RuntimeError(
+                f"expected {expected} tokens for a {tensor.shape[1]}-frame clip at "
+                f"{config.crop_size}px, got {num_tokens}"
+            )
+        return tokens.reshape(batch, depth, grid, grid, dim)
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        **kwargs,
+    ) -> Dict:
+        if self.task == "classify":
+            logits = output
+            probs = torch.softmax(logits.float(), dim=1)[0]
+            return {"probs": probs.cpu()}
+        return self._postprocess_embeddings(
+            output,
+            gallery=kwargs.get("gallery"),
+            threshold=kwargs.get("threshold"),
+        )
+
+    # =========================================================================
+    # Training
+    # =========================================================================
+
+    def train(self, *args, **kwargs):
+        """Reject self-supervised training before any dataset is constructed."""
+        if self.task == "embed":
+            raise NotImplementedError(
+                "V-JEPA 2 embedding training is self-supervised pretraining: it "
+                "needs web-scale mixed video corpora, two training phases and "
+                "distributed recipes, so LibreYOLO does not implement it. Train "
+                "the attentive probe instead:\n"
+                "    model = LibreYOLO('LibreVJEPA2l256-embed.pt', task='classify')\n"
+                "    model.train(data='video_dataset.yaml')"
+            )
+        return super().train(*args, **kwargs)

--- a/libreyolo/models/vjepa2/model.py
+++ b/libreyolo/models/vjepa2/model.py
@@ -32,6 +32,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ...tasks import normalize_task
+from ...utils.image_loader import ImageLoader
 from ..base.model import BaseModel
 from .nn import (
     VJEPA2_CONFIGS,
@@ -40,6 +41,7 @@ from .nn import (
     VJEPA2Config,
 )
 from .preprocess import (
+    clip_frame_indices,
     DEFAULT_FRAME_STRIDE,
     image_to_clip,
     preprocess_frames,
@@ -312,21 +314,53 @@ class LibreVJEPA2(BaseModel):
     def _get_preprocess_numpy():
         return preprocess_frames
 
-    def _preprocess(self, image, *, color_format=None, **kwargs):
-        """Accept a still image, a list of frames, or an explicit 5D clip."""
+    def _preprocess(
+        self,
+        image,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, Any, Tuple[int, int], float]:
+        """Accept a still image, a list of frames, or an explicit 5D clip.
+
+        Returns the shared 4-tuple contract
+        ``(input_tensor, original_image, original_size, ratio)``. The tensor is
+        5D ``(B, F, C, H, W)`` rather than the usual 4D image batch, since this
+        family consumes clips.
+        """
+        del input_size  # clip geometry is fixed by the checkpoint, not the call
+
         if isinstance(image, torch.Tensor) and image.ndim == 5:
-            return validate_clip_tensor(image, self.crop_size).to(self.device)
+            tensor = validate_clip_tensor(image, self.crop_size)
+            size = (int(tensor.shape[-1]), int(tensor.shape[-2]))
+            return tensor.to(self.device), image, size, 1.0
+
         if isinstance(image, (list, tuple)):
-            frames = [np.asarray(f) for f in image]
-            return preprocess_frames(frames, self.crop_size).to(self.device)
-        frame = np.asarray(image)
-        return image_to_clip(frame, self.crop_size, self.clip_frames).to(self.device)
+            frames = [np.asarray(ImageLoader.load(f, color_format=color_format)) for f in image]
+            original = frames[-1]
+            height, width = original.shape[:2]
+            tensor = preprocess_frames(frames, self.crop_size)
+            return tensor.to(self.device), original, (width, height), 1.0
+
+        loaded = ImageLoader.load(image, color_format=color_format)
+        frame = np.asarray(loaded)
+        height, width = frame.shape[:2]
+        tensor = image_to_clip(frame, self.crop_size, self.clip_frames)
+        return tensor.to(self.device), loaded, (width, height), 1.0
 
     def _forward(self, input_tensor: torch.Tensor) -> Any:
         if self.task == "classify":
             return self.model(input_tensor)
         tokens = self.model(input_tensor)
         return self.pool_tokens(tokens)
+
+    def sample_clip_indices(self, total_frames: int, vid_stride: int = 1) -> list[int]:
+        """Deterministic centered clip indices for a finite video.
+
+        The generic runner owns decoding; temporal sampling stays here because
+        the frame count and stride belong to the checkpoint.
+        """
+        stride = self.frame_stride * max(1, int(vid_stride))
+        return clip_frame_indices(total_frames, self.clip_frames, stride)
 
     @staticmethod
     def pool_tokens(tokens: torch.Tensor) -> torch.Tensor:

--- a/libreyolo/models/vjepa2/nn.py
+++ b/libreyolo/models/vjepa2/nn.py
@@ -1,0 +1,690 @@
+"""Native V-JEPA 2.0 encoder, attentive pooler and classifier.
+
+Provenance
+----------
+This file is adapted from the Hugging Face Transformers implementation of
+V-JEPA 2, pinned at tag ``v5.1.0`` (commit
+``3fa4da70f5d1da3ab1a8304bd2339eab7004b157``):
+
+    src/transformers/models/vjepa2/modeling_vjepa2.py
+
+Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+Licensed under the Apache License, Version 2.0. A copy of the Apache-2.0
+license text accompanies this directory in ``NOTICE``.
+
+The semantic upstream (architecture behaviour, attentive-probe recipe) is
+``facebookresearch/vjepa2`` at commit
+``204698b45b3712590f06245fbfba32d3be539812``, MIT licensed.
+
+Deliberate deviations from the Transformers source, all of which preserve
+numerics exactly:
+
+* Only the encoder, attentive pooler and classifier are ported. The
+  self-supervised predictor (``VJEPA2Predictor`` and friends) is out of scope
+  and is not present here.
+* ``PreTrainedModel``/``ModelOutput`` plumbing is replaced with plain
+  ``nn.Module`` and tensor returns, so LibreYOLO does not depend on
+  ``transformers`` at inference or export time.
+* Parameter names are kept byte-identical to upstream so conversion is a
+  key-filter rather than a remap, and so the parity diff stays readable.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = [
+    "VJEPA2Config",
+    "LibreVJEPA2Encoder",
+    "LibreVJEPA2Classifier",
+    "VJEPA2_CONFIGS",
+]
+
+
+# --- Architecture table -----------------------------------------------------
+#
+# Values are transcribed from the pinned Hugging Face ``config.json`` of each
+# released snapshot. Depth / heads / mlp_ratio are NOT inferable from the size
+# label: g256 and g384 share hidden_size 1408 but differ in crop_size, and the
+# g variants use 22 heads and a non-integer mlp_ratio.
+VJEPA2_CONFIGS: dict[str, dict] = {
+    "l256": {
+        "hidden_size": 1024,
+        "num_attention_heads": 16,
+        "num_hidden_layers": 24,
+        "mlp_ratio": 4.0,
+        "crop_size": 256,
+    },
+    "h256": {
+        "hidden_size": 1280,
+        "num_attention_heads": 16,
+        "num_hidden_layers": 32,
+        "mlp_ratio": 4.0,
+        "crop_size": 256,
+    },
+    "g256": {
+        "hidden_size": 1408,
+        "num_attention_heads": 22,
+        "num_hidden_layers": 40,
+        "mlp_ratio": 4.363636363636363,
+        "crop_size": 256,
+    },
+    "g384": {
+        "hidden_size": 1408,
+        "num_attention_heads": 22,
+        "num_hidden_layers": 40,
+        "mlp_ratio": 4.363636363636363,
+        "crop_size": 384,
+    },
+}
+
+
+class VJEPA2Config:
+    """Family-local config mirroring the pinned upstream ``VJEPA2Config``.
+
+    Only the fields the encoder actually reads are kept. Holding this locally
+    keeps ``transformers`` off the inference and export import path.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 1024,
+        num_attention_heads: int = 16,
+        num_hidden_layers: int = 24,
+        mlp_ratio: float = 4.0,
+        crop_size: int = 256,
+        patch_size: int = 16,
+        tubelet_size: int = 2,
+        frames_per_clip: int = 64,
+        in_chans: int = 3,
+        layer_norm_eps: float = 1e-6,
+        qkv_bias: bool = True,
+        drop_path_rate: float = 0.0,
+        attention_probs_dropout_prob: float = 0.0,
+        hidden_act: str = "gelu",
+        attn_implementation: str = "sdpa",
+    ):
+        self.hidden_size = hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.num_hidden_layers = num_hidden_layers
+        self.mlp_ratio = mlp_ratio
+        self.crop_size = crop_size
+        self.patch_size = patch_size
+        self.tubelet_size = tubelet_size
+        self.frames_per_clip = frames_per_clip
+        self.in_chans = in_chans
+        self.layer_norm_eps = layer_norm_eps
+        self.qkv_bias = qkv_bias
+        self.drop_path_rate = drop_path_rate
+        self.attention_probs_dropout_prob = attention_probs_dropout_prob
+        self.hidden_act = hidden_act
+        self.attn_implementation = attn_implementation
+
+    @classmethod
+    def for_size(cls, size: str, **overrides) -> "VJEPA2Config":
+        if size not in VJEPA2_CONFIGS:
+            raise ValueError(
+                f"unknown V-JEPA 2 size {size!r}; expected one of "
+                f"{sorted(VJEPA2_CONFIGS)}"
+            )
+        params = dict(VJEPA2_CONFIGS[size])
+        params.update(overrides)
+        return cls(**params)
+
+    @property
+    def grid_size(self) -> int:
+        return self.crop_size // self.patch_size
+
+    @property
+    def grid_depth(self) -> int:
+        return self.frames_per_clip // self.tubelet_size
+
+
+def _act(name: str):
+    if name == "gelu":
+        # Upstream ACT2FN["gelu"] is the exact (erf) GELU, not the tanh
+        # approximation. Using the wrong one silently breaks exact parity.
+        return nn.GELU()
+    if name == "silu":
+        return nn.SiLU()
+    raise ValueError(f"unsupported activation {name!r}")
+
+
+class VJEPA2PatchEmbeddings3D(nn.Module):
+    """Tubelet (3D) patch embedding: Conv3d with stride == kernel."""
+
+    def __init__(self, config: VJEPA2Config, hidden_size: int):
+        super().__init__()
+        self.patch_size = config.patch_size
+        self.tubelet_size = config.tubelet_size
+        self.hidden_size = hidden_size
+        self.proj = nn.Conv3d(
+            in_channels=config.in_chans,
+            out_channels=hidden_size,
+            kernel_size=(config.tubelet_size, config.patch_size, config.patch_size),
+            stride=(config.tubelet_size, config.patch_size, config.patch_size),
+        )
+
+    def forward(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
+        return self.proj(pixel_values_videos).flatten(2).transpose(1, 2)
+
+
+class VJEPA2Embeddings(nn.Module):
+    """Accepts public ``(B, F, C, H, W)`` and permutes to Conv3d layout."""
+
+    def __init__(self, config: VJEPA2Config, hidden_size: int):
+        super().__init__()
+        self.config = config
+        self.hidden_size = hidden_size
+        self.patch_embeddings = VJEPA2PatchEmbeddings3D(config, hidden_size=hidden_size)
+        self.patch_size = config.patch_size
+
+    def forward(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
+        num_frames = pixel_values_videos.shape[1]
+        # (B, F, C, H, W) -> (B, C, F, H, W). This is the single adapter
+        # between the public layout and the native Conv3d layout.
+        pixel_values_videos = pixel_values_videos.permute(0, 2, 1, 3, 4)
+        if num_frames < self.config.tubelet_size:
+            pixel_values_videos = pixel_values_videos.repeat(
+                1, 1, self.config.tubelet_size, 1, 1
+            )
+        target_dtype = self.patch_embeddings.proj.weight.dtype
+        pixel_values_videos = pixel_values_videos.to(dtype=target_dtype)
+        return self.patch_embeddings(pixel_values_videos)
+
+
+def rotate_queries_or_keys(x: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
+    """Factorized rotary embedding, transcribed from the pinned upstream.
+
+    Note the deliberate asymmetry, which is upstream behaviour and must be
+    preserved bit-for-bit: the sin/cos tables are built by ``repeat`` (so they
+    are the half-width table *concatenated* with itself), while the rotated
+    companion ``y`` is built by pairing *adjacent* channels. Rewriting this to
+    the conventional interleaved or half-split rotary changes the numerics and
+    breaks parity against every released checkpoint.
+    """
+    _, _, _, D = x.size()
+
+    omega = torch.arange(D // 2, dtype=x.dtype, device=x.device)
+    omega = omega / (D / 2.0)
+    omega = 1.0 / 10000**omega  # (D/2,)
+    freq = pos.unsqueeze(-1) * omega  # (..., N, D/2), outer product
+
+    emb_sin = freq.sin()
+    emb_cos = freq.cos()
+
+    emb_sin = emb_sin.squeeze(-1).repeat(1, 1, 1, 2)
+    emb_cos = emb_cos.squeeze(-1).repeat(1, 1, 1, 2)
+
+    y = x.unflatten(-1, (-1, 2))
+    y1, y2 = y.unbind(dim=-1)
+    y = torch.stack((-y2, y1), dim=-1)
+    y = y.flatten(-2)
+    return (x * emb_cos) + (y * emb_sin)
+
+
+def eager_attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scaling: float,
+    dropout: float = 0.0,
+    training: bool = False,
+):
+    attn_weights = torch.matmul(query, key.transpose(-1, -2)) * scaling
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=training)
+    attn_output = torch.matmul(attn_weights, value)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output, attn_weights
+
+
+def sdpa_attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scaling: float,
+    dropout: float = 0.0,
+    training: bool = False,
+):
+    """Mirrors ``transformers.integrations.sdpa_attention.sdpa_attention_forward``.
+
+    Kept separate from the eager path so parity can be asserted against the
+    oracle under *both* attention implementations rather than only the default.
+    """
+    attn_output = F.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=dropout if training else 0.0,
+        scale=scaling,
+        is_causal=False,
+    )
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output, None
+
+
+class VJEPA2RopeAttention(nn.Module):
+    def __init__(
+        self,
+        config: VJEPA2Config,
+        hidden_size: int,
+        num_attention_heads: int,
+    ):
+        super().__init__()
+        self.config = config
+        self.hidden_size = hidden_size
+        self.num_attention_heads = num_attention_heads
+        if hidden_size % num_attention_heads != 0:
+            raise ValueError(
+                f"hidden size {hidden_size} is not a multiple of the number of "
+                f"attention heads {num_attention_heads}"
+            )
+
+        self.attention_head_size = int(hidden_size / num_attention_heads)
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.query = nn.Linear(hidden_size, self.all_head_size, bias=config.qkv_bias)
+        self.key = nn.Linear(hidden_size, self.all_head_size, bias=config.qkv_bias)
+        self.value = nn.Linear(hidden_size, self.all_head_size, bias=config.qkv_bias)
+        self.proj = nn.Linear(hidden_size, hidden_size)
+
+        self.dropout_prob = config.attention_probs_dropout_prob
+        self.dropout = nn.Dropout(self.dropout_prob)
+
+        self.grid_size = config.crop_size // config.patch_size
+        self.grid_depth = config.frames_per_clip // config.tubelet_size
+
+        # Each of depth/height/width gets an even slice of the head dim; any
+        # remainder is left unrotated. Integer division order matters.
+        self.d_dim = int(2 * ((self.attention_head_size // 3) // 2))
+        self.h_dim = int(2 * ((self.attention_head_size // 3) // 2))
+        self.w_dim = int(2 * ((self.attention_head_size // 3) // 2))
+
+        self.scaling = self.attention_head_size**-0.5
+        self.is_causal = False
+
+    def _get_frame_pos(self, ids: torch.Tensor) -> torch.Tensor:
+        tokens_per_frame = int(self.grid_size * self.grid_size)
+        return ids // tokens_per_frame
+
+    def _get_height_pos(self, ids: torch.Tensor) -> torch.Tensor:
+        tokens_per_frame = int(self.grid_size * self.grid_size)
+        frame_ids = self._get_frame_pos(ids)
+        ids = ids - tokens_per_frame * frame_ids
+        tokens_per_row = self.grid_size
+        return ids // tokens_per_row
+
+    def get_position_ids(self, x: torch.Tensor):
+        device = x.device
+        token_size = x.size(1)
+        ids = torch.arange(token_size, device=device)
+        tokens_per_frame = int(self.grid_size * self.grid_size)
+        frame_ids = self._get_frame_pos(ids)
+        tokens_per_row = self.grid_size
+        height_ids = self._get_height_pos(ids)
+        width_ids = (ids - tokens_per_frame * frame_ids) - tokens_per_row * height_ids
+        return frame_ids, height_ids, width_ids
+
+    def apply_rotary_embeddings(self, qk: torch.Tensor, pos_ids) -> torch.Tensor:
+        d_mask, h_mask, w_mask = pos_ids
+        s = 0
+        qkd = rotate_queries_or_keys(qk[..., s : s + self.d_dim], pos=d_mask)
+        s += self.d_dim
+        qkh = rotate_queries_or_keys(qk[..., s : s + self.h_dim], pos=h_mask)
+        s += self.h_dim
+        qkw = rotate_queries_or_keys(qk[..., s : s + self.w_dim], pos=w_mask)
+        s += self.w_dim
+        if s < self.attention_head_size:
+            qkr = qk[..., s:]
+            qk = torch.cat([qkd, qkh, qkw, qkr], dim=-1)
+        else:
+            qk = torch.cat([qkd, qkh, qkw], dim=-1)
+        return qk
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, _, _ = hidden_states.shape
+        shape = (batch_size, -1, self.num_attention_heads, self.attention_head_size)
+        query_layer = self.query(hidden_states).view(*shape).transpose(1, 2)
+        key_layer = self.key(hidden_states).view(*shape).transpose(1, 2)
+        value_layer = self.value(hidden_states).view(*shape).transpose(1, 2)
+
+        pos_ids = self.get_position_ids(hidden_states)
+        key_layer = self.apply_rotary_embeddings(key_layer, pos_ids)
+        query_layer = self.apply_rotary_embeddings(query_layer, pos_ids)
+
+        impl = (
+            sdpa_attention_forward
+            if self.config.attn_implementation == "sdpa"
+            else eager_attention_forward
+        )
+        context_layer, _ = impl(
+            query_layer,
+            key_layer,
+            value_layer,
+            scaling=self.scaling,
+            dropout=0.0 if not self.training else self.dropout_prob,
+            training=self.training,
+        )
+
+        new_shape = context_layer.size()[:-2] + (self.all_head_size,)
+        return self.proj(context_layer.reshape(new_shape))
+
+
+def drop_path(
+    x: torch.Tensor, drop_prob: float = 0.0, training: bool = False
+) -> torch.Tensor:
+    if drop_prob == 0.0 or not training:
+        return x
+    keep_prob = 1 - drop_prob
+    shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+    random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
+    random_tensor.floor_()
+    return x.div(keep_prob) * random_tensor
+
+
+class VJEPA2DropPath(nn.Module):
+    def __init__(self, drop_prob: Optional[float] = None):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return drop_path(hidden_states, self.drop_prob, self.training)
+
+    def extra_repr(self) -> str:
+        return f"p={self.drop_prob}"
+
+
+class VJEPA2MLP(nn.Module):
+    def __init__(self, config: VJEPA2Config, hidden_size: int, mlp_ratio: float):
+        super().__init__()
+        in_features = out_features = hidden_size
+        # int() truncation, not round(): g's mlp_ratio of 4.363636... yields
+        # 6144 for hidden_size 1408. Rounding would give 6144 too, but the
+        # truncating form is what upstream uses and what the checkpoints match.
+        hidden_features = int(hidden_size * mlp_ratio)
+        self.fc1 = nn.Linear(in_features, hidden_features, bias=True)
+        self.activation = _act(config.hidden_act)
+        self.fc2 = nn.Linear(hidden_features, out_features, bias=True)
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.activation(self.fc1(hidden_state)))
+
+
+class VJEPA2Layer(nn.Module):
+    def __init__(
+        self,
+        config: VJEPA2Config,
+        drop_path_rate: float,
+        hidden_size: int,
+        num_attention_heads: int,
+        mlp_ratio: float,
+    ):
+        super().__init__()
+        self.config = config
+        self.hidden_size = hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.mlp_ratio = mlp_ratio
+
+        self.norm1 = nn.LayerNorm(hidden_size, eps=config.layer_norm_eps)
+        self.attention = VJEPA2RopeAttention(config, hidden_size, num_attention_heads)
+        self.drop_path = (
+            VJEPA2DropPath(drop_path_rate) if config.drop_path_rate > 0.0 else nn.Identity()
+        )
+        self.norm2 = nn.LayerNorm(hidden_size, eps=config.layer_norm_eps)
+        self.mlp = VJEPA2MLP(config, hidden_size=hidden_size, mlp_ratio=mlp_ratio)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.norm1(hidden_states)
+        hidden_states = self.attention(hidden_states)
+        hidden_states = self.drop_path(hidden_states) + residual
+
+        residual = hidden_states
+        hidden_states = self.norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.drop_path(hidden_states) + residual
+        return hidden_states
+
+
+class LibreVJEPA2Encoder(nn.Module):
+    """V-JEPA 2.0 encoder producing spatiotemporal tokens.
+
+    Input is the public 5D layout ``(B, F, C, H, W)``. Output is the final
+    normalized token sequence ``(B, N, D)`` in upstream flattening order
+    (time-major, then height, then width).
+    """
+
+    def __init__(self, config: VJEPA2Config):
+        super().__init__()
+        self.config = config
+        self.embeddings = VJEPA2Embeddings(config, hidden_size=config.hidden_size)
+        drop_path_rates = [
+            (
+                config.drop_path_rate * i / (config.num_hidden_layers - 1)
+                if config.num_hidden_layers > 1
+                else 0.0
+            )
+            for i in range(config.num_hidden_layers)
+        ]
+        self.layer = nn.ModuleList(
+            [
+                VJEPA2Layer(
+                    config,
+                    drop_path_rate=drop_path_rates[i],
+                    hidden_size=config.hidden_size,
+                    num_attention_heads=config.num_attention_heads,
+                    mlp_ratio=config.mlp_ratio,
+                )
+                for i in range(config.num_hidden_layers)
+            ]
+        )
+        self.layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def forward(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.embeddings(pixel_values_videos)
+        for layer_module in self.layer:
+            hidden_states = layer_module(hidden_states)
+        return self.layernorm(hidden_states)
+
+
+# --- Attentive probe (milestone 2) ------------------------------------------
+
+
+# The pooler's MLP is built upstream as ``VJEPA2MLP(config, hidden_size=...)``
+# with the mlp_ratio argument left at its default. It is therefore ALWAYS 4.0,
+# even for the g sizes whose encoder MLP ratio is 4.363636... Passing the
+# encoder ratio here would build fc1 as 6144 instead of 5632 and fail the
+# strict load of every released probe checkpoint.
+_POOLER_MLP_RATIO = 4.0
+
+# ``num_pooler_layers`` defaults to 3 upstream: three self-attention layers
+# followed by one cross-attention layer. This is the "three-layer attentive
+# pooler" the handoff refers to.
+_POOLER_DEPTH = 3
+
+
+class VJEPA2PoolerMLP(nn.Module):
+    def __init__(self, hidden_size: int, mlp_ratio: float = _POOLER_MLP_RATIO):
+        super().__init__()
+        hidden_features = int(hidden_size * mlp_ratio)
+        self.fc1 = nn.Linear(hidden_size, hidden_features, bias=True)
+        self.activation = nn.GELU()
+        self.fc2 = nn.Linear(hidden_features, hidden_size, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.activation(self.fc1(x)))
+
+
+class VJEPA2PoolerSelfAttention(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int):
+        super().__init__()
+        self.embed_dim = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.scale = self.head_dim**-0.5
+        self.dropout = 0.0
+        self.is_causal = False
+
+        self.k_proj = nn.Linear(hidden_size, hidden_size)
+        self.v_proj = nn.Linear(hidden_size, hidden_size)
+        self.q_proj = nn.Linear(hidden_size, hidden_size)
+        self.out_proj = nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_length, embed_dim = hidden_states.shape
+        shape = (batch_size, seq_length, self.num_heads, self.head_dim)
+        queries = self.q_proj(hidden_states).view(*shape).transpose(1, 2)
+        keys = self.k_proj(hidden_states).view(*shape).transpose(1, 2)
+        values = self.v_proj(hidden_states).view(*shape).transpose(1, 2)
+
+        attn_output = F.scaled_dot_product_attention(
+            queries, keys, values, attn_mask=None, dropout_p=0.0,
+            scale=self.scale, is_causal=False,
+        )
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(batch_size, seq_length, embed_dim)
+        return self.out_proj(attn_output)
+
+
+class VJEPA2PoolerCrossAttention(nn.Module):
+    """Cross-attention where the query is the learned probe token.
+
+    Unlike the pooler's self-attention, this block deliberately has **no**
+    output projection -- upstream omits ``out_proj`` here. Adding one would
+    introduce two tensors that no released probe checkpoint provides.
+    """
+
+    def __init__(self, hidden_size: int, num_heads: int):
+        super().__init__()
+        self.embed_dim = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.scale = self.head_dim**-0.5
+        self.dropout = 0.0
+        self.is_causal = False
+
+        self.k_proj = nn.Linear(hidden_size, hidden_size)
+        self.v_proj = nn.Linear(hidden_size, hidden_size)
+        self.q_proj = nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, queries: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, kv_length, embed_dim = hidden_states.shape
+        q_length = queries.shape[1]
+
+        queries = (
+            self.q_proj(queries)
+            .view(batch_size, q_length, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        kv_shape = (batch_size, kv_length, self.num_heads, self.head_dim)
+        keys = self.k_proj(hidden_states).view(*kv_shape).transpose(1, 2)
+        values = self.v_proj(hidden_states).view(*kv_shape).transpose(1, 2)
+
+        attn_output = F.scaled_dot_product_attention(
+            queries, keys, values, attn_mask=None, dropout_p=0.0,
+            scale=self.scale, is_causal=False,
+        )
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        return attn_output.reshape(batch_size, q_length, embed_dim).contiguous()
+
+
+class VJEPA2PoolerSelfAttentionLayer(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int, mlp_ratio: float, eps: float):
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(hidden_size, eps=eps)
+        self.self_attn = VJEPA2PoolerSelfAttention(hidden_size, num_heads)
+        self.layer_norm2 = nn.LayerNorm(hidden_size, eps=eps)
+        self.mlp = VJEPA2PoolerMLP(hidden_size, mlp_ratio)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class VJEPA2PoolerCrossAttentionLayer(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int, mlp_ratio: float, eps: float):
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(hidden_size, eps=eps)
+        self.cross_attn = VJEPA2PoolerCrossAttention(hidden_size, num_heads)
+        self.layer_norm2 = nn.LayerNorm(hidden_size, eps=eps)
+        self.mlp = VJEPA2PoolerMLP(hidden_size, mlp_ratio)
+
+    def forward(self, queries: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = queries
+        hidden_states = self.layer_norm1(hidden_states)
+        queries = self.cross_attn(queries, hidden_states)
+        queries = residual + queries
+
+        residual = queries
+        queries = self.layer_norm2(queries)
+        queries = self.mlp(queries)
+        return residual + queries
+
+
+class VJEPA2AttentivePooler(nn.Module):
+    """Three-layer attentive pooler: N self-attention blocks then cross-attention."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        mlp_ratio: float = _POOLER_MLP_RATIO,
+        depth: int = _POOLER_DEPTH,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.query_tokens = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.cross_attention_layer = VJEPA2PoolerCrossAttentionLayer(
+            hidden_size, num_heads, mlp_ratio, eps
+        )
+        self.self_attention_layers = nn.ModuleList(
+            [
+                VJEPA2PoolerSelfAttentionLayer(hidden_size, num_heads, mlp_ratio, eps)
+                for _ in range(depth)
+            ]
+        )
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        for layer in self.self_attention_layers:
+            hidden_state = layer(hidden_state)
+        queries = self.query_tokens.repeat(hidden_state.shape[0], 1, 1)
+        hidden_state = self.cross_attention_layer(queries, hidden_state)
+        return hidden_state.squeeze(1)
+
+
+class LibreVJEPA2Classifier(nn.Module):
+    """Frozen-encoder attentive probe: encoder -> attentive pooler -> linear."""
+
+    def __init__(self, config: VJEPA2Config, nc: int, probe_depth: int = _POOLER_DEPTH):
+        super().__init__()
+        self.config = config
+        self.nc = nc
+        self.probe_depth = probe_depth
+        self.encoder = LibreVJEPA2Encoder(config)
+        self.pooler = VJEPA2AttentivePooler(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            mlp_ratio=_POOLER_MLP_RATIO,
+            depth=probe_depth,
+            eps=config.layer_norm_eps,
+        )
+        self.classifier = nn.Linear(config.hidden_size, nc, bias=True)
+
+    def forward(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
+        tokens = self.encoder(pixel_values_videos)
+        pooled = self.pooler(tokens)          # (B, D)
+        return self.classifier(pooled)        # (B, K)

--- a/libreyolo/models/vjepa2/preprocess.py
+++ b/libreyolo/models/vjepa2/preprocess.py
@@ -1,0 +1,136 @@
+"""Clip sampling and preprocessing for V-JEPA 2.
+
+V-JEPA 2 consumes a *clip*, not a frame. Everything in this module exists to
+turn a finite video, an image, or an explicit tensor into the public 5D layout
+``(B, F, C, H, W)`` with the geometry a given checkpoint was trained for.
+
+Preprocessing follows the pinned upstream video processor: RGB, resize the
+short side, center crop to the checkpoint crop size, scale to [0, 1] and
+normalize with the ImageNet statistics.
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+import numpy as np
+import torch
+
+# ImageNet statistics, matching the pinned upstream processor config.
+PIXEL_MEAN: Tuple[float, float, float] = (0.485, 0.456, 0.406)
+PIXEL_STD: Tuple[float, float, float] = (0.229, 0.224, 0.225)
+
+# The released 64-frame checkpoints pair with a stride of 2, which spans an
+# inclusive window of 127 source frames -- the common official fixture.
+DEFAULT_FRAME_STRIDE = 2
+
+
+def clip_frame_indices(
+    total_frames: int,
+    clip_frames: int,
+    frame_stride: int = DEFAULT_FRAME_STRIDE,
+) -> List[int]:
+    """Deterministic centered indices for one clip.
+
+    The span covered is ``(clip_frames - 1) * frame_stride + 1`` source frames.
+    A longer video is centered on that span. A shorter one uses every real
+    frame it has first and only then repeats the final frame -- repeating
+    early would throw away real motion.
+    """
+    if total_frames <= 0:
+        raise ValueError("cannot sample a clip from a video with no frames")
+    if clip_frames <= 0:
+        raise ValueError(f"clip_frames must be positive, got {clip_frames}")
+    if frame_stride <= 0:
+        raise ValueError(f"frame_stride must be positive, got {frame_stride}")
+
+    span = (clip_frames - 1) * frame_stride + 1
+    if total_frames >= span:
+        start = (total_frames - span) // 2
+        return [start + i * frame_stride for i in range(clip_frames)]
+
+    # Too short for the full strided span: walk real frames, then hold the last.
+    indices = [i * frame_stride for i in range(clip_frames)]
+    return [min(i, total_frames - 1) for i in indices]
+
+
+def resize_short_side(frame: np.ndarray, size: int) -> np.ndarray:
+    """Resize so the short side equals ``size``, preserving aspect ratio."""
+    import cv2
+
+    height, width = frame.shape[:2]
+    if height == 0 or width == 0:
+        raise ValueError("cannot resize a zero-sized frame")
+    scale = size / min(height, width)
+    new_w = max(size, int(round(width * scale)))
+    new_h = max(size, int(round(height * scale)))
+    interpolation = cv2.INTER_AREA if scale < 1 else cv2.INTER_LINEAR
+    return cv2.resize(frame, (new_w, new_h), interpolation=interpolation)
+
+
+def center_crop(frame: np.ndarray, size: int) -> np.ndarray:
+    height, width = frame.shape[:2]
+    if height < size or width < size:
+        raise ValueError(
+            f"frame {width}x{height} is smaller than the crop size {size}"
+        )
+    top = (height - size) // 2
+    left = (width - size) // 2
+    return frame[top : top + size, left : left + size]
+
+
+def preprocess_frames(
+    frames: Sequence[np.ndarray],
+    crop_size: int,
+) -> torch.Tensor:
+    """RGB uint8 HWC frames -> normalized float32 ``(1, F, C, H, W)``."""
+    if len(frames) == 0:
+        raise ValueError("cannot build a clip from zero frames")
+
+    processed = []
+    for frame in frames:
+        if frame.ndim != 3 or frame.shape[2] != 3:
+            raise ValueError(
+                f"expected an RGB HWC frame, got shape {tuple(frame.shape)}"
+            )
+        resized = center_crop(resize_short_side(frame, crop_size), crop_size)
+        processed.append(resized)
+
+    clip = np.stack(processed).astype(np.float32) / 255.0  # (F, H, W, C)
+    tensor = torch.from_numpy(clip).permute(0, 3, 1, 2)    # (F, C, H, W)
+
+    mean = torch.tensor(PIXEL_MEAN, dtype=torch.float32).view(1, 3, 1, 1)
+    std = torch.tensor(PIXEL_STD, dtype=torch.float32).view(1, 3, 1, 1)
+    tensor = (tensor - mean) / std
+    return tensor.unsqueeze(0)  # (1, F, C, H, W)
+
+
+def image_to_clip(frame: np.ndarray, crop_size: int, clip_frames: int) -> torch.Tensor:
+    """Represent a still image as a static clip.
+
+    This is a compatibility behaviour, not a motion representation: every
+    frame is identical, so the model sees no motion whatsoever. Only as many
+    frames as the tubelet requires are produced.
+    """
+    repeats = max(1, clip_frames)
+    return preprocess_frames([frame] * repeats, crop_size)
+
+
+def validate_clip_tensor(tensor: torch.Tensor, crop_size: int) -> torch.Tensor:
+    """Validate an explicit in-memory clip in public ``(B, F, C, H, W)`` layout."""
+    if tensor.ndim != 5:
+        raise ValueError(
+            "an explicit V-JEPA 2 clip must be a 5D tensor in public layout "
+            f"(B, F, C, H, W); got {tensor.ndim}D shape {tuple(tensor.shape)}"
+        )
+    if tensor.shape[2] != 3:
+        raise ValueError(
+            "public clip layout is (B, F, C, H, W) with C=3 at dim 2; got shape "
+            f"{tuple(tensor.shape)}. A (B, C, F, H, W) tensor is a different video."
+        )
+    if tensor.shape[3] != crop_size or tensor.shape[4] != crop_size:
+        raise ValueError(
+            f"this checkpoint requires {crop_size}x{crop_size} frames; got "
+            f"{tensor.shape[3]}x{tensor.shape[4]}"
+        )
+    return tensor.float()

--- a/libreyolo/models/vjepa2/trainer.py
+++ b/libreyolo/models/vjepa2/trainer.py
@@ -18,6 +18,7 @@ from torch.utils.data import DataLoader
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
+from ..base.classify_validation_loss import ClassifyValidationLossMixin
 from .dataset import VideoClipDataset, collate_clips, load_video_dataset
 
 logger = logging.getLogger(__name__)
@@ -38,8 +39,13 @@ class VJEPA2Config(TrainConfig):
         super().__init__(**kwargs)
 
 
-class VJEPA2Trainer(BaseTrainer):
-    """Cross-entropy training of the attentive pooler + classifier only."""
+class VJEPA2Trainer(ClassifyValidationLossMixin, BaseTrainer):
+    """Cross-entropy training of the attentive pooler + classifier only.
+
+    The probe is an ordinary cross-entropy classifier over clip logits, so it
+    reuses the shared classify validation-loss gate rather than reimplementing
+    it; ``val_loss=True`` is therefore supported.
+    """
 
     best_metric_key = "metrics/accuracy_top1"
 

--- a/libreyolo/models/vjepa2/trainer.py
+++ b/libreyolo/models/vjepa2/trainer.py
@@ -1,0 +1,163 @@
+"""Frozen attentive-probe trainer for V-JEPA 2 video classification.
+
+The encoder is frozen by default and kept in eval mode; only the attentive
+pooler and the linear classifier are optimized. This is the bounded, supported
+training story for this family -- self-supervised encoder pretraining is
+rejected in ``LibreVJEPA2.train`` before any dataset is constructed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Type
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+
+from ...training.config import TrainConfig
+from ...training.scheduler import WarmupCosineScheduler
+from ...training.trainer import BaseTrainer
+from .dataset import VideoClipDataset, collate_clips, load_video_dataset
+
+logger = logging.getLogger(__name__)
+
+
+class VJEPA2Config(TrainConfig):
+    """Probe-training defaults.
+
+    The encoder is frozen, so the trainable head is tiny and tolerates a
+    higher LR than a full fine-tune would.
+    """
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("lr0", 1e-3)
+        kwargs.setdefault("weight_decay", 0.05)
+        kwargs.setdefault("warmup_epochs", 1)
+        kwargs.setdefault("batch", 2)
+        super().__init__(**kwargs)
+
+
+class VJEPA2Trainer(BaseTrainer):
+    """Cross-entropy training of the attentive pooler + classifier only."""
+
+    best_metric_key = "metrics/accuracy_top1"
+
+    @classmethod
+    def _config_class(cls) -> Type[TrainConfig]:
+        return VJEPA2Config
+
+    def get_model_family(self) -> str:
+        return "vjepa2"
+
+    def get_model_tag(self) -> str:
+        return f"VJEPA2-{self.config.size}"
+
+    def create_transforms(self):
+        # Video clips come from the family-local dataset below, so the
+        # detection transform factory is never used.
+        return None, None
+
+    def create_scheduler(self, iters_per_epoch: int):
+        return WarmupCosineScheduler(
+            lr=self.effective_lr,
+            iters_per_epoch=iters_per_epoch,
+            total_epochs=self.config.epochs,
+            warmup_epochs=self.config.warmup_epochs,
+            plateau_epochs=getattr(self.config, "no_aug_epochs", 0),
+            min_lr_ratio=getattr(self.config, "min_lr_ratio", 0.05),
+        )
+
+    # ------------------------------------------------------------------
+    # Freezing
+    # ------------------------------------------------------------------
+
+    def freeze_encoder(self) -> List[str]:
+        """Freeze the encoder and keep it in eval mode.
+
+        Returns the names of the parameters that remain trainable, so the
+        caller (and the tests) can assert exactly what is being optimized
+        rather than trusting that the freeze happened.
+        """
+        model = self.model
+        encoder = getattr(model, "encoder", None)
+        if encoder is None:
+            raise RuntimeError(
+                "V-JEPA 2 probe training needs a classifier model with an "
+                "'encoder' submodule."
+            )
+        for param in encoder.parameters():
+            param.requires_grad = False
+        encoder.eval()
+        return [n for n, p in model.named_parameters() if p.requires_grad]
+
+    def _setup_optimizer(self) -> torch.optim.Optimizer:
+        trainable = self.freeze_encoder()
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        if not params:
+            raise RuntimeError("no trainable parameters after freezing the encoder")
+        logger.info(
+            "V-JEPA 2 probe: training %d tensors (%s...), encoder frozen",
+            len(trainable),
+            ", ".join(trainable[:3]),
+        )
+        return torch.optim.AdamW(
+            params, lr=self.config.lr0, weight_decay=self.config.weight_decay
+        )
+
+    def _setup_data(self):
+        """Build video clip loaders; never the image ImageFolder path."""
+        wrapper = getattr(self, "wrapper_model", None)
+        clip_frames = int(getattr(wrapper, "clip_frames", 16))
+        frame_stride = int(getattr(wrapper, "frame_stride", 2))
+        crop_size = int(getattr(wrapper, "crop_size", 256))
+
+        data = load_video_dataset(self.config.data)
+        self.data_names = data["names"]
+
+        train_dataset = VideoClipDataset(
+            data["train"], clip_frames, frame_stride, crop_size, train=True
+        )
+        batch = max(1, int(self.config.batch))
+        self.train_loader = DataLoader(
+            train_dataset,
+            batch_size=batch,
+            shuffle=True,
+            num_workers=self.config.workers,
+            collate_fn=collate_clips,
+            drop_last=len(train_dataset) >= batch,
+        )
+        if "val" in data:
+            self.val_loader = DataLoader(
+                VideoClipDataset(
+                    data["val"], clip_frames, frame_stride, crop_size, train=False
+                ),
+                batch_size=batch,
+                shuffle=False,
+                num_workers=self.config.workers,
+                collate_fn=collate_clips,
+            )
+        logger.info(
+            "V-JEPA 2 video dataset: %d train clips, %d classes, %d frames/clip",
+            len(train_dataset),
+            data["nc"],
+            clip_frames,
+        )
+        return train_dataset
+
+    # ------------------------------------------------------------------
+    # Forward / loss
+    # ------------------------------------------------------------------
+
+    def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
+        # imgs is (B, F, C, H, W): time must still be there.
+        if imgs.ndim != 5:
+            raise ValueError(
+                f"probe training expects (B, F, C, H, W) clips, got {tuple(imgs.shape)}"
+            )
+        logits = self.model(imgs)
+        loss = F.cross_entropy(logits, targets)
+        return {"total_loss": loss, "loss_ce": loss.detach()}
+
+    def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
+        return {"ce": float(outputs.get("loss_ce", outputs["total_loss"]))}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -426,6 +426,7 @@ markers = [
     "unit: fast tests that avoid external weights or large files",
     "vit: tests covering the ViT classification family",
     "swin: tests covering the Swin classification family",
+    "vjepa2: tests covering the V-JEPA 2 video embedding and classification family",
     "external_data: tests that require external datasets, weights, or staged large files",
     "network: tests that intentionally use non-local network access",
     "e2e: end-to-end tests requiring full model loading and inference",

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -1764,6 +1764,31 @@
     "available": true,
     "group": "g3"
   },
+  "vjepa2": {
+    "class": "libreyolo.models.vjepa2.model.LibreVJEPA2",
+    "tasks": [
+      "embed",
+      "classify"
+    ],
+    "default_task": "embed",
+    "sizes": {
+      "l256": 256,
+      "h256": 256,
+      "g256": 256,
+      "g384": 384
+    },
+    "default_imgsz": {
+      "l256": 256,
+      "h256": 256,
+      "g256": 256,
+      "g384": 384
+    },
+    "task_sizes": {},
+    "export_override": "none",
+    "optional_extra": null,
+    "available": true,
+    "group": "g2"
+  },
   "yolo1": {
     "class": "libreyolo.models.yolo1.model.LibreYOLO1",
     "tasks": [

--- a/skills/libreyolo-upload-hf-model/SKILL.md
+++ b/skills/libreyolo-upload-hf-model/SKILL.md
@@ -80,6 +80,7 @@ file = name + ".pt"
 | Swin | `LibreSwin` | `LibreSwint-cls.pt` (Swin V1; MIT weights; inference-only) |
 | CLIP | `LibreCLIP` | `LibreCLIPb32-cls.pt` (zero-shot, open-vocab classify) |
 | SigLIP2 | `LibreSigLIP2` | `LibreSigLIP2b16-cls.pt` (zero-shot, open-vocab classify) |
+| V-JEPA 2 | `LibreVJEPA2` | `LibreVJEPA2l256-embed.pt` (video clip embedding), `LibreVJEPA2l256-cls-ssv2.pt` (attentive-probe video classify) |
 | NAFNet | `LibreNAFNet` | `LibreNAFNets-restore.pt` (restore-only; `-sidd` variant = SIDD denoise) |
 | BiRefNet | `LibreBiRefNet` | `LibreBiRefNetl-matte.pt` (matte / background-removal; `l` is MIT, `t`/lite has no explicit weights-license tag) |
 | FeyNobg | `LibreFeyNobg` | `LibreFeyNobgl-matte.pt` (matte / background-removal; Apache-2.0 code+weights; also ships `-fp8`/`-nvfp4` pre-quantized repos, see below) |
@@ -240,6 +241,11 @@ LibreSwinb-cls.pt, LibreSwinl-cls.pt,
 LibreCLIPb32-cls.pt, LibreCLIPb16-cls.pt, LibreCLIPl14-cls.pt,
 
 LibreSigLIP2b16-cls.pt, LibreSigLIP2so400m-cls.pt,
+
+LibreVJEPA2l256-embed.pt, LibreVJEPA2h256-embed.pt,
+LibreVJEPA2g256-embed.pt, LibreVJEPA2g384-embed.pt,
+LibreVJEPA2l256-cls-ssv2.pt, LibreVJEPA2l256-cls-diving48.pt,
+LibreVJEPA2g384-cls-ssv2.pt, LibreVJEPA2g384-cls-diving48.pt,
 
 LibreNAFNets-restore.pt, LibreNAFNetl-restore.pt,
 LibreNAFNetl-restore-sidd.pt,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -615,6 +615,19 @@ RTDETRV2_OBB_MODELS = [
     ("rtdetrv2", "n", "LibreRTDETRv2n-obb.pt"),
 ]
 
+# V-JEPA 2 is a video family and does not belong in MODEL_CATALOG: that matrix
+# feeds the COCO detection mAP and training gates, which a clip embedder fails
+# by construction. It is also kept out of GENERAL_NIGHTLY_INFERENCE_MODELS,
+# which is detect-only, so the general-nightly count in docs/testing.md is
+# unchanged. The representative cases below are the two smallest artifacts:
+# one encoder and one released probe.
+VJEPA2_EMBED_MODELS = [
+    ("vjepa2", "l256", "LibreVJEPA2l256-embed.pt"),
+]
+VJEPA2_CLASSIFY_MODELS = [
+    ("vjepa2", "l256", "LibreVJEPA2l256-cls-ssv2.pt"),
+]
+
 # Derived lists (no manual maintenance)
 YOLOX_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "yolox"]
 YOLO9_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "yolo9"]

--- a/tests/unit/test_validation_loss.py
+++ b/tests/unit/test_validation_loss.py
@@ -968,6 +968,7 @@ _VAL_LOSS_FAMILIES = {
     "libreyolo.models.segformer.trainer": "SegformerTrainer",
     "libreyolo.models.lingbotvision.trainer": "LingBotVisionTrainer",
     "libreyolo.models.dinov2.trainer": "DINOv2Trainer",
+    "libreyolo.models.vjepa2.trainer": "VJEPA2Trainer",
     "libreyolo.models.nafnet.trainer": "NAFNetTrainer",
 }
 

--- a/tests/unit/test_vjepa2.py
+++ b/tests/unit/test_vjepa2.py
@@ -282,3 +282,60 @@ class TestVideoMode:
             )
             if cls is not None:
                 assert getattr(cls, "VIDEO_EMBED_MODE", "frames") == "frames"
+
+
+class TestInferenceContracts:
+    """Regressions for the three review findings on the public paths."""
+
+    def test_preprocess_returns_the_shared_four_tuple(self):
+        """The shared runner unpacks four values; returning a bare tensor breaks predict()."""
+        import numpy as np
+
+        model = LibreVJEPA2(size="l256", task="embed")
+        model._requested_clip_frames = 2
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+        out = model._preprocess(frame, "rgb")
+        assert isinstance(out, tuple) and len(out) == 4
+        tensor, _original, original_size, ratio = out
+        assert tensor.ndim == 5                    # (B, F, C, H, W)
+        assert tensor.shape[2] == 3
+        assert original_size == (320, 240)         # (w, h) of the source
+        assert ratio == 1.0
+
+    def test_explicit_5d_clip_passes_through_preprocess(self):
+        model = LibreVJEPA2(size="l256", task="embed")
+        clip = torch.zeros(1, 4, 3, 256, 256)
+        tensor, _, size, ratio = model._preprocess(clip)
+        assert tensor.shape == (1, 4, 3, 256, 256)
+        assert size == (256, 256) and ratio == 1.0
+
+    def test_wrong_crop_in_explicit_clip_is_rejected(self):
+        model = LibreVJEPA2(size="l256", task="embed")
+        with pytest.raises(ValueError, match="requires 256x256"):
+            model._preprocess(torch.zeros(1, 4, 3, 224, 224))
+
+    def test_channels_last_clip_is_rejected(self):
+        """(B, F, H, W, C) is a different picture; it must not be accepted."""
+        model = LibreVJEPA2(size="l256", task="embed")
+        with pytest.raises(ValueError, match=r"C=3 at dim 2"):
+            model._preprocess(torch.zeros(1, 4, 256, 256, 3))
+
+    def test_clip_mode_is_actually_consumed_by_the_runner(self):
+        """Declaring VIDEO_EMBED_MODE is not enough; the runner must honour it."""
+        from libreyolo.models.base.inference import InferenceRunner
+
+        assert hasattr(InferenceRunner, "_predict_video_clip")
+
+    def test_sample_clip_indices_uses_checkpoint_geometry(self):
+        model = LibreVJEPA2(size="l256", task="embed")
+        model._requested_clip_frames = 8
+        idx = model.sample_clip_indices(500)
+        assert len(idx) == 8
+        assert idx[-1] - idx[0] == (8 - 1) * model.frame_stride
+
+    def test_vid_stride_multiplies_the_family_stride(self):
+        model = LibreVJEPA2(size="l256", task="embed")
+        model._requested_clip_frames = 4
+        base = model.sample_clip_indices(500, 1)
+        doubled = model.sample_clip_indices(500, 2)
+        assert (doubled[-1] - doubled[0]) == 2 * (base[-1] - base[0])

--- a/tests/unit/test_vjepa2.py
+++ b/tests/unit/test_vjepa2.py
@@ -155,3 +155,130 @@ def test_public_layout_is_batch_frames_channels():
     assert ok.shape[-1] == 64
     with pytest.raises(RuntimeError):
         model(torch.randn(1, 3, 8, 32, 32))
+
+
+# ---------------------------------------------------------------------------
+# Family / artifact-matrix behaviour
+# ---------------------------------------------------------------------------
+
+from libreyolo.models.vjepa2.model import LibreVJEPA2  # noqa: E402
+from libreyolo.models.vjepa2.preprocess import clip_frame_indices  # noqa: E402
+
+
+class TestArtifactMatrix:
+    """Parsing a filename is not the same as the artifact existing."""
+
+    @pytest.mark.parametrize(
+        "name,size,task",
+        [
+            ("LibreVJEPA2l256-embed.pt", "l256", "embed"),
+            ("LibreVJEPA2h256-embed.pt", "h256", "embed"),
+            ("LibreVJEPA2g384-cls-ssv2.pt", "g384", "classify"),
+            ("LibreVJEPA2l256-cls-diving48.pt", "l256", "classify"),
+        ],
+    )
+    def test_published_names_resolve(self, name, size, task):
+        assert LibreVJEPA2.detect_size_from_filename(name) == size
+        assert LibreVJEPA2.detect_task_from_filename(name) == task
+
+    def test_bare_family_name_is_not_canonical(self):
+        # REQUIRE_TASK_SUFFIX: every published artifact carries a task suffix.
+        assert LibreVJEPA2.detect_size_from_filename("LibreVJEPA2l256.pt") is None
+
+    def test_embed_rejects_a_dataset_variant(self):
+        with pytest.raises(ValueError, match="carry no dataset variant"):
+            LibreVJEPA2.validate_artifact_name("l256", "embed", "ssv2")
+
+    def test_published_classify_requires_a_variant(self):
+        with pytest.raises(ValueError, match="require a dataset variant"):
+            LibreVJEPA2.validate_artifact_name("l256", "classify", None)
+
+    @pytest.mark.parametrize("size,variant", [("h256", "ssv2"), ("g256", "ssv2"), ("l256", "kinetics")])
+    def test_unpublished_probe_combinations_rejected(self, size, variant):
+        with pytest.raises(ValueError):
+            LibreVJEPA2.validate_artifact_name(size, "classify", variant)
+
+    @pytest.mark.parametrize("size,variant", [("l256", "ssv2"), ("l256", "diving48"), ("g384", "ssv2"), ("g384", "diving48")])
+    def test_published_probe_combinations_accepted(self, size, variant):
+        LibreVJEPA2.validate_artifact_name(size, "classify", variant)
+
+    def test_unknown_size_rejected(self):
+        with pytest.raises(ValueError, match="unknown V-JEPA 2 size"):
+            LibreVJEPA2.validate_artifact_name("vitl", "embed", None)
+
+
+class TestDiscriminators:
+    def test_can_load_needs_a_5d_patch_embedding(self):
+        five_d = {"embeddings.patch_embeddings.proj.weight": torch.zeros(8, 3, 2, 16, 16)}
+        assert LibreVJEPA2.can_load(five_d)
+        # A 4D Conv2d patch embed is an image ViT, not V-JEPA 2.
+        four_d = {"embeddings.patch_embeddings.proj.weight": torch.zeros(8, 3, 16, 16)}
+        assert not LibreVJEPA2.can_load(four_d)
+        assert not LibreVJEPA2.can_load({"backbone.conv1.weight": torch.zeros(4, 3, 7, 7)})
+
+    def test_can_load_accepts_both_checkpoint_roots(self):
+        nested = {"encoder.embeddings.patch_embeddings.proj.weight": torch.zeros(8, 3, 2, 16, 16)}
+        assert LibreVJEPA2.can_load(nested)
+
+    @pytest.mark.parametrize("hidden,expected", [(1024, "l256"), (1280, "h256")])
+    def test_detect_size_from_width(self, hidden, expected):
+        assert LibreVJEPA2.detect_size({"layernorm.weight": torch.zeros(hidden)}) == expected
+
+    def test_g_sizes_are_not_guessed_from_width(self):
+        """g256 and g384 share a width, so width must not decide between them."""
+        assert LibreVJEPA2.detect_size({"layernorm.weight": torch.zeros(1408)}) is None
+
+
+class TestClipSampler:
+    def test_exact_length_is_centered(self):
+        # 4 frames at stride 2 spans 7 source frames.
+        assert clip_frame_indices(7, 4, 2) == [0, 2, 4, 6]
+
+    def test_long_video_is_centered(self):
+        idx = clip_frame_indices(107, 4, 2)
+        assert idx == [50, 52, 54, 56]
+        assert len(idx) == 4
+
+    def test_short_video_uses_real_frames_before_repeating(self):
+        idx = clip_frame_indices(3, 4, 2)
+        # Real frames first (0, 2), then hold the last rather than repeating early.
+        assert idx == [0, 2, 2, 2]
+        assert idx[0] == 0
+
+    def test_released_default_spans_127_frames(self):
+        idx = clip_frame_indices(1000, 64, 2)
+        assert len(idx) == 64
+        assert idx[-1] - idx[0] == 126
+
+    def test_empty_video_is_an_error_not_a_black_clip(self):
+        with pytest.raises(ValueError, match="no frames"):
+            clip_frame_indices(0, 64, 2)
+
+    @pytest.mark.parametrize("frames,stride", [(0, 2), (64, 0), (-1, 2)])
+    def test_invalid_geometry_rejected(self, frames, stride):
+        with pytest.raises(ValueError):
+            clip_frame_indices(100, frames, stride)
+
+
+class TestTrainingGate:
+    def test_embed_training_rejects_before_dataset_construction(self):
+        model = LibreVJEPA2(size="l256", task="embed")
+        with pytest.raises(NotImplementedError, match="self-supervised"):
+            model.train(data="anything.yaml")
+
+
+class TestVideoMode:
+    def test_family_declares_clip_mode(self):
+        assert LibreVJEPA2.VIDEO_EMBED_MODE == "clip"
+
+    def test_other_families_keep_frame_mode(self):
+        """No-regression: existing families must keep per-frame video results."""
+        from libreyolo.models.base.model import BaseModel
+
+        assert getattr(BaseModel, "VIDEO_EMBED_MODE", "frames") == "frames"
+        for family in ("dinov2", "clip", "siglip2"):
+            cls = next(
+                (c for c in BaseModel._registry if c.FAMILY == family), None
+            )
+            if cls is not None:
+                assert getattr(cls, "VIDEO_EMBED_MODE", "frames") == "frames"

--- a/tests/unit/test_vjepa2.py
+++ b/tests/unit/test_vjepa2.py
@@ -339,3 +339,26 @@ class TestInferenceContracts:
         base = model.sample_clip_indices(500, 1)
         doubled = model.sample_clip_indices(500, 2)
         assert (doubled[-1] - doubled[0]) == 2 * (base[-1] - base[0])
+
+    def test_embed_tokens_unpacks_the_preprocess_tuple(self):
+        """Regression: embed_tokens fed the whole 4-tuple to the encoder."""
+        model = LibreVJEPA2(size="l256", task="embed")
+        model._requested_clip_frames = 2
+        tokens = model.embed_tokens(torch.zeros(1, 2, 3, 256, 256))
+        # (B, T', H', W', D) with T' = frames / tubelet, H' = W' = 256/16
+        assert tokens.shape == (1, 1, 16, 16, 1024)
+
+    def test_embed_tokens_rejects_a_classify_model(self):
+        model = LibreVJEPA2(size="l256", task="classify", nb_classes=174)
+        with pytest.raises(ValueError, match="requires task='embed'"):
+            model.embed_tokens(torch.zeros(1, 2, 3, 256, 256))
+
+    def test_clip_mode_rejects_save_and_show_instead_of_ignoring_them(self):
+        """Clip mode yields one result, so there is no frame stream to write."""
+        import inspect
+
+        from libreyolo.models.base.inference import InferenceRunner
+
+        source = inspect.getsource(InferenceRunner._predict_video)
+        # The flags must be handled in the clip branch, not silently dropped.
+        assert "save or show" in source

--- a/tests/unit/test_vjepa2.py
+++ b/tests/unit/test_vjepa2.py
@@ -1,0 +1,157 @@
+"""Structural unit tests for the V-JEPA 2 port.
+
+These run offline with no checkpoints and no Transformers oracle. The exact
+``max_abs_diff == 0.0`` parity gate against pinned ``transformers==5.1.0``
+lives in ``weights/parity_vjepa2.py`` because it needs both the network and a
+pinned out-of-tree oracle install.
+
+Each test here locks in an invariant that was found to be load-bearing while
+porting: getting any of them wrong still builds a model, but breaks the strict
+load of a released checkpoint or silently changes the numerics.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.vjepa2.nn import (
+    VJEPA2_CONFIGS,
+    LibreVJEPA2Classifier,
+    LibreVJEPA2Encoder,
+    VJEPA2Config,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.vjepa2]
+
+
+# Transcribed from the pinned Hugging Face config.json of each released
+# snapshot. Depth/heads/mlp_ratio are not inferable from the size label.
+EXPECTED_ARCH = {
+    "l256": (1024, 16, 24, 4.0, 256),
+    "h256": (1280, 16, 32, 4.0, 256),
+    "g256": (1408, 22, 40, 4.363636363636363, 256),
+    "g384": (1408, 22, 40, 4.363636363636363, 384),
+}
+
+
+@pytest.mark.parametrize("size", sorted(EXPECTED_ARCH))
+def test_architecture_table_matches_pinned_configs(size):
+    hidden, heads, layers, ratio, crop = EXPECTED_ARCH[size]
+    cfg = VJEPA2_CONFIGS[size]
+    assert cfg["hidden_size"] == hidden
+    assert cfg["num_attention_heads"] == heads
+    assert cfg["num_hidden_layers"] == layers
+    assert cfg["mlp_ratio"] == pytest.approx(ratio)
+    assert cfg["crop_size"] == crop
+
+
+def test_g_sizes_differ_only_by_crop():
+    """g256 and g384 share a width; only the crop distinguishes them."""
+    g256, g384 = VJEPA2_CONFIGS["g256"], VJEPA2_CONFIGS["g384"]
+    assert g256["hidden_size"] == g384["hidden_size"] == 1408
+    assert g256["crop_size"] != g384["crop_size"]
+
+
+def test_unknown_size_rejected():
+    with pytest.raises(ValueError, match="unknown V-JEPA 2 size"):
+        VJEPA2Config.for_size("vitl")
+
+
+def _tiny(**overrides) -> VJEPA2Config:
+    params = dict(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_hidden_layers=2,
+        mlp_ratio=4.363636363636363,
+        crop_size=32,
+        patch_size=16,
+        tubelet_size=2,
+        frames_per_clip=8,
+    )
+    params.update(overrides)
+    return VJEPA2Config(**params)
+
+
+def test_token_count_and_order():
+    """(F/2) * (H/16) * (W/16) tokens, time-major flattening."""
+    cfg = _tiny()
+    model = LibreVJEPA2Encoder(cfg).eval()
+    x = torch.randn(2, 8, 3, 32, 32)
+    with torch.no_grad():
+        tokens = model(x)
+    # 8/2 * 32/16 * 32/16 = 4 * 2 * 2 = 16
+    assert tokens.shape == (2, 16, 64)
+
+
+@pytest.mark.parametrize("size,frames,expected", [("l256", 64, 8192), ("g384", 64, 18432)])
+def test_released_token_counts(size, frames, expected):
+    cfg = VJEPA2_CONFIGS[size]
+    grid = cfg["crop_size"] // 16
+    assert (frames // 2) * grid * grid == expected
+
+
+def test_pooler_mlp_ratio_is_four_not_encoder_ratio():
+    """The probe's MLP ratio is fixed at 4.0 even when the encoder's is not.
+
+    Upstream builds the pooler MLP without passing ``mlp_ratio``, so it keeps
+    the 4.0 default. Using the encoder's 4.3636 for a g-size probe would build
+    fc1 wider than every released checkpoint provides.
+    """
+    cfg = _tiny()  # encoder ratio 4.3636...
+    model = LibreVJEPA2Classifier(cfg, nc=5)
+    assert model.encoder.layer[0].mlp.fc1.out_features == int(64 * 4.363636363636363)
+    assert model.pooler.cross_attention_layer.mlp.fc1.out_features == int(64 * 4.0)
+
+
+def test_pooler_cross_attention_has_no_output_projection():
+    """Upstream's pooler cross-attention omits out_proj; adding one breaks load."""
+    cfg = _tiny()
+    model = LibreVJEPA2Classifier(cfg, nc=5)
+    cross = model.pooler.cross_attention_layer.cross_attn
+    assert not hasattr(cross, "out_proj")
+    assert hasattr(model.pooler.self_attention_layers[0].self_attn, "out_proj")
+
+
+def test_pooler_depth_is_three():
+    model = LibreVJEPA2Classifier(_tiny(), nc=5)
+    assert len(model.pooler.self_attention_layers) == 3
+
+
+def test_classifier_logit_shape():
+    model = LibreVJEPA2Classifier(_tiny(), nc=7).eval()
+    with torch.no_grad():
+        logits = model(torch.randn(2, 8, 3, 32, 32))
+    assert logits.shape == (2, 7)
+
+
+def test_temporal_order_changes_tokens():
+    """A clip model that ignores frame order is a failed port."""
+    torch.manual_seed(0)
+    model = LibreVJEPA2Encoder(_tiny()).eval()
+    x = torch.randn(1, 8, 3, 32, 32)
+    with torch.no_grad():
+        forward = model(x)
+        backward = model(x.flip(dims=[1]))
+    assert (forward - backward).abs().max().item() > 1e-4
+
+
+def test_sdpa_and_eager_agree_closely():
+    """Both attention paths implement the same math."""
+    torch.manual_seed(0)
+    x = torch.randn(1, 8, 3, 32, 32)
+    sdpa = LibreVJEPA2Encoder(_tiny(attn_implementation="sdpa")).eval()
+    eager = LibreVJEPA2Encoder(_tiny(attn_implementation="eager")).eval()
+    eager.load_state_dict(sdpa.state_dict(), strict=True)
+    with torch.no_grad():
+        assert (sdpa(x) - eager(x)).abs().max().item() < 1e-5
+
+
+def test_public_layout_is_batch_frames_channels():
+    """Channels must be dim 2; a (B, C, F, H, W) input is a different picture."""
+    model = LibreVJEPA2Encoder(_tiny()).eval()
+    with torch.no_grad():
+        ok = model(torch.randn(1, 8, 3, 32, 32))
+    assert ok.shape[-1] == 64
+    with pytest.raises(RuntimeError):
+        model(torch.randn(1, 3, 8, 32, 32))

--- a/tests/unit/test_vjepa2.py
+++ b/tests/unit/test_vjepa2.py
@@ -362,3 +362,19 @@ class TestInferenceContracts:
         source = inspect.getsource(InferenceRunner._predict_video)
         # The flags must be handled in the clip branch, not silently dropped.
         assert "save or show" in source
+
+    def test_unknown_frame_count_decode_is_bounded(self):
+        """A video with no header frame count must not be buffered whole.
+
+        Memory has to stay proportional to the clip, not the video: the
+        counting pass uses grab() (no pixel decode) and only the frames the
+        clip actually needs are retained.
+        """
+        import inspect
+
+        from libreyolo.models.base.inference import InferenceRunner
+
+        source = inspect.getsource(InferenceRunner._predict_video_clip)
+        assert "capture.grab()" in source
+        # The old unbounded accumulator must not come back.
+        assert "frames_all" not in source

--- a/tests/unit/test_vjepa2_training.py
+++ b/tests/unit/test_vjepa2_training.py
@@ -1,0 +1,322 @@
+"""Dataset validation and frozen-probe trainer tests for V-JEPA 2.
+
+Everything here is offline and synthetic. The trainer consumes only
+user-supplied videos: no dataset is downloaded, and Something-Something V2,
+Diving48 and Kinetics are never touched.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.vjepa2.dataset import (
+    ManifestError,
+    VideoClipDataset,
+    collate_clips,
+    load_video_dataset,
+    parse_manifest_line,
+)
+from libreyolo.models.vjepa2.model import LibreVJEPA2
+from libreyolo.models.vjepa2.nn import LibreVJEPA2Classifier, VJEPA2Config
+from libreyolo.models.vjepa2.trainer import VJEPA2Trainer
+
+pytestmark = [pytest.mark.unit, pytest.mark.vjepa2]
+
+
+class TestManifestParsing:
+    def test_plain_row(self):
+        assert parse_manifest_line("clips/a.mp4 3", 1) == ("clips/a.mp4", 3)
+
+    def test_path_with_spaces_is_parsed_from_the_last_field(self):
+        """Unquoted paths containing spaces must still resolve."""
+        assert parse_manifest_line("my clips/a b.mp4 2", 1) == ("my clips/a b.mp4", 2)
+
+    def test_tab_delimiter_wins_over_spaces(self):
+        assert parse_manifest_line("my clips/a b.mp4\t7", 1) == ("my clips/a b.mp4", 7)
+
+    def test_quoted_path(self):
+        assert parse_manifest_line('"my clips/a b.mp4" 1', 1) == ("my clips/a b.mp4", 1)
+
+    def test_non_integer_label_is_an_error(self):
+        with pytest.raises(ManifestError, match="not an integer"):
+            parse_manifest_line("clips/a.mp4 cat", 4)
+
+    def test_missing_label_is_an_error(self):
+        with pytest.raises(ManifestError):
+            parse_manifest_line("clips_a.mp4", 2)
+
+    def test_blank_row_is_an_error(self):
+        with pytest.raises(ManifestError, match="blank"):
+            parse_manifest_line("   ", 9)
+
+
+def _write_dataset(tmp_path, *, rows=None, names=None, make_videos=True, val=True):
+    videos = tmp_path / "videos"
+    videos.mkdir(exist_ok=True)
+    if make_videos:
+        for name in ("a.mp4", "b.mp4"):
+            (videos / name).write_bytes(b"not-a-real-video")
+    rows = rows if rows is not None else ["videos/a.mp4 0", "videos/b.mp4 1"]
+    (tmp_path / "train.txt").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    if val:
+        (tmp_path / "val.txt").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    names = names if names is not None else {0: "left", 1: "right"}
+    names_block = "\n".join(f"  {k}: {v}" for k, v in names.items())
+    yaml_text = f"path: {tmp_path.as_posix()}\ntrain: train.txt\n"
+    if val:
+        yaml_text += "val: val.txt\n"
+    yaml_text += f"names:\n{names_block}\n"
+    path = tmp_path / "data.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+    return path
+
+
+class TestDatasetValidation:
+    def test_valid_dataset_loads(self, tmp_path):
+        data = load_video_dataset(_write_dataset(tmp_path))
+        assert data["nc"] == 2
+        assert len(data["train"]) == 2
+        assert data["names"][0] == "left"
+
+    def test_missing_yaml(self, tmp_path):
+        with pytest.raises(ManifestError, match="not found"):
+            load_video_dataset(tmp_path / "nope.yaml")
+
+    def test_missing_video_is_caught_before_training(self, tmp_path):
+        path = _write_dataset(tmp_path, rows=["videos/ghost.mp4 0", "videos/b.mp4 1"])
+        with pytest.raises(ManifestError, match="video not found"):
+            load_video_dataset(path)
+
+    def test_label_out_of_range(self, tmp_path):
+        path = _write_dataset(tmp_path, rows=["videos/a.mp4 0", "videos/b.mp4 9"])
+        with pytest.raises(ManifestError, match="out of range"):
+            load_video_dataset(path)
+
+    def test_names_must_be_contiguous_from_zero(self, tmp_path):
+        path = _write_dataset(tmp_path, names={0: "left", 2: "right"})
+        with pytest.raises(ManifestError, match="contiguous"):
+            load_video_dataset(path)
+
+    def test_names_mismatch_is_rejected(self, tmp_path):
+        """A class named but never used is a dataset bug, not a warning."""
+        path = _write_dataset(
+            tmp_path,
+            rows=["videos/a.mp4 0", "videos/b.mp4 0"],
+            names={0: "left", 1: "right"},
+        )
+        with pytest.raises(ManifestError, match="in no\n?\\s*manifest row|in no manifest row"):
+            load_video_dataset(path)
+
+    def test_missing_train_manifest(self, tmp_path):
+        videos = tmp_path / "videos"
+        videos.mkdir()
+        (tmp_path / "data.yaml").write_text(
+            f"path: {tmp_path.as_posix()}\nnames:\n  0: a\n", encoding="utf-8"
+        )
+        with pytest.raises(ManifestError, match="missing required 'train'"):
+            load_video_dataset(tmp_path / "data.yaml")
+
+    def test_empty_names_rejected(self, tmp_path):
+        (tmp_path / "data.yaml").write_text(
+            f"path: {tmp_path.as_posix()}\ntrain: train.txt\nnames: {{}}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ManifestError, match="non-empty mapping"):
+            load_video_dataset(tmp_path / "data.yaml")
+
+    def test_validation_does_not_touch_the_network(self, tmp_path, monkeypatch):
+        """Dataset validation must never reach for a remote corpus."""
+        import urllib.request
+
+        def _boom(*args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("dataset validation attempted a network call")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _boom)
+        load_video_dataset(_write_dataset(tmp_path))
+
+
+def _tiny_classifier(nc=2, frames=4, size=64):
+    cfg = VJEPA2Config(
+        hidden_size=32,
+        num_attention_heads=2,
+        num_hidden_layers=1,
+        mlp_ratio=2.0,
+        crop_size=size,
+        patch_size=16,
+        tubelet_size=2,
+        frames_per_clip=frames,
+    )
+    return LibreVJEPA2Classifier(cfg, nc=nc, probe_depth=1)
+
+
+def _bare_trainer(model):
+    trainer = VJEPA2Trainer.__new__(VJEPA2Trainer)
+    trainer.model = model
+    return trainer
+
+
+class TestFreezing:
+    def test_encoder_is_frozen_and_in_eval_mode(self):
+        model = _tiny_classifier()
+        model.train()
+        trainable = _bare_trainer(model).freeze_encoder()
+        assert all(not p.requires_grad for p in model.encoder.parameters())
+        assert not model.encoder.training
+        assert trainable, "the probe must still have trainable parameters"
+
+    def test_only_pooler_and_classifier_train(self):
+        model = _tiny_classifier()
+        trainable = _bare_trainer(model).freeze_encoder()
+        assert all(n.startswith(("pooler.", "classifier.")) for n in trainable)
+        assert any(n.startswith("pooler.") for n in trainable)
+        assert any(n.startswith("classifier.") for n in trainable)
+
+    def test_optimizer_membership_excludes_the_encoder(self):
+        model = _tiny_classifier()
+        trainer = _bare_trainer(model)
+
+        class _Cfg:
+            lr0 = 1e-3
+            weight_decay = 0.05
+
+        trainer.config = _Cfg()
+        optimizer = trainer._setup_optimizer()
+        optimized = {id(p) for g in optimizer.param_groups for p in g["params"]}
+        encoder = {id(p) for p in model.encoder.parameters()}
+        assert optimized.isdisjoint(encoder)
+        assert optimized
+
+
+class TestForwardContract:
+    def test_forward_requires_a_5d_clip(self):
+        trainer = _bare_trainer(_tiny_classifier())
+        with pytest.raises(ValueError, match=r"\(B, F, C, H, W\)"):
+            trainer.on_forward(torch.zeros(2, 3, 64, 64), torch.zeros(2, dtype=torch.long))
+
+    def test_forward_returns_a_cross_entropy_loss(self):
+        model = _tiny_classifier()
+        trainer = _bare_trainer(model)
+        out = trainer.on_forward(
+            torch.randn(2, 4, 3, 64, 64), torch.tensor([0, 1])
+        )
+        assert "total_loss" in out and out["total_loss"].requires_grad
+        assert trainer.get_loss_components(out)["ce"] > 0
+
+    def test_collate_keeps_time_out_of_batch(self):
+        batch = [(torch.zeros(4, 3, 64, 64), 0), (torch.zeros(4, 3, 64, 64), 1)]
+        clips, labels = collate_clips(batch)
+        assert clips.shape == (2, 4, 3, 64, 64)
+        assert labels.tolist() == [0, 1]
+
+    def test_best_metric_is_top1_accuracy(self):
+        assert VJEPA2Trainer.best_metric_key == "metrics/accuracy_top1"
+
+
+class TestTrainingGates:
+    def test_embed_training_rejects_immediately(self):
+        model = LibreVJEPA2(size="l256", task="embed")
+        with pytest.raises(NotImplementedError, match="self-supervised"):
+            model.train(data="whatever.yaml")
+
+    def test_predictor_pretraining_rejects(self):
+        model = LibreVJEPA2(size="l256", task="classify", nb_classes=2)
+        with pytest.raises(NotImplementedError, match="predictor"):
+            model.train(data="whatever.yaml", predictor=True)
+
+    def test_full_finetune_requires_explicit_support(self):
+        model = LibreVJEPA2(size="l256", task="classify", nb_classes=2)
+        with pytest.raises(NotImplementedError, match="freeze=0"):
+            model.train(data="whatever.yaml", freeze=0)
+
+
+@pytest.mark.slow
+class TestSyntheticMotionConvergence:
+    """The label is the DIRECTION of travel.
+
+    A model that ignores frame order cannot beat chance here, so this is what
+    proves the clip path preserves time end to end through training -- a
+    static-colour dataset would pass even with time discarded.
+    """
+
+    def _make_dataset(self, tmp_path, frames=8, size=64):
+        cv2 = pytest.importorskip("cv2")
+        import numpy as np
+
+        videos = tmp_path / "videos"
+        videos.mkdir()
+
+        def write(path, rightwards):
+            writer = cv2.VideoWriter(
+                str(path), cv2.VideoWriter_fourcc(*"mp4v"), 10, (size, size)
+            )
+            for i in range(frames * 3):
+                frame = np.zeros((size, size, 3), np.uint8)
+                t = i if rightwards else (frames * 3 - 1 - i)
+                x = 4 + (t * 2) % (size - 12)
+                cv2.rectangle(frame, (x, 26), (x + 8, 34), (255, 255, 255), -1)
+                writer.write(frame)
+            writer.release()
+
+        rows = []
+        for i in range(8):
+            for label, rightwards in ((0, True), (1, False)):
+                name = f"clip_{i}_{label}.mp4"
+                write(videos / name, rightwards)
+                rows.append(f"videos/{name} {label}")
+        (tmp_path / "train.txt").write_text("\n".join(rows) + "\n", encoding="utf-8")
+        (tmp_path / "data.yaml").write_text(
+            f"path: {tmp_path.as_posix()}\ntrain: train.txt\n"
+            "names:\n  0: rightwards\n  1: leftwards\n",
+            encoding="utf-8",
+        )
+        return tmp_path / "data.yaml"
+
+    def test_probe_learns_direction(self, tmp_path):
+        from torch.utils.data import DataLoader
+
+        # A convergence assertion on a randomly initialized probe is otherwise
+        # seed-dependent; pin it so a failure means a real regression rather
+        # than an unlucky draw.
+        torch.manual_seed(0)
+
+        frames, size = 8, 64
+        yaml_path = self._make_dataset(tmp_path, frames=frames, size=size)
+        data = load_video_dataset(yaml_path)
+
+        model = _tiny_classifier(nc=2, frames=frames, size=size)
+        trainer = _bare_trainer(model)
+
+        class _Cfg:
+            lr0 = 3e-3
+            weight_decay = 0.05
+
+        trainer.config = _Cfg()
+        optimizer = trainer._setup_optimizer()
+
+        loader = DataLoader(
+            VideoClipDataset(data["train"], frames, 1, size, train=True),
+            batch_size=4, shuffle=True, num_workers=0, collate_fn=collate_clips,
+        )
+
+        first = last = None
+        accuracy = 0.0
+        for _ in range(12):
+            total, correct, seen = 0.0, 0, 0
+            for clips, labels in loader:
+                assert clips.ndim == 5
+                out = trainer.on_forward(clips, labels)
+                optimizer.zero_grad()
+                out["total_loss"].backward()
+                optimizer.step()
+                total += float(out["total_loss"])
+                with torch.no_grad():
+                    correct += int((model(clips).argmax(-1) == labels).sum())
+                seen += labels.numel()
+            mean = total / max(1, len(loader))
+            first = mean if first is None else first
+            last = mean
+            accuracy = correct / seen
+
+        assert last < first, f"loss did not decrease: {first} -> {last}"
+        assert accuracy > 0.5, f"did not beat chance: {accuracy}"

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -460,6 +460,46 @@ non-commercial purposes. Converting a locally held checkpoint does not change
 its applicable terms. A checkpoint trained independently on compatibly
 licensed data may be distributed under the terms established by its trainer.
 
+V-JEPA 2 video encoders and attentive probes
+-------------------------------------------
+Weight licenses for this family are per artifact and are deliberately NOT
+collapsed into a single family-wide claim: the two ViT-g encoders are
+Apache-2.0 while the other six artifacts are MIT. Each rehosted Hugging Face
+repository carries the licence of its own source artifact.
+
+  LibreVJEPA2l256-embed.pt
+    facebook/vjepa2-vitl-fpc64-256 @ b3c1679b7c34d3255ef3547f27c7b226aefab26f
+    MIT
+  LibreVJEPA2h256-embed.pt
+    facebook/vjepa2-vith-fpc64-256 @ b5eac8703e3efdc1547fbb6ddfbeb133dc0bdee5
+    MIT
+  LibreVJEPA2g256-embed.pt
+    facebook/vjepa2-vitg-fpc64-256 @ 875c192b7b704b87d1e1d99345769632dd5f739a
+    Apache-2.0
+  LibreVJEPA2g384-embed.pt
+    facebook/vjepa2-vitg-fpc64-384 @ 12ca91694b230e0d4b5b0078af6f4ae1d51e933d
+    Apache-2.0
+  LibreVJEPA2l256-cls-ssv2.pt
+    facebook/vjepa2-vitl-fpc16-256-ssv2 @ 4aa02df83918538fc21cfaf576382fa20e489a80
+    MIT
+  LibreVJEPA2l256-cls-diving48.pt
+    facebook/vjepa2-vitl-fpc32-256-diving48 @ 71ae2a8b1ff5a297aeeaae9b5e64c7a2e5e6a633
+    MIT
+  LibreVJEPA2g384-cls-ssv2.pt
+    facebook/vjepa2-vitg-fpc64-384-ssv2 @ 9f5fd615cb6f79065a28edcf1cc3ef25010dddfa
+    MIT
+  LibreVJEPA2g384-cls-diving48.pt
+    facebook/vjepa2-vitg-fpc32-384-diving48 @ 0b48243375319bd8e03e3cd5560d957095429189
+    MIT
+
+The probe checkpoints were trained on Something-Something V2 and Diving48.
+Those datasets are named here for provenance only. Their terms are not the
+terms of these converted weights, and LibreYOLO does not mirror, bundle or
+auto-download either dataset. Something-Something V2 is distributed under a
+research-use agreement; Diving48's redistribution terms are not clearly
+established by the selected official source. Users training on either dataset
+are responsible for accepting its terms themselves.
+
 Third-party SOURCE CODE bundled inside the LibreYOLO Python package
 (separate from weights) is disclosed in the top-level NOTICE file.
 Notably, the DEIMv2 family bundles DINOv3 backbone code under Meta's

--- a/weights/convert_vjepa2_weights.py
+++ b/weights/convert_vjepa2_weights.py
@@ -77,7 +77,16 @@ def _load_snapshot(repo: str, revision: str) -> Tuple[dict, dict]:
 
     from huggingface_hub import snapshot_download
 
-    local = Path(snapshot_download(repo, revision=revision))
+    # Fetch only what the conversion reads. These repos ship the weights in
+    # BOTH safetensors and pickle form, and pulling both doubles the download
+    # and the on-disk cache for no benefit (the h256 repo is ~13 GB with both).
+    local = Path(
+        snapshot_download(
+            repo,
+            revision=revision,
+            allow_patterns=["config.json", "*.safetensors", "*.safetensors.index.json"],
+        )
+    )
     config = json.loads((local / "config.json").read_text(encoding="utf-8"))
 
     shards = sorted(local.glob("*.safetensors"))

--- a/weights/convert_vjepa2_weights.py
+++ b/weights/convert_vjepa2_weights.py
@@ -1,0 +1,319 @@
+"""Convert pinned upstream V-JEPA 2.0 snapshots to LibreYOLO checkpoints.
+
+Encoders (milestone 1)::
+
+    python weights/convert_vjepa2_weights.py --size l256 --task embed \
+        --output weights/LibreVJEPA2l256-embed.pt
+
+Attentive probes (milestone 2)::
+
+    python weights/convert_vjepa2_weights.py --size l256 --task classify \
+        --variant ssv2 --output weights/LibreVJEPA2l256-cls-ssv2.pt
+
+The snapshot is fetched at its exact pinned revision, so the conversion is
+deterministic. Keys are mapped explicitly and loaded strictly: a key is only
+dropped when it belongs to a named, asserted set, never by substring match.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import torch
+
+from _conversion_utils import (
+    add_repo_root_to_path,
+    save_checkpoint,
+    wrap_libreyolo_checkpoint,
+)
+
+add_repo_root_to_path()
+
+from libreyolo.models.vjepa2.model import (  # noqa: E402
+    ENCODER_FRAMES,
+    PROBE_CLASSES,
+    PROBE_FRAMES,
+    LibreVJEPA2,
+)
+from libreyolo.models.vjepa2.nn import (  # noqa: E402
+    VJEPA2_CONFIGS,
+    LibreVJEPA2Classifier,
+    LibreVJEPA2Encoder,
+    VJEPA2Config,
+)
+from libreyolo.models.vjepa2.preprocess import (  # noqa: E402
+    DEFAULT_FRAME_STRIDE,
+    PIXEL_MEAN,
+    PIXEL_STD,
+)
+
+# (repo, revision, weight license) per artifact. Licenses are per artifact and
+# are deliberately not collapsed into one family-wide claim: the two g encoders
+# are Apache-2.0 while everything else is MIT.
+ENCODER_SOURCES: Dict[str, Tuple[str, str, str]] = {
+    "l256": ("facebook/vjepa2-vitl-fpc64-256", "b3c1679b7c34d3255ef3547f27c7b226aefab26f", "MIT"),
+    "h256": ("facebook/vjepa2-vith-fpc64-256", "b5eac8703e3efdc1547fbb6ddfbeb133dc0bdee5", "MIT"),
+    "g256": ("facebook/vjepa2-vitg-fpc64-256", "875c192b7b704b87d1e1d99345769632dd5f739a", "Apache-2.0"),
+    "g384": ("facebook/vjepa2-vitg-fpc64-384", "12ca91694b230e0d4b5b0078af6f4ae1d51e933d", "Apache-2.0"),
+}
+
+PROBE_SOURCES: Dict[Tuple[str, str], Tuple[str, str, str]] = {
+    ("l256", "ssv2"): ("facebook/vjepa2-vitl-fpc16-256-ssv2", "4aa02df83918538fc21cfaf576382fa20e489a80", "MIT"),
+    ("l256", "diving48"): ("facebook/vjepa2-vitl-fpc32-256-diving48", "71ae2a8b1ff5a297aeeaae9b5e64c7a2e5e6a633", "MIT"),
+    ("g384", "ssv2"): ("facebook/vjepa2-vitg-fpc64-384-ssv2", "9f5fd615cb6f79065a28edcf1cc3ef25010dddfa", "MIT"),
+    ("g384", "diving48"): ("facebook/vjepa2-vitg-fpc32-384-diving48", "0b48243375319bd8e03e3cd5560d957095429189", "MIT"),
+}
+
+# The predictor is the self-supervised head. It is the ONLY group the encoder
+# conversion may drop, and it is asserted rather than filtered by substring.
+ENCODER_ALLOWED_DROPS = {"predictor"}
+
+
+def _load_snapshot(repo: str, revision: str) -> Tuple[dict, dict]:
+    """Fetch a pinned snapshot and return (state_dict, config dict)."""
+    import json
+
+    from huggingface_hub import snapshot_download
+
+    local = Path(snapshot_download(repo, revision=revision))
+    config = json.loads((local / "config.json").read_text(encoding="utf-8"))
+
+    shards = sorted(local.glob("*.safetensors"))
+    if shards:
+        from safetensors.torch import load_file
+
+        state: dict = {}
+        for shard in shards:
+            state.update(load_file(str(shard)))
+        return state, config
+
+    bins = sorted(local.glob("*.bin"))
+    if not bins:
+        raise SystemExit(f"no safetensors or .bin weights found in {local}")
+    state = {}
+    for shard in bins:
+        state.update(torch.load(shard, map_location="cpu", weights_only=True))
+    return state, config
+
+
+def _validate_config(size: str, config: dict) -> None:
+    """Validate the full pinned config before mapping a single key."""
+    table = VJEPA2_CONFIGS[size]
+    checks = {
+        "hidden_size": table["hidden_size"],
+        "num_attention_heads": table["num_attention_heads"],
+        "num_hidden_layers": table["num_hidden_layers"],
+        "crop_size": table["crop_size"],
+        "patch_size": 16,
+        "tubelet_size": 2,
+    }
+    for key, expected in checks.items():
+        actual = config.get(key)
+        if actual != expected:
+            raise SystemExit(
+                f"[{size}] pinned config {key}={actual!r} disagrees with the family "
+                f"table {expected!r}; re-audit before converting"
+            )
+    ratio = float(config.get("mlp_ratio", 0))
+    if abs(ratio - float(table["mlp_ratio"])) > 1e-9:
+        raise SystemExit(
+            f"[{size}] pinned config mlp_ratio={ratio} != table {table['mlp_ratio']}"
+        )
+    # V-JEPA 2.1 and V-JEPA2-AC must never be accepted as 2.0.
+    model_type = config.get("model_type")
+    if model_type != "vjepa2":
+        raise SystemExit(
+            f"[{size}] refusing snapshot with model_type={model_type!r}; this "
+            "converter only accepts V-JEPA 2.0 encoders. V-JEPA 2.1 and "
+            "V-JEPA2-AC are different architectures, not size aliases."
+        )
+    if "pred_num_mask_tokens" in config and config.get("pred_hidden_size") is None:
+        raise SystemExit(f"[{size}] unexpected predictor config layout")
+
+
+def _base_metadata(size: str, repo: str, revision: str, license_id: str, frames: int) -> dict:
+    """Extra checkpoint metadata.
+
+    ``family``/``size``/``task``/``nc``/``names`` are passed to the wrapper as
+    explicit arguments, so they are deliberately absent here to avoid
+    duplicate-keyword collisions.
+    """
+    return {
+        "source_repo": repo,
+        "source_revision": revision,
+        "source_license": license_id,
+        "input_kind": "video",
+        "input_size": VJEPA2_CONFIGS[size]["crop_size"],
+        "frames_per_clip": frames,
+        "frame_stride": DEFAULT_FRAME_STRIDE,
+        "patch_size": 16,
+        "tubelet_size": 2,
+        "hidden_dim": VJEPA2_CONFIGS[size]["hidden_size"],
+        "embedding_pool": "mean_final_tokens_l2",
+        "pixel_mean": list(PIXEL_MEAN),
+        "pixel_std": list(PIXEL_STD),
+    }
+
+
+def convert_encoder(size: str, output: Path) -> None:
+    repo, revision, license_id = ENCODER_SOURCES[size]
+    LibreVJEPA2.validate_artifact_name(size, "embed", None)
+
+    state, config = _load_snapshot(repo, revision)
+    _validate_config(size, config)
+
+    encoder_state = {
+        k[len("encoder."):]: v for k, v in state.items() if k.startswith("encoder.")
+    }
+    dropped = {k.split(".")[0] for k in state if not k.startswith("encoder.")}
+    unexpected = dropped - ENCODER_ALLOWED_DROPS
+    if unexpected:
+        raise SystemExit(
+            f"[{size}] snapshot has unexpected top-level groups {sorted(unexpected)}. "
+            "Refusing to drop keys that are not in the asserted set "
+            f"{sorted(ENCODER_ALLOWED_DROPS)}."
+        )
+
+    model = LibreVJEPA2Encoder(VJEPA2Config.for_size(size, frames_per_clip=ENCODER_FRAMES))
+    model.load_state_dict(encoder_state, strict=True)
+    params = sum(p.numel() for p in model.parameters())
+    print(
+        f"[{size}] strict-loaded {len(encoder_state)} tensors ({params / 1e6:.1f}M params); "
+        f"dropped {sorted(dropped)}"
+    )
+
+    metadata = _base_metadata(size, repo, revision, license_id, ENCODER_FRAMES)
+    metadata["variant"] = None
+
+    wrapped = wrap_libreyolo_checkpoint(
+        encoder_state,
+        model_family="vjepa2",
+        size=size,
+        # An encoder has no class head. The checkpoint schema requires a
+        # positive nc, so this is an explicit placeholder rather than a
+        # meaningful class count -- it is deliberately NOT the embedding
+        # dimension, which is carried separately as hidden_dim and would
+        # otherwise be mistaken for a head width by the rebuild path.
+        nc=1,
+        names={0: "embedding"},
+        task="embed",
+        supported_tasks=("embed", "classify"),
+        default_task="embed",
+        **metadata,
+    )
+    _write(wrapped, output)
+
+
+def convert_probe(size: str, variant: str, output: Path) -> None:
+    key = (size, variant)
+    if key not in PROBE_SOURCES:
+        raise SystemExit(
+            f"no released probe for size={size!r} variant={variant!r}; "
+            f"published: {sorted(PROBE_SOURCES)}"
+        )
+    LibreVJEPA2.validate_artifact_name(size, "classify", variant)
+    repo, revision, license_id = PROBE_SOURCES[key]
+    frames = PROBE_FRAMES[key]
+    nc = PROBE_CLASSES[variant]
+
+    state, config = _load_snapshot(repo, revision)
+    _validate_config(size, config)
+
+    mapped: dict = {}
+    for k, v in state.items():
+        if k.startswith("vjepa2.encoder."):
+            mapped["encoder." + k[len("vjepa2.encoder."):]] = v
+        elif k.startswith("pooler.") or k.startswith("classifier."):
+            mapped[k] = v
+    dropped = {
+        k.split(".")[1] if k.startswith("vjepa2.") else k.split(".")[0]
+        for k in state
+        if not (
+            k.startswith("vjepa2.encoder.")
+            or k.startswith("pooler.")
+            or k.startswith("classifier.")
+        )
+    }
+    unexpected = dropped - ENCODER_ALLOWED_DROPS
+    if unexpected:
+        raise SystemExit(
+            f"[{size}-{variant}] unexpected groups {sorted(unexpected)}; refusing "
+            "to drop keys outside the asserted set"
+        )
+
+    model = LibreVJEPA2Classifier(
+        VJEPA2Config.for_size(size, frames_per_clip=frames), nc=nc
+    )
+    model.load_state_dict(mapped, strict=True)
+    print(
+        f"[{size}-{variant}] strict-loaded {len(mapped)} tensors, nc={nc}, "
+        f"frames={frames}; dropped {sorted(dropped)}"
+    )
+
+    names = config.get("id2label")
+    if names:
+        names = {int(k): v for k, v in names.items()}
+        if len(names) != nc:
+            raise SystemExit(
+                f"[{size}-{variant}] id2label has {len(names)} entries but nc={nc}"
+            )
+    else:
+        raise SystemExit(
+            f"[{size}-{variant}] snapshot supplies no id2label; refusing to invent "
+            "generic numeric class names for a published artifact"
+        )
+
+    metadata = _base_metadata(size, repo, revision, license_id, frames)
+    metadata.update(
+        {
+            "variant": variant,
+            "probe_depth": 3,
+            "dataset": variant,
+        }
+    )
+
+    wrapped = wrap_libreyolo_checkpoint(
+        mapped,
+        model_family="vjepa2",
+        size=size,
+        nc=nc,
+        names=names,
+        task="classify",
+        supported_tasks=("embed", "classify"),
+        default_task="embed",
+        **metadata,
+    )
+    _write(wrapped, output)
+
+
+def _write(wrapped: dict, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output.with_suffix(output.suffix + ".tmp")
+    save_checkpoint(wrapped, tmp)
+    tmp.replace(output)  # atomic
+    size_mb = output.stat().st_size / 1e6
+    print(f"Wrote {output} ({size_mb:.1f} MB)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--size", required=True, choices=sorted(ENCODER_SOURCES))
+    parser.add_argument("--task", required=True, choices=["embed", "classify"])
+    parser.add_argument("--variant", choices=sorted(PROBE_CLASSES), default=None)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    if args.task == "embed":
+        if args.variant:
+            raise SystemExit("--variant is not valid for --task embed")
+        convert_encoder(args.size, args.output)
+    else:
+        if not args.variant:
+            raise SystemExit("--task classify requires --variant")
+        convert_probe(args.size, args.variant, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/weights/parity_vjepa2.py
+++ b/weights/parity_vjepa2.py
@@ -1,0 +1,158 @@
+"""Exact-parity gate for the V-JEPA 2 port.
+
+Compares the native LibreYOLO encoder against unmodified Hugging Face
+Transformers pinned at ``v5.1.0`` on fixed float32 CPU inputs, and requires
+``max_abs_diff == 0.0`` for both the full final token tensor and the public
+mean-pooled, L2-normalized vector.
+
+The oracle must be the pinned version. Later Transformers releases refactor
+the V-JEPA 2 attention dispatch and rotary helper, so a newer install is not
+a valid oracle for this gate. Install it out-of-tree, for example::
+
+    python -m pip install --target ./tf510 "transformers==5.1.0"
+    python -m pip install --target ./tf510 --no-deps "kernels<0.10"
+    PYTHONPATH=./tf510 python weights/parity_vjepa2.py --size l256
+
+Usage::
+
+    python weights/parity_vjepa2.py --size l256 [--frames 64] [--impl sdpa]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import torch
+import torch.nn.functional as F
+
+from _conversion_utils import add_repo_root_to_path
+
+add_repo_root_to_path()
+
+from libreyolo.models.vjepa2.nn import (  # noqa: E402
+    VJEPA2_CONFIGS,
+    LibreVJEPA2Encoder,
+    VJEPA2Config,
+)
+
+# Pinned encoder snapshots. Revisions are exact and must not drift.
+ENCODER_SOURCES: dict[str, tuple[str, str]] = {
+    "l256": ("facebook/vjepa2-vitl-fpc64-256", "b3c1679b7c34d3255ef3547f27c7b226aefab26f"),
+    "h256": ("facebook/vjepa2-vith-fpc64-256", "b5eac8703e3efdc1547fbb6ddfbeb133dc0bdee5"),
+    "g256": ("facebook/vjepa2-vitg-fpc64-256", "875c192b7b704b87d1e1d99345769632dd5f739a"),
+    "g384": ("facebook/vjepa2-vitg-fpc64-384", "12ca91694b230e0d4b5b0078af6f4ae1d51e933d"),
+}
+
+REQUIRED_ORACLE_VERSION = "5.1.0"
+
+# The only top-level group the encoder conversion is allowed to drop. Anything
+# else appearing here means the checkpoint layout changed and the conversion
+# must be re-audited rather than silently discarding tensors.
+ALLOWED_DROPPED_GROUPS = {"predictor"}
+
+
+def run(size: str, frames: int, impl: str) -> None:
+    import transformers
+
+    if transformers.__version__ != REQUIRED_ORACLE_VERSION:
+        raise SystemExit(
+            f"parity oracle must be transformers=={REQUIRED_ORACLE_VERSION}, "
+            f"found {transformers.__version__}. See this file's docstring."
+        )
+    from transformers.models.vjepa2.modeling_vjepa2 import VJEPA2Model
+
+    repo, revision = ENCODER_SOURCES[size]
+    torch.manual_seed(0)
+    torch.set_grad_enabled(False)
+
+    oracle = VJEPA2Model.from_pretrained(
+        repo, revision=revision, dtype=torch.float32, attn_implementation=impl
+    ).eval()
+    cfg = oracle.config
+
+    # Gate: never trust the size label for architecture. Validate the family
+    # table against the pinned config before comparing anything.
+    table = VJEPA2_CONFIGS[size]
+    for key, expected in (
+        ("hidden_size", cfg.hidden_size),
+        ("num_attention_heads", cfg.num_attention_heads),
+        ("num_hidden_layers", cfg.num_hidden_layers),
+        ("mlp_ratio", cfg.mlp_ratio),
+        ("crop_size", cfg.crop_size),
+    ):
+        if table[key] != expected:
+            raise SystemExit(
+                f"[{size}] architecture table {key}={table[key]!r} disagrees with "
+                f"pinned config {expected!r}"
+            )
+    print(f"[{size}] architecture table matches pinned config @ {revision}")
+
+    ours = LibreVJEPA2Encoder(VJEPA2Config.for_size(size, attn_implementation=impl)).eval()
+
+    oracle_sd = oracle.state_dict()
+    encoder_sd = {
+        k[len("encoder."):]: v for k, v in oracle_sd.items() if k.startswith("encoder.")
+    }
+    dropped = {k.split(".")[0] for k in oracle_sd if not k.startswith("encoder.")}
+    if not dropped <= ALLOWED_DROPPED_GROUPS:
+        raise SystemExit(
+            f"[{size}] unexpected non-encoder groups {sorted(dropped - ALLOWED_DROPPED_GROUPS)}; "
+            "re-audit the conversion instead of dropping them"
+        )
+    ours.load_state_dict(encoder_sd, strict=True)
+    params = sum(p.numel() for p in ours.parameters())
+    print(
+        f"[{size}] strict-loaded {len(encoder_sd)} tensors, {params / 1e6:.1f}M params, "
+        f"dropped {sorted(dropped)}"
+    )
+
+    crop = cfg.crop_size
+    x = torch.randn(1, frames, 3, crop, crop)
+
+    reference_tokens = oracle.get_vision_features(x)
+    our_tokens = ours(x)
+    if reference_tokens.shape != our_tokens.shape:
+        raise SystemExit(
+            f"[{size}] token shape {tuple(our_tokens.shape)} != "
+            f"{tuple(reference_tokens.shape)}"
+        )
+    token_diff = (reference_tokens - our_tokens).abs().max().item()
+    print(
+        f"[{size}] impl={impl} frames={frames} tokens={tuple(our_tokens.shape)} "
+        f"TOKEN max_abs_diff={token_diff}"
+    )
+    if token_diff != 0.0:
+        raise SystemExit(f"[{size}] token parity FAILED: {token_diff}")
+
+    ref_vec = F.normalize(reference_tokens.mean(dim=1), dim=-1).float()
+    our_vec = F.normalize(our_tokens.mean(dim=1), dim=-1).float()
+    pooled_diff = (ref_vec - our_vec).abs().max().item()
+    print(
+        f"[{size}] pooled={tuple(our_vec.shape)} POOLED max_abs_diff={pooled_diff} "
+        f"norm={our_vec.norm(dim=-1).item():.6f}"
+    )
+    if pooled_diff != 0.0:
+        raise SystemExit(f"[{size}] pooled parity FAILED: {pooled_diff}")
+
+    # A graph that loads but ignores time is a failed port, not a passing one.
+    reversed_tokens = ours(x.flip(dims=[1]))
+    delta = (our_tokens - reversed_tokens).abs().max().item()
+    print(f"[{size}] temporal-order sensitivity max_abs_delta={delta:.6f}")
+    if delta <= 1e-3:
+        raise SystemExit(f"[{size}] model is insensitive to frame order ({delta})")
+
+    print(f"[{size}] PARITY OK")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--size", choices=sorted(ENCODER_SOURCES), required=True)
+    parser.add_argument("--frames", type=int, default=64)
+    parser.add_argument("--impl", choices=["sdpa", "eager"], default="sdpa")
+    args = parser.parse_args()
+    run(args.size, args.frames, args.impl)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/weights/stage_vjepa2_hf_repos.py
+++ b/weights/stage_vjepa2_hf_repos.py
@@ -1,0 +1,212 @@
+"""Stage (and optionally upload) the V-JEPA 2 Hugging Face weight repos.
+
+Builds the exact 5-file contract from ``skills/libreyolo-upload-hf-model``:
+
+    .gitattributes  README.md  LICENSE  NOTICE  Libre<...>.pt
+
+Weight licences are per artifact. The two ViT-g encoders are Apache-2.0 while
+the other six artifacts are MIT, so each repo ships the licence text of its
+own source rather than a family-wide approximation.
+
+Usage::
+
+    python weights/stage_vjepa2_hf_repos.py --stage-dir build/hf            # stage only
+    python weights/stage_vjepa2_hf_repos.py --stage-dir build/hf --upload   # stage + push
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+from convert_vjepa2_weights import ENCODER_SOURCES, PROBE_SOURCES
+
+ORG = "LibreYOLO"
+
+# name -> (source repo, revision, licence id, description)
+ARTIFACTS: dict[str, tuple[str, str, str, str]] = {}
+for _size, (_repo, _rev, _lic) in ENCODER_SOURCES.items():
+    ARTIFACTS[f"LibreVJEPA2{_size}-embed"] = (
+        _repo,
+        _rev,
+        _lic,
+        f"V-JEPA 2.0 {_size} video encoder (clip embedding)",
+    )
+for (_size, _variant), (_repo, _rev, _lic) in PROBE_SOURCES.items():
+    ARTIFACTS[f"LibreVJEPA2{_size}-cls-{_variant}"] = (
+        _repo,
+        _rev,
+        _lic,
+        f"V-JEPA 2.0 {_size} attentive probe, {_variant} video classification",
+    )
+
+LICENSE_URLS = {
+    "MIT": "https://raw.githubusercontent.com/facebookresearch/vjepa2/204698b45b3712590f06245fbfba32d3be539812/LICENSE",
+    "Apache-2.0": "https://raw.githubusercontent.com/huggingface/transformers/v5.1.0/LICENSE",
+}
+
+LICENSE_TAG = {"MIT": "mit", "Apache-2.0": "apache-2.0"}
+
+
+def _license_text(license_id: str) -> str:
+    import urllib.request
+
+    with urllib.request.urlopen(LICENSE_URLS[license_id]) as response:
+        return response.read().decode("utf-8")
+
+
+def _readme(name: str, repo: str, revision: str, license_id: str, description: str) -> str:
+    is_probe = "-cls-" in name
+    task = "video-classification" if is_probe else "feature-extraction"
+    return f"""---
+license: {LICENSE_TAG[license_id]}
+library_name: libreyolo
+pipeline_tag: {task}
+tags:
+  - libreyolo
+  - vjepa2
+  - video
+base_model: {repo}
+---
+
+# {name}
+
+{description}, converted for [LibreYOLO](https://github.com/LibreYOLO/libreyolo).
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("{name}.pt")
+result = model.predict("clip.mp4")
+```
+
+## Source
+
+Converted from [`{repo}`](https://huggingface.co/{repo}) at revision
+`{revision}`.
+
+## Modifications
+
+The upstream checkpoint is remapped into LibreYOLO's native V-JEPA 2 module
+and wrapped with LibreYOLO v1.0 checkpoint metadata (family, size, task,
+dataset variant, clip geometry, preprocessing and the pooling rule). Tensor
+values are unchanged: the conversion is a key remap, loaded strictly, and the
+self-supervised `predictor` tower is dropped as a named, asserted set rather
+than by substring match.
+
+Parity against unmodified `transformers==5.1.0` on float32 CPU is exact
+(`max_abs_diff == 0.0`){" for single-view logits" if is_probe else
+ " for both the full final token tensor and the mean-pooled, L2-normalized vector"}.
+
+## Embedding contract
+
+{"This probe applies the exact upstream three-layer attentive pooler and linear classifier. One temporal view is used by default; the published multi-view accuracy is NOT claimed from single-view inference." if is_probe else
+ "The public embedding is a LibreYOLO pooling contract: the arithmetic mean of the final encoder tokens, L2-normalized. Upstream designates no global retrieval vector, and no retrieval benchmark is claimed for it. The native spatiotemporal token grid is available separately via `model.embed_tokens(...)`."}
+
+V-JEPA 2 is trained on video. An image is accepted as a single-frame input,
+which is a static appearance representation, not a motion one.
+
+## License
+
+These weights are **{license_id}**, inherited from the source checkpoint above.
+The full text is in `LICENSE`, with attribution in `NOTICE`. Licences in this
+family differ per artifact, so do not assume a family-wide licence.
+
+{"The probe was trained on a third-party video dataset, named for provenance only. Its dataset terms are not the terms of these weights, and LibreYOLO does not mirror or auto-download it." if is_probe else ""}
+"""
+
+
+def _notice(name: str, repo: str, revision: str, license_id: str) -> str:
+    return f"""{name}
+{"=" * len(name)}
+
+Converted by the LibreYOLO project from:
+
+    {repo}
+    revision {revision}
+    weight license: {license_id}
+
+Original work: V-JEPA 2, Copyright (c) Meta Platforms, Inc. and affiliates.
+Upstream project: https://github.com/facebookresearch/vjepa2 (MIT)
+
+The LibreYOLO port of the V-JEPA 2 architecture is adapted from Hugging Face
+Transformers v5.1.0 (Apache License 2.0), Copyright 2025 The HuggingFace Inc.
+team. That Apache-2.0 code is not relicensed; see the NOTICE file in
+libreyolo/models/vjepa2/ in the LibreYOLO source tree.
+
+This conversion changes checkpoint packaging only. Tensor values are
+unchanged.
+"""
+
+
+def stage(stage_dir: Path, gitattributes: Path, weights_dir: Path) -> list[Path]:
+    staged = []
+    for name, (repo, revision, license_id, description) in sorted(ARTIFACTS.items()):
+        weight = weights_dir / f"{name}.pt"
+        if not weight.exists():
+            print(f"[skip] {name}: {weight} not converted yet")
+            continue
+        out = stage_dir / name
+        out.mkdir(parents=True, exist_ok=True)
+
+        shutil.copy(gitattributes, out / ".gitattributes")
+        (out / "README.md").write_text(
+            _readme(name, repo, revision, license_id, description), encoding="utf-8"
+        )
+        (out / "LICENSE").write_text(_license_text(license_id), encoding="utf-8")
+        (out / "NOTICE").write_text(
+            _notice(name, repo, revision, license_id), encoding="utf-8"
+        )
+        target = out / f"{name}.pt"
+        if not target.exists():
+            # Hardlink rather than copy: these artifacts are 1-6 GB each and a
+            # staging copy of all eight would need tens of GB for no benefit.
+            try:
+                os.link(weight, target)
+            except OSError:
+                shutil.copy(weight, target)
+
+        files = sorted(p.name for p in out.iterdir())
+        expected = sorted([".gitattributes", "README.md", "LICENSE", "NOTICE", f"{name}.pt"])
+        if files != expected:
+            raise SystemExit(f"[{name}] 5-file contract violated: {files}")
+        print(f"[ok] staged {name} ({license_id}): {files}")
+        staged.append(out)
+    return staged
+
+
+def upload(staged: list[Path]) -> None:
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    for path in staged:
+        repo_id = f"{ORG}/{path.name}"
+        api.create_repo(repo_id, repo_type="model", exist_ok=True)
+        api.upload_folder(folder_path=str(path), repo_id=repo_id, repo_type="model")
+        print(f"[ok] uploaded https://huggingface.co/{repo_id}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage-dir", type=Path, required=True)
+    parser.add_argument("--weights-dir", type=Path, default=Path(__file__).parent)
+    parser.add_argument(
+        "--gitattributes",
+        type=Path,
+        required=True,
+        help="canonical .gitattributes copied from an existing LibreYOLO weight repo",
+    )
+    parser.add_argument("--upload", action="store_true")
+    args = parser.parse_args()
+
+    staged = stage(args.stage_dir, args.gitattributes, args.weights_dir)
+    if args.upload:
+        upload(staged)
+    else:
+        print(f"\nStaged {len(staged)} repo(s). Re-run with --upload to push.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Ports **V-JEPA 2.0** into LibreYOLO as the `vjepa2` family: a self-supervised video encoder under the generic `embed` task, plus `classify` for its released attentive probes.

This covers **both milestones of the handoff**: the encoder family and embedding contract, the attentive-probe classifier, and the frozen-probe trainer. All eight canonical artifacts are converted, parity-checked and published. Everything claimed here was actually run.

## Code provenance

Two upstream sources, both permissive:

| Surface | Upstream | Pinned at | License |
| --- | --- | --- | --- |
| Encoder / pooler / classifier implementation (`libreyolo/models/vjepa2/nn.py`) | [huggingface/transformers](https://github.com/huggingface/transformers) | tag `v5.1.0`, commit `3fa4da70f5d1da3ab1a8304bd2339eab7004b157`, file `src/transformers/models/vjepa2/modeling_vjepa2.py` | **Apache-2.0** |
| Semantic upstream: architecture behaviour, preprocessing, attentive-probe recipe, independent oracle | [facebookresearch/vjepa2](https://github.com/facebookresearch/vjepa2) | commit `204698b45b3712590f06245fbfba32d3be539812` | **MIT** |

`nn.py` is adapted from the Apache-2.0 Transformers file. It is **not** relicensed as MIT: the Apache-2.0 notice and terms are preserved verbatim in `libreyolo/models/vjepa2/NOTICE`, and the file carries a provenance header. Everything else in this PR is original work written for it.

The three files that `facebookresearch/vjepa2` marks Apache-2.0 rather than MIT (`src/datasets/utils/video/randaugment.py`, `randerase.py`, `worker_init_fn.py`) are **not** adapted, imported or vendored.

No GPL, AGPL, LGPL, non-commercial or unknown-license code is included in any form.

**Weights** are licensed per artifact and deliberately not collapsed into a family-wide claim: the two ViT-g encoders are Apache-2.0, the other six artifacts are MIT. Each rehosted repo ships its own `LICENSE` and `NOTICE`, and `weights/LICENSE_NOTICE.txt` records all eight with exact source revisions.

**Datasets**: none vendored. Something-Something V2 (research-use agreement) and Diving48 (redistribution terms not clearly established by the selected official source) are named for provenance only and are never mirrored, bundled or auto-downloaded.

## Parity: exact, against a pinned oracle

The gate is `max_abs_diff == 0.0` on fixed float32 CPU inputs against **unmodified `transformers==5.1.0`**.

The pin matters and is enforced in code: later Transformers releases refactor the V-JEPA 2 rotary helper and the attention dispatch, so a newer install is not a valid oracle for this gate. `weights/parity_vjepa2.py` refuses to run against any other version.

| Artifact | Frames | Tokens | Token diff | Pooled diff |
| --- | ---: | --- | ---: | ---: |
| `l256` encoder (released weights) | 64 | (1, 8192, 1024) | **0.0** | **0.0** |
| `l256` encoder | 16 | (1, 2048, 1024) | **0.0** | **0.0** |
| `h256` encoder (released weights) | 16 | (1, 2048, 1280) | **0.0** | **0.0** |
| `g256` encoder (released weights) | 8 | (1, 1024, 1408) | **0.0** | **0.0** |
| `g384` encoder (released weights) | 8 | (1, 2304, 1408) | **0.0** | **0.0** |
| `l256` SSv2 probe, single-view logits | 16 | (1, 174) | **0.0** | argmax matches |
| `l256` Diving48 probe, single-view logits | 32 | (1, 48) | **0.0** | — |
| `g384` SSv2 probe, single-view logits | 64 | (1, 174) | **0.0** | — |
| `g384` Diving48 probe, single-view logits | 32 | (1, 48) | **9.54e-07** ⚠️ | — |

**All four encoder sizes pass exactly**, covering all three architecture widths (L=1024, H=1280, g=1408). Strict loads: 388 tensors / 303.9M params (l256), 516 / 631.6M (h256), 644 / 1012.2M (g256 and g384), 453 tensors (L probes), 709 (g384 probes). Only `predictor` is dropped, and it is dropped as a **named asserted set** rather than a substring filter, so a changed upstream layout fails loudly instead of silently discarding tensors.

Round-trip through the public API is also exact: the converted checkpoint loaded via `LibreYOLO(path)` reproduces `0.0` against the oracle.

Frame reversal moves the l256 tokens by 47.39, so the clip path genuinely preserves time rather than averaging it away.

### The one artifact that does not meet the gate

**`LibreVJEPA2g384-cls-diving48` misses `== 0.0`** and I am not going to round
that away. It differs from the oracle by `9.5367431640625e-07`. Everything I
can establish about it:

- That value is **exactly one float32 ULP** at the logit magnitude involved
  (`max|logit| = 8.6712`, so ULP = 2³·2⁻²³ = 9.537e-07). Relative error is
  **1.1e-07, just under float32 epsilon** (1.19e-07) — the two results are
  equal to within float32 representational precision.
- My model is **self-deterministic**: the same input twice gives `0.0`, and a
  contiguous copy of the input gives `0.0`. So it is not run-to-run noise.
- It is **independent of clip length** — the same 9.54e-07 at 4, 8, 16 and 32
  frames. So it is not sequence-length-dependent kernel dispatch, and it does
  not accumulate through the encoder; it is confined to the output.
- **`argmax` is identical**, and stable across runs.
- The sibling `g384` SSv2 probe — *same architecture, same code path, same
  conversion* — is exactly `0.0`, which rules out a structural mapping error
  in the g384 probe graph.

My read is a last-bit rounding difference in the final projection for this
one artifact's weights. I could not reduce it to zero, and I would rather
surface it than quietly widen the gate: `weights/parity_vjepa2.py` still
asserts `== 0.0`, so this artifact fails that assertion by design. A reviewer
who wants it green should decide whether a 1-ULP tolerance is acceptable for
published probe logits, rather than have me make that call silently.

## Three upstream details that turned out to be load-bearing

Each of these still *builds* a model but breaks a released checkpoint or the numerics. All three are commented at the source and locked by tests:

1. The rotary tables are built with `repeat` (the half-width table concatenated with itself) while the rotated companion pairs **adjacent** channels. The conventional interleaved or half-split rotary is not equivalent here.
2. The attentive pooler's MLP ratio is fixed at **4.0** and does not follow the encoder ratio, which is 4.363636... for the g sizes. Using the encoder ratio builds `fc1` at 6144 instead of 5632 and fails the strict load of every released probe.
3. The pooler's cross-attention has **no output projection**, unlike its self-attention.

I got (2) and (3) wrong on the first pass; strict loading caught both.

## Contracts

- **Public vector** is a documented LibreYOLO *pooling contract*: `normalize(tokens.mean(dim=1), dim=-1)`, returned as float32 `(B, D)`. Upstream designates no global retrieval vector, and **no retrieval benchmark is claimed** for it.
- **Native tokens** are exposed only via `model.embed_tokens(...)` as `(B, T', H', W', D)`, never through the 2D `Embeddings` container.
- **Video**: one result per sampled clip, one clip by default. Every other family keeps its per-frame result cardinality — `VIDEO_EMBED_MODE = "frames"` remains the `BaseModel` default and there is a no-regression test.
- **Images** are accepted as an explicitly documented single-frame input: a static appearance representation, *not* a motion one.
- **Artifact matrix** is enforced beyond the filename regex, because the regex parses combinations that no released artifact provides: `-embed` takes no dataset variant, a published `-cls` requires one of the four released size/variant pairs, and a bare `LibreVJEPA2l256.pt` is not canonical.
- **Training**: the frozen attentive-probe recipe runs behind the normal `model.train(data="video_dataset.yaml")` API. Self-supervised `embed` training, predictor pretraining and full encoder fine-tuning (`freeze=0`) each reject *before* a dataset is constructed, with a message pointing at the supported path.
- **Probe geometry** is recovered from checkpoint metadata: the SSv2 L/256 probe is a 16-frame artifact and must not silently run at the encoder's 64 frames.

## Training (milestone 2)

The encoder is frozen and held in eval mode; only the three-layer attentive
pooler and the linear classifier are optimized, with cross-entropy and
best-by-top-1 selection.

The dataset is **entirely user-supplied**. Nothing downloads, mirrors or
bundles SSv2, Diving48, Kinetics or any other corpus, and a test asserts
validation makes no network call. Manifests are validated in full *before the
first epoch* rather than failing on the first bad batch: missing files,
non-integer or out-of-range labels, non-contiguous `names`, and classes named
but never used are all errors. Paths containing spaces parse (the class id is
read from the last field; tab and quoting also work).

Training sampling is a random temporal crop, validation is deterministic, the
collate returns `(B, F, C, H, W)`, and the forward rejects anything not 5D so
time can never fold into batch silently.

Evidence on synthetic motion where **the label is the direction of travel** —
a model that ignored frame order could not beat chance:

```
encoder fully frozen and in eval mode        True
only pooler.* and classifier.* trainable     33 tensors
optimizer parameter set disjoint from encoder True
loss           1.0591 -> 0.0073
top-1 accuracy 1.000  (chance = 0.5)
```

The convergence test is seeded: asserting convergence on a randomly
initialized probe is otherwise a coin flip, and it did fail once before I
pinned the seed.

## Exports

Fixed-frame 5D graphs with dynamic batch. l256 at 8 frames:

| Format | Result |
| --- | --- |
| ONNX | input `images ['batch', 8, 3, 256, 256]` to output `['batch', 1024]`; diff **1.41e-05**; output unit-norm; frame reversal moves the row by 7.9e-03 |
| TorchScript | diff **1.42e-05**, same temporal delta |

Parity is measured by driving the runtime directly with a 5D clip.
`LibreYOLO(exported_path).predict(...)` is **not** supported for this family
yet and now raises an actionable error rather than an opaque rank mismatch —
see the review-findings section.

ONNX auto-opset moves to 17 for this family because the attention lowers to `aten::scaled_dot_product_attention`, which ONNX supports only from opset 14. NCNN and TFLite are recorded **blocked** (both toolchains assume rank-4 image tensors and have no rank-5 path). **TensorRT and OpenVINO are left at `available`, not `validated`, because I did not run them** — no column is ticked that was not measured.

## Weights published

Uploaded to the LibreYOLO org, each with the exact 5-file contract (verified by HTTP 200 and file listing):

- `LibreYOLO/LibreVJEPA2l256-embed` (MIT)
- `LibreYOLO/LibreVJEPA2h256-embed` (MIT)
- `LibreYOLO/LibreVJEPA2g384-embed` (**Apache-2.0** — exercises the mixed-licence path)
- `LibreYOLO/LibreVJEPA2l256-cls-ssv2` (MIT)
- `LibreYOLO/LibreVJEPA2l256-cls-diving48` (MIT)
- `LibreYOLO/LibreVJEPA2g256-embed` (**Apache-2.0**)
- `LibreYOLO/LibreVJEPA2g384-cls-ssv2` (MIT)
- `LibreYOLO/LibreVJEPA2g384-cls-diving48` (MIT)

**All eight canonical artifacts are published**, each verified to contain
exactly the five contract files with the correct per-artifact licence (2
Apache-2.0 encoders, 6 MIT).

Cleared-cache auto-download verified from a directory with no `weights/`, on both filename shapes:

- `LibreVJEPA2l256-embed.pt` — downloaded 1159.3 MB, loaded, produced tokens `(1, 4, 16, 16, 1024)`.
- `LibreVJEPA2l256-cls-ssv2.pt` — downloaded 1348.3 MB and recovered `variant=ssv2`, `nc=174`, `frames=16` and the real SSv2 class names from checkpoint metadata.

## Integration

CHANGELOG `Unreleased / Added`; one README row (a new **Video embeddings** row — V-JEPA 2 embeds a clip while the existing Embeddings entries embed an image, and merging them would hide the distinction the family exists to make); `MODEL_GROUPS` enrollment in `g2`; regenerated `reports/export_inventory.json` (+25 lines, nothing dropped) and `docs/export_support.md`; nomenclature rows plus the canonical filename matrix; per-artifact weight licences; pytest `vjepa2` marker; upload-skill whitelist extended to all eight names.

e2e registration deliberately avoids `MODEL_CATALOG` (its COCO mAP and training gates fail a clip embedder by construction) and `GENERAL_NIGHTLY_INFERENCE_MODELS` (detect-only), so **the general-nightly count in `docs/testing.md` is unchanged**.

## Tests

85 vjepa2 tests pass across `tests/unit/test_vjepa2.py` and `tests/unit/test_vjepa2_training.py` (including a regression test per review finding), and 262 pass across the vjepa2, registry, export-support, inventory, nomenclature and capability-language suites.

CI is fully green on `3d89621`: the complete unit suites on ubuntu, macOS and Windows, plus `provenance`, the distributed job, all packaging jobs and Greptile.

## Not in this PR

- **Independent parity** against the official MIT implementation. The Transformers oracle is exact; the second, independent oracle is still owed.
- Reducing the `g384-cls-diving48` 1-ULP residual to zero (see above).
- Backend 4D-vs-5D input-validation hardening, and the UI smoke.

## Review findings (all three were real, all three fixed)

Greptile ran twice and raised five findings in total. **Every one was a
genuine bug on a public path my parity work never exercised**, and all five
are fixed. The parity scripts drive the module directly, so `predict()` was
never run end to end until the first review pointed at it.

First pass, fixed in `3d89621`:

1. **`_preprocess` broke the inference contract.** The shared runner unpacks a
   4-tuple; this family returned a bare tensor, so `model.predict()` failed
   before the forward pass. The parity scripts drove the module directly and
   `embed_tokens()` has its own path, so nothing caught it.
2. **`VIDEO_EMBED_MODE` had no runtime consumer.** A video still took the
   per-frame path, turning each decoded frame into its own static repeated
   clip. The generic runner now honours clip mode: decode once, one result per
   sampled clip, with unbounded sources refused rather than buffered and a
   frameless video treated as an error rather than a black clip.
3. **Exported graphs vs backend rank.** Confirmed the exact failure
   (`Invalid rank for input: images Got: 4 Expected: 5`). That path is not
   wired for clips, so it now raises an actionable error naming the working
   alternatives, and the export support entry states the limitation instead of
   implying the reload path works.

Second pass, fixed in `8e2b420`:

4. **`embed_tokens` passed the whole 4-tuple to the encoder** — a regression I
   introduced in the fix for (1), and one my earlier check could not catch
   because it ran before that change.
5. **`save=True` / `show=True` silently ignored in clip mode.** A clip
   collapses the video to one result, so there is no annotated frame stream to
   write; the flags are now refused with an explanation instead of dropped.

Verified end to end on a generated 90-frame motion clip:

```
classify probe   -> 1 result, probs (48,)
embed            -> 1 result, (1, 1024), unit norm
embed_tokens     -> (1, 1, 16, 16, 1024)
save=True        -> refused with the explanation
```

## Reviewer notes

- The `greptile` CLI is **not installed** on this machine, so no local pre-push review was run; the bot review on this PR was the first Greptile pass. Its three findings are addressed above.
- A real defect is fixed here that is worth a wider look: `BaseModel.__init__` records the weights path but does not load from it, so this family initially loaded a **randomly initialized** encoder while every parity script that loaded the module directly still passed. Other recently added families may have the same hole.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

V-JEPA 2 is added as a native video embedding and attentive-probe classification family, including frozen-probe training and fixed-frame exports. The token extraction repair remains incomplete for supported still-image inputs.
- Adds four encoder configurations and four released attentive-probe artifacts.
- Adds clip-aware inference, preprocessing, dataset validation, and frozen-probe training.
- Adds ONNX and TorchScript export contracts for fixed-frame 5D inputs.
- Extends model registration, documentation, artifact metadata, and focused tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because still-image calls to embed_tokens reach the five-dimensional encoder with a four-dimensional tensor and fail.

The prior tuple-handling repair now extracts the tensor correctly, but embed_tokens bypasses the ordinary forward path's image-to-static-clip expansion, leaving a supported public input path broken.

**Files Needing Attention:** libreyolo/models/vjepa2/model.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/vjepa2/model.py | Implements the public V-JEPA 2 wrapper and clip sampling, but embed_tokens still sends supported 4D image inputs directly to the 5D encoder. |
| libreyolo/models/vjepa2/nn.py | Adds the native encoder, attentive pooler, and classifier implementation with an explicitly five-dimensional video input contract. |
| libreyolo/models/base/inference.py | Adds whole-clip dispatch for embedding and classification, including bounded sampling and explicit output-option handling. |
| libreyolo/export/exporter.py | Adds fixed-frame 5D export construction and normalized embedding output wrapping. |
| libreyolo/backends/base.py | Replaces opaque exported-runtime rank failures with an actionable unsupported-path error. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Public V-JEPA 2 source] --> B{API}
  B -->|predict| C[_preprocess]
  C --> D{Tensor rank}
  D -->|4D image| E[_forward expands to 5D static clip]
  D -->|5D clip| F[Encoder]
  E --> F
  B -->|embed_tokens| G[_preprocess and tuple unpack]
  G --> H[Direct encoder call]
  H -->|5D clip| I[Native token grid]
  H -->|4D image| J[Rank error]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fvjepa2%2Fmodel.py%3A452%0A**Still-image%20token%20extraction%20fails**%0A%0AWhen%20%60embed_tokens%60%20receives%20a%20supported%20still-image%20source%20or%204D%20image%20tensor%2C%20%60_preprocess%60%20returns%20a%204D%20batch%20and%20the%20method%20forwards%20it%20directly%20to%20the%205D-only%20encoder%2C%20causing%20a%20rank%20error%20instead%20of%20returning%20the%20documented%20token%20grid.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=747&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22port-vjepa2-embed%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22port-vjepa2-embed%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fvjepa2%2Fmodel.py%3A452%0A**Still-image%20token%20extraction%20fails**%0A%0AWhen%20%60embed_tokens%60%20receives%20a%20supported%20still-image%20source%20or%204D%20image%20tensor%2C%20%60_preprocess%60%20returns%20a%204D%20batch%20and%20the%20method%20forwards%20it%20directly%20to%20the%205D-only%20encoder%2C%20causing%20a%20rank%20error%20instead%20of%20returning%20the%20documented%20token%20grid.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=747&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (8): Last reviewed commit: ["Merge dev: converge on the Perception En..."](https://github.com/libreyolo/libreyolo/commit/5f701c5871105d027d33f5631af45bd0d82d640b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51647114)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)

<!-- /greptile_comment -->