### PR TITLE
Promote a still frame to a clip in V-JEPA 2 embed_tokens

### DIFF
--- a/libreyolo/models/vjepa2/model.py
+++ b/libreyolo/models/vjepa2/model.py
@@ -355,14 +355,29 @@ class LibreVJEPA2(BaseModel):
         tensor = preprocess_frames([frame], self.crop_size)[0]
         return tensor.to(self.device), loaded, (width, height), 1.0
 
-    def _forward(self, input_tensor: torch.Tensor) -> Any:
-        # A 4D tensor is a single still frame. Represent it as a static clip:
-        # every frame identical, so there is no motion in it at all. This is a
-        # documented compatibility behaviour, not a motion representation.
+    def _as_clip(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        """Promote a 4D still frame to a 5D static clip; pass 5D through.
+
+        Every caller that reaches the encoder must go through here. The encoder
+        is 5D-only, and ``_preprocess`` returns a single frame so the shared
+        whole-clip runner can concatenate frames itself, so a still image
+        arrives here as 4D and would otherwise hit a bare rank error.
+
+        A static clip repeats one frame, so it contains no motion at all. That
+        is a documented compatibility behaviour, not a motion representation.
+        """
         if input_tensor.ndim == 4:
-            input_tensor = input_tensor.unsqueeze(1).repeat(
-                1, self.clip_frames, 1, 1, 1
+            return input_tensor.unsqueeze(1).repeat(1, self.clip_frames, 1, 1, 1)
+        if input_tensor.ndim != 5:
+            raise ValueError(
+                "V-JEPA 2 consumes a 5D clip (B, F, C, H, W) or a 4D still "
+                f"frame (B, C, H, W); got {input_tensor.ndim}D shape "
+                f"{tuple(input_tensor.shape)}."
             )
+        return input_tensor
+
+    def _forward(self, input_tensor: torch.Tensor) -> Any:
+        input_tensor = self._as_clip(input_tensor)
         if self.task == "classify":
             return self.model(input_tensor)
         tokens = self.model(input_tensor)
@@ -447,6 +462,8 @@ class LibreVJEPA2(BaseModel):
                 f"task={self.task!r}."
             )
         tensor, _, _, _ = self._preprocess(source, **kwargs)
+        # A still image arrives as a 4D frame; the encoder is 5D-only.
+        tensor = self._as_clip(tensor)
         with torch.no_grad():
             encoder = self.model
             tokens = encoder(tensor)

--- a/tests/unit/test_vjepa2.py
+++ b/tests/unit/test_vjepa2.py
@@ -368,6 +368,36 @@ class TestInferenceContracts:
         # (B, T', H', W', D) with T' = frames / tubelet, H' = W' = 256/16
         assert tokens.shape == (1, 1, 16, 16, 1024)
 
+    @pytest.mark.parametrize("source", ["still_image", "frame_tensor"])
+    def test_embed_tokens_accepts_a_still_frame(self, source):
+        """Regression: _preprocess returns a 4D frame, the encoder is 5D-only.
+
+        The earlier test only passed an explicit 5D clip, which takes the
+        passthrough branch, so it never exercised the still-image path that
+        actually broke.
+        """
+        import numpy as np
+
+        model = LibreVJEPA2(size="l256", task="embed")
+        model._requested_clip_frames = 2
+        if source == "still_image":
+            payload = np.zeros((240, 320, 3), dtype=np.uint8)
+        else:
+            payload = torch.zeros(1, 3, 256, 256, device=model.device)
+        tokens = model.embed_tokens(payload)
+        assert tokens.shape == (1, 1, 16, 16, 1024)
+
+    def test_every_encoder_entry_point_promotes_to_a_clip(self):
+        """_forward and embed_tokens must share one promotion path.
+
+        They diverged once already: _forward expanded a 4D still into a clip
+        while embed_tokens called the encoder directly and hit a rank error.
+        """
+        import inspect
+
+        for method in (LibreVJEPA2._forward, LibreVJEPA2.embed_tokens):
+            assert "_as_clip" in inspect.getsource(method), method.__name__
+
     def test_embed_tokens_rejects_a_classify_model(self):
         model = LibreVJEPA2(size="l256", task="classify", nb_classes=174)
         with pytest.raises(ValueError, match="requires task='embed'"):


### PR DESCRIPTION
Follow-up to #747. Greptile's post-merge finding was correct, and the bug was real.

`embed_tokens` called the 5D-only encoder directly, so a still image or a 4D frame tensor died with a bare rank error instead of returning the documented token grid:

```
RuntimeError: permute(sparse_coo): number of dimensions in the tensor input
does not match the length of the desired ordering of dimensions
i.e. input.dim() = 4 is not equal ...
```

## Where it came from

I introduced it in the merge that joined the Perception Encoder's whole-clip route. `_preprocess` started returning a single `(1, C, H, W)` frame so the shared runner could concatenate frames itself, and `_forward` grew the 4D-to-clip promotion — but `embed_tokens` bypasses `_forward` and kept handing the encoder whatever `_preprocess` produced.

The existing test passed an explicit **5D** clip, which takes the passthrough branch, so it never touched the path that broke. That is the actual gap: the test covered the shape that could not fail.

## Fix

The promotion is now a single `_as_clip` helper that both encoder entry points go through, and it raises an actionable error for any rank that is neither a 4D frame nor a 5D clip, instead of letting a rank error surface from inside `permute`.

## Evidence

| Input | Before | After |
| --- | --- | --- |
| 5D clip `(1, 2, 3, 256, 256)` | `(1, 1, 16, 16, 1024)` | `(1, 1, 16, 16, 1024)` |
| still image `(240, 320, 3)` | **RuntimeError** | `(1, 1, 16, 16, 1024)` |
| 4D frame `(1, 3, 256, 256)` | **RuntimeError** | `(1, 1, 16, 16, 1024)` |

Two regression tests: one parameterized over both still-frame forms, and one asserting `_forward` and `embed_tokens` share the promotion path — they diverged once already, which is exactly how this slipped through.

133 tests pass across the `vjepa2`, `vjepa2-training` and `pe` suites.

## Code provenance

Original work for this PR. No third-party code is added; this only changes control flow in `libreyolo/models/vjepa2/model.py`, whose provenance is unchanged from #747 (encoder adapted from Apache-2.0 Hugging Face Transformers `v5.1.0`, semantic upstream MIT `facebookresearch/vjepa2`, both recorded in `libreyolo/models/vjepa2/NOTICE`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes V-JEPA 2 frame-to-clip normalization so both `_forward` and `embed_tokens` accept 4D still frames while preserving 5D clips.

- Adds an actionable rank check for unsupported tensor shapes.
- Adds still-image and frame-tensor regression coverage.
- Adds a structural test intended to keep both encoder entry points on the shared normalization path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking test-maintainability concern around source-code introspection.

The shared normalization correctly promotes reachable 4D inputs and preserves 5D clips; the sole accepted concern is that one regression test checks helper-name text rather than observable behavior.

**Files Needing Attention:** tests/unit/test_vjepa2.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/vjepa2/model.py | Correctly centralizes tensor-rank normalization across both encoder entry points and provides a clear error for unsupported ranks. |
| tests/unit/test_vjepa2.py | Adds useful behavioral regression coverage, but the source-text assertion unnecessarily couples the suite to a private implementation detail. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Input[4D frame or 5D clip] --> Normalize[_as_clip]
  Normalize -->|4D| Repeat[Repeat frame across clip_frames]
  Normalize -->|5D| Pass[Pass through unchanged]
  Repeat --> Encoder[V-JEPA 2 encoder]
  Pass --> Encoder
  Encoder --> Forward[_forward output]
  Encoder --> Tokens[embed_tokens grid]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atests%2Funit%2Ftest_vjepa2.py%3A397%0A**Avoid%20source-text%20contract%20tests**%0A%0AThis%20assertion%20verifies%20that%20each%20method's%20source%20contains%20%60_as_clip%60%20rather%20than%20checking%20promotion%20behavior.%20A%20correct%20refactor%20that%20renames%2C%20wraps%2C%20delegates%2C%20or%20inlines%20the%20helper%20will%20fail%20the%20suite%2C%20while%20an%20unreachable%20call%20or%20comment%20containing%20the%20name%20can%20satisfy%20the%20test%20without%20preserving%20the%20runtime%20contract.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=748&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22fix%2Fvjepa2-embed-tokens-still-frame%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvjepa2-embed-tokens-still-frame%22.%0A%0A%23%23%23%20Issue%201%0Atests%2Funit%2Ftest_vjepa2.py%3A397%0A**Avoid%20source-text%20contract%20tests**%0A%0AThis%20assertion%20verifies%20that%20each%20method's%20source%20contains%20%60_as_clip%60%20rather%20than%20checking%20promotion%20behavior.%20A%20correct%20refactor%20that%20renames%2C%20wraps%2C%20delegates%2C%20or%20inlines%20the%20helper%20will%20fail%20the%20suite%2C%20while%20an%20unreachable%20call%20or%20comment%20containing%20the%20name%20can%20satisfy%20the%20test%20without%20preserving%20the%20runtime%20contract.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=748&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Promote a still frame to a clip in embed..."](https://github.com/libreyolo/libreyolo/commit/0f5af11a65a1c98ab4ee43663d500bc3b45d732f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51871172)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->