### PR TITLE
Make the Paddle install-lock test measure the lock

### DIFF
--- a/tests/unit/test_export_paddle.py
+++ b/tests/unit/test_export_paddle.py
@@ -16,7 +16,11 @@ import yaml
 from libreyolo.export.exporter import PaddleExporter
 
 pytestmark = pytest.mark.unit
-_PROCESS_SYNC_TIMEOUT = 10
+_PROCESS_SYNC_TIMEOUT = 30
+# Window used to assert the second process stays blocked. Only meaningful
+# after both children have signalled readiness, so it measures the lock and
+# not interpreter startup.
+_LOCK_CONTENTION_WINDOW = 1.0
 
 
 def _wrapper(family: str = "yolo9", task: str = "detect") -> MagicMock:
@@ -26,9 +30,15 @@ def _wrapper(family: str = "yolo9", task: str = "detect") -> MagicMock:
     return model
 
 
-def _hold_paddle_install_lock(output_path, entered, release):
+def _hold_paddle_install_lock(output_path, ready, entered, release):
     from libreyolo.export.paddle import _paddle_install_lock
 
+    # Announce readiness *before* contending. A spawned child has to boot a new
+    # interpreter and import libreyolo first, which costs far more than the
+    # window the mutual-exclusion assertion uses. Signalling here lets the test
+    # pay that cost explicitly, so the window afterwards measures the lock
+    # rather than process startup.
+    ready.put(True)
     with _paddle_install_lock(Path(output_path)):
         entered.put(True)
         release.wait(timeout=_PROCESS_SYNC_TIMEOUT)
@@ -152,26 +162,50 @@ def test_export_paddle_restores_previous_artifact_when_install_fails(
 
 
 def test_paddle_install_lock_serializes_processes(tmp_path):
+    """A second process must not enter the install lock while the first holds it.
+
+    Two things this test has to avoid, both of which it got wrong before:
+
+    * The mutual-exclusion assertion is a *negative* one ("the second process
+      does not signal"), so it only means something once that process is
+      actually ready to contend. A spawned child spends over a second booting
+      an interpreter and importing libreyolo, which is longer than the window
+      itself, so without a readiness handshake the assertion held whatever the
+      lock did -- it passed even against a no-op lock.
+    * Only started processes may be joined. Building the list as they start
+      keeps a timeout here from being replaced by "can only join a started
+      process" from the cleanup path, which hid the real cause.
+    """
     ctx = multiprocessing.get_context("spawn")
+    ready = ctx.Queue()
     entered = ctx.Queue()
     release_first = ctx.Event()
     release_second = ctx.Event()
     output = tmp_path / "model_paddle"
-    first = ctx.Process(
-        target=_hold_paddle_install_lock,
-        args=(str(output), entered, release_first),
-    )
-    second = ctx.Process(
-        target=_hold_paddle_install_lock,
-        args=(str(output), entered, release_second),
-    )
+    started = []
+
+    def spawn(release):
+        process = ctx.Process(
+            target=_hold_paddle_install_lock,
+            args=(str(output), ready, entered, release),
+        )
+        process.start()
+        started.append(process)
+        # Wait out interpreter startup and imports before relying on any timing.
+        ready.get(timeout=_PROCESS_SYNC_TIMEOUT)
+        return process
 
     try:
-        first.start()
+        first = spawn(release_first)
         entered.get(timeout=_PROCESS_SYNC_TIMEOUT)
-        second.start()
+
+        second = spawn(release_second)
+        # The second child is past its imports and about to take the lock, so
+        # this window now measures the lock. Against a no-op lock the child
+        # signals within milliseconds and this assertion fails, which is the
+        # point.
         with pytest.raises(queue.Empty):
-            entered.get(timeout=0.3)
+            entered.get(timeout=_LOCK_CONTENTION_WINDOW)
 
         release_first.set()
         entered.get(timeout=_PROCESS_SYNC_TIMEOUT)
@@ -183,7 +217,7 @@ def test_paddle_install_lock_serializes_processes(tmp_path):
     finally:
         release_first.set()
         release_second.set()
-        for process in (first, second):
+        for process in started:
             if process.is_alive():
                 process.terminate()
             process.join(timeout=_PROCESS_SYNC_TIMEOUT)


### PR DESCRIPTION
`test_paddle_install_lock_serializes_processes` had **both failure modes inverted**: it could not fail when the lock was broken, and it could fail when everything was correct.

## It could not detect a broken lock

Mutual exclusion was asserted negatively — *"the second process does not signal within 0.3s"*:

```python
second.start()
with pytest.raises(queue.Empty):
    entered.get(timeout=0.3)
```

But a spawned child has to boot a new interpreter and import `libreyolo` before it can reach the lock at all — measured at **~1.3s**, idle machine, warm cache. The window closed long before contention was even possible, so the assertion held whatever the lock did.

Replacing the entire lock body with a bare `yield` still passed:

```
VACUOUS second did NOT signal within 0.3s -> assertion PASSES even though the lock is a no-op
VACUOUS second actually needed 1.31s to signal
VACUOUS verdict: test detects a broken lock = False
```

## It could fail when nothing was wrong

```python
first.start()
entered.get(timeout=_PROCESS_SYNC_TIMEOUT)   # raises queue.Empty on a slow runner
second.start()                               # never runs
...
finally:
    for process in (first, second):
        process.join(...)                    # joins a process that never started
```

If the first child overran the 10s budget, the cleanup loop joined an unstarted process and raised `AssertionError: can only join a started process`, **replacing** the real cause. That is why the CI failure read as a product bug rather than a timeout. It is deductive, not guesswork: that assertion can only fire if `second.start()` was skipped, and the only statement between the two `start()` calls is that `entered.get()`.

## Fix

A readiness handshake. Each child announces itself *after* its imports and *before* contending, so the test pays startup cost explicitly and the window afterwards measures the lock rather than interpreter boot. Processes are collected as they start, so cleanup can never join an unstarted one and a timeout survives as itself. `_PROCESS_SYNC_TIMEOUT` goes to 30s — now a backstop, not the thing under test.

## Evidence

Neutered `_paddle_install_lock` to a no-op and ran both versions against it:

| | broken lock | real lock |
| --- | --- | --- |
| old test | **PASSED** — proves nothing | passed |
| new test | **FAILED** — detects it | 14 passed, 3 consecutive runs |

## Context

This fired **once in ~80 CI runs** since the test landed on 4 Aug, so it is not the repo's chronic flake. Until `98984128` those were `test_rtdetrv2_obb::..._torchscript_raw_roundtrip` (12 runs) and `test_distillation::test_mgd_loss_converges` (10 runs). With those quiet, this quieter race became visible for the first time.

Worth noting the mgd fix seeded an unseeded convergence assertion whose bound "had no margin at all" — the same shape of problem as this one: a timing/luck-dependent assertion presented as a behavioural one.

## Code provenance

Original for this PR. Test-only change; no third-party code, and no product code is modified.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR revises the Paddle install-lock multiprocessing test to separate spawned-process startup from its contention window and to clean up only processes that successfully started.

- Adds a child readiness queue before lock contention.
- Extends the synchronization backstop and introduces a dedicated contention window.
- Tracks started processes so timeout cleanup cannot join an unstarted child.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The test-only PR appears safe to merge, with a non-blocking synchronization gap that can still make the lock assertion vacuous under delayed child scheduling.

The cleanup correction is sound, but the parent begins measuring after a readiness message emitted before lock acquisition, so the intended broken-lock detection is not fully deterministic.

**Files Needing Attention:** tests/unit/test_export_paddle.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/unit/test_export_paddle.py | Improves process startup and cleanup synchronization, but the pre-acquisition readiness signal does not guarantee that the contention window measures an active lock attempt. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Parent test
    participant C1 as First child
    participant C2 as Second child
    P->>C1: start
    C1->>P: ready
    C1->>C1: acquire lock
    C1->>P: entered
    P->>C2: start
    C2->>P: ready
    Note over C2: Scheduling gap before acquisition
    P->>P: begin contention window
    C2->>C2: attempt lock
    P->>C1: release
    C2->>C2: acquire lock
    C2->>P: entered
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atests%2Funit%2Ftest_export_paddle.py%3A41-42%0A**Readiness%20precedes%20lock%20contention**%0A%0A%60ready.put%28True%29%60%20runs%20before%20the%20child%20attempts%20%60_paddle_install_lock%60%2C%20so%20delayed%20child%20scheduling%20can%20let%20the%20one-second%20negative%20assertion%20expire%20without%20testing%20the%20lock.%20This%20leaves%20the%20test%20able%20to%20pass%20against%20a%20no-op%20lock%20under%20that%20scheduling%20condition.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=749&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22fix%2Fpaddle-install-lock-test%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaddle-install-lock-test%22.%0A%0A%23%23%23%20Issue%201%0Atests%2Funit%2Ftest_export_paddle.py%3A41-42%0A**Readiness%20precedes%20lock%20contention**%0A%0A%60ready.put%28True%29%60%20runs%20before%20the%20child%20attempts%20%60_paddle_install_lock%60%2C%20so%20delayed%20child%20scheduling%20can%20let%20the%20one-second%20negative%20assertion%20expire%20without%20testing%20the%20lock.%20This%20leaves%20the%20test%20able%20to%20pass%20against%20a%20no-op%20lock%20under%20that%20scheduling%20condition.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=749&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Make the Paddle install-lock test measur..."](https://github.com/libreyolo/libreyolo/commit/257efd87276415991c9905565b43b73ea33bf9e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51886905)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->