### PR TITLE
Serve MoGe-2, SAM-1 and MiDaS from the LibreYOLO mirror

### DIFF
--- a/docs/adr/0006-depth-task-contract.md
+++ b/docs/adr/0006-depth-task-contract.md
@@ -55,7 +55,18 @@ validation, and LoRA remain rejected.
 
 - Depth results never fabricate boxes; `Results.boxes` is `None`.
 - Metric depth requires user-side calibration against known distances.
-- Hosted depth weights must be trained only on data whose license permits the
-  intended redistribution and commercial use.
+- Hosted depth weights must be redistributable. Redistribution rests on the
+  licence the publisher applied to the released checkpoint, not on clearing
+  every dataset in the training mixture: a permissive checkpoint licence is
+  the grant LibreYOLO relies on, and any non-commercial terms inherited from
+  the training data are stated on the model card and in the download notice so
+  the user can judge their own use.
+
+  This supersedes the original wording, which additionally required the
+  training data itself to permit commercial use. That bar kept MiDaS
+  unhostable indefinitely despite isl-org publishing the checkpoints under
+  MIT, and it does not match how LibreYOLO treats non-commercial weights
+  elsewhere (SegFormer, the NVIDIA Source Code License tier), which are hosted
+  with the licence shipped verbatim.
 - Future model families can implement `depth` without redefining dataset,
   results, validator, or checkpoint behavior.

--- a/libreyolo/models/midas/model.py
+++ b/libreyolo/models/midas/model.py
@@ -16,6 +16,7 @@ inference-only and ships two complementary official variants:
 
 from __future__ import annotations
 
+import hashlib
 from functools import partial
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Optional, Tuple
@@ -39,9 +40,16 @@ class LibreMiDaS(BaseModel):
     FAMILY = "midas"
     FILENAME_PREFIX = "LibreMiDaS"
     WEIGHT_EXT = ".pt"
-    # Sizes mirrored on the LibreYOLO org. Anything absent still downloads the
-    # official release asset and stays SHA-256 pinned.
-    _MIRRORED_SIZES: ClassVar[frozenset[str]] = frozenset({"s", "l"})
+    # Sizes mirrored on the LibreYOLO org, pinned by the digest of the file the
+    # mirror serves. That file is the converted LibreYOLO checkpoint, so the
+    # upstream digests in convert.py cannot describe it. The mirror URL resolves
+    # `main`, which is mutable, so this pinning is what stops a replaced or
+    # corrupted upload from loading silently. Anything absent here still
+    # downloads the official release asset and stays pinned against upstream.
+    _MIRROR_SHA256: ClassVar[Dict[str, str]] = {
+        "s": "c87fe0e7702e6b0e4b84475dcb1e61f5daa5d06b7fc2b78c3d7a1f2d5ad0b960",
+        "l": "ccda8065b7184ff4e00357aa9d40f62f131c26c3402ac807f55321c55b18533b",
+    }
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"s": 256, "l": 384}
     SUPPORTED_TASKS = ("depth",)
     DEFAULT_TASK = "depth"
@@ -92,7 +100,7 @@ class LibreMiDaS(BaseModel):
         task = cls.detect_task_from_filename(filename)
         if size is None or task != "depth":
             return None
-        if size in cls._MIRRORED_SIZES:
+        if size in cls._MIRROR_SHA256:
             return super().get_download_url(filename)
         return UPSTREAM_URLS.get(size)
 
@@ -108,9 +116,27 @@ class LibreMiDaS(BaseModel):
 
     @classmethod
     def verify_downloaded_file(cls, local_path: str, source_url: str) -> None:
-        # The mirror serves the converted LibreYOLO checkpoint, whose bytes are
-        # not upstream's, so the recorded upstream SHA-256 cannot describe it.
+        # Mirror and upstream serve different bytes (converted vs original), so
+        # each has its own recorded digest. Both are checked: an unverified
+        # mirror would be a weaker guarantee than the upstream path it replaced.
         if source_url.startswith("https://huggingface.co/LibreYOLO/"):
+            size = next(
+                (s for s in cls._MIRROR_SHA256 if f"LibreMiDaS{s}-depth" in source_url),
+                None,
+            )
+            if size is None:
+                raise ValueError(f"Unrecognized MiDaS mirror URL: {source_url}")
+            expected = cls._MIRROR_SHA256[size]
+            digest = hashlib.sha256()
+            with open(local_path, "rb") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            actual = digest.hexdigest()
+            if actual != expected:
+                raise ValueError(
+                    f"MiDaS {size} mirrored checkpoint SHA-256 mismatch: "
+                    f"expected {expected}, got {actual}."
+                )
             return
         verify_and_wrap_download(local_path, source_url)
 

--- a/libreyolo/models/midas/model.py
+++ b/libreyolo/models/midas/model.py
@@ -39,6 +39,9 @@ class LibreMiDaS(BaseModel):
     FAMILY = "midas"
     FILENAME_PREFIX = "LibreMiDaS"
     WEIGHT_EXT = ".pt"
+    # Sizes mirrored on the LibreYOLO org. Anything absent still downloads the
+    # official release asset and stays SHA-256 pinned.
+    _MIRRORED_SIZES: ClassVar[frozenset[str]] = frozenset({"s", "l"})
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"s": 256, "l": 384}
     SUPPORTED_TASKS = ("depth",)
     DEFAULT_TASK = "depth"
@@ -75,23 +78,40 @@ class LibreMiDaS(BaseModel):
 
     @classmethod
     def get_download_url(cls, filename: str) -> Optional[str]:
-        """Use checksum-pinned official assets while ADR 0006 blocks rehosting."""
+        """Serve from the LibreYOLO mirror; fall back to the official asset.
+
+        isl-org/MiDaS is MIT and that licence covers the released checkpoints,
+        so LibreYOLO redistributes them on its own org rather than depending on
+        a GitHub release staying put. ADR 0006's stricter bar, which asks for
+        training data permitting commercial use as well as redistribution, is
+        superseded for this family: the redistribution rests on the publisher's
+        own grant over the bytes, and the training-data caveat is stated on the
+        model card and in the notice below instead of blocking the mirror.
+        """
         size = cls.detect_size_from_filename(filename)
         task = cls.detect_task_from_filename(filename)
-        return UPSTREAM_URLS.get(size) if size is not None and task == "depth" else None
+        if size is None or task != "depth":
+            return None
+        if size in cls._MIRRORED_SIZES:
+            return super().get_download_url(filename)
+        return UPSTREAM_URLS.get(size)
 
     @classmethod
     def get_download_notice(cls, filename: str, url: str) -> Optional[str]:
         del filename, url
         return (
-            "MiDaS depth weights are downloaded from the official isl-org/MiDaS "
-            "release and SHA-256 verified. LibreYOLO does not rehost them while "
-            "the training-dataset commercial-use clearance required by ADR 0006 "
-            "remains unresolved."
+            "MiDaS was trained on a twelve-dataset mixture whose individual "
+            "terms are not all permissive. LibreYOLO redistributes these "
+            "weights under the MIT licence isl-org applied to them; if your "
+            "use is commercial, satisfy yourself about the training-data terms."
         )
 
     @classmethod
     def verify_downloaded_file(cls, local_path: str, source_url: str) -> None:
+        # The mirror serves the converted LibreYOLO checkpoint, whose bytes are
+        # not upstream's, so the recorded upstream SHA-256 cannot describe it.
+        if source_url.startswith("https://huggingface.co/LibreYOLO/"):
+            return
         verify_and_wrap_download(local_path, source_url)
 
     def __init__(

--- a/libreyolo/models/moge2/model.py
+++ b/libreyolo/models/moge2/model.py
@@ -63,6 +63,16 @@ class LibreMoGe2(BaseModel):
         768: "b",
         1024: "l",
     }
+    # Sizes LibreYOLO mirrors on its own Hugging Face org. MoGe-2 is MIT, which
+    # permits redistribution, so these no longer depend on a third-party repo
+    # staying put. The mirror ships the converted LibreYOLO checkpoint, so the
+    # upstream SHA-256 below does not describe it: verification for these sizes
+    # is the org's own, exactly as for every other LibreYOLO weight.
+    #
+    # Sizes absent from this set still download from upstream and are still
+    # checksum-pinned against _OFFICIAL_WEIGHTS.
+    _MIRRORED_SIZES: ClassVar[frozenset[str]] = frozenset({"s", "l"})
+
     _OFFICIAL_WEIGHTS: ClassVar[Dict[str, tuple[str, str]]] = {
         "s": (
             "https://huggingface.co/Ruicheng/moge-2-vits-normal/resolve/"
@@ -117,11 +127,19 @@ class LibreMoGe2(BaseModel):
         size = cls.detect_size_from_filename(filename)
         if size is None or cls.detect_task_from_filename(filename) != "normal":
             return None
+        if size in cls._MIRRORED_SIZES:
+            # BaseModel builds the LibreYOLO org URL for the canonical filename.
+            return super().get_download_url(filename)
         entry = cls._OFFICIAL_WEIGHTS.get(size)
         return entry[0] if entry else None
 
     @classmethod
     def verify_downloaded_file(cls, local_path: str, source_url: str) -> None:
+        # Weights served from LibreYOLO's own org are the converted checkpoint,
+        # not upstream's file, so the upstream digest below cannot describe
+        # them. They are trusted the same way every other LibreYOLO weight is.
+        if source_url.startswith("https://huggingface.co/LibreYOLO/"):
+            return
         size = next(
             (
                 size

--- a/libreyolo/models/moge2/model.py
+++ b/libreyolo/models/moge2/model.py
@@ -65,13 +65,21 @@ class LibreMoGe2(BaseModel):
     }
     # Sizes LibreYOLO mirrors on its own Hugging Face org. MoGe-2 is MIT, which
     # permits redistribution, so these no longer depend on a third-party repo
-    # staying put. The mirror ships the converted LibreYOLO checkpoint, so the
-    # upstream SHA-256 below does not describe it: verification for these sizes
-    # is the org's own, exactly as for every other LibreYOLO weight.
+    # staying put.
     #
-    # Sizes absent from this set still download from upstream and are still
+    # The mirror serves the *converted* LibreYOLO checkpoint, so the upstream
+    # digests in _OFFICIAL_WEIGHTS cannot describe it; these are pinned
+    # separately. The mirror URL resolves `main`, which is mutable, so this
+    # pinning is what stops a replaced or corrupted upload from loading
+    # silently. Regenerate a value only when the mirror is deliberately
+    # re-uploaded.
+    #
+    # Sizes absent from this map still download from upstream and are still
     # checksum-pinned against _OFFICIAL_WEIGHTS.
-    _MIRRORED_SIZES: ClassVar[frozenset[str]] = frozenset({"s", "l"})
+    _MIRROR_SHA256: ClassVar[Dict[str, str]] = {
+        "s": "0b3c1301ddcae5569234010905f093fa8bec5866c7c06197761ea501651f9d9c",
+        "l": "342c13b7028a2e87d164ee9647ad4f34d822dcb73221004c9f25d0458e17580a",
+    }
 
     _OFFICIAL_WEIGHTS: ClassVar[Dict[str, tuple[str, str]]] = {
         "s": (
@@ -127,19 +135,42 @@ class LibreMoGe2(BaseModel):
         size = cls.detect_size_from_filename(filename)
         if size is None or cls.detect_task_from_filename(filename) != "normal":
             return None
-        if size in cls._MIRRORED_SIZES:
+        if size in cls._MIRROR_SHA256:
             # BaseModel builds the LibreYOLO org URL for the canonical filename.
             return super().get_download_url(filename)
         entry = cls._OFFICIAL_WEIGHTS.get(size)
         return entry[0] if entry else None
 
+    @staticmethod
+    def _sha256(path: str) -> str:
+        digest = hashlib.sha256()
+        with open(path, "rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
     @classmethod
     def verify_downloaded_file(cls, local_path: str, source_url: str) -> None:
-        # Weights served from LibreYOLO's own org are the converted checkpoint,
-        # not upstream's file, so the upstream digest below cannot describe
-        # them. They are trusted the same way every other LibreYOLO weight is.
+        # Mirror and upstream serve different bytes (converted vs original), so
+        # each has its own recorded digest. Both are checked: `resolve/main` is
+        # mutable, and an unverified mirror would be a weaker guarantee than the
+        # upstream path it replaced.
         if source_url.startswith("https://huggingface.co/LibreYOLO/"):
+            size = next(
+                (s for s in cls._MIRROR_SHA256 if f"LibreMoGe2{s}-normal" in source_url),
+                None,
+            )
+            if size is None:
+                raise ValueError(f"Unrecognized MoGe-2 mirror URL: {source_url}")
+            expected = cls._MIRROR_SHA256[size]
+            actual = cls._sha256(local_path)
+            if actual != expected:
+                raise ValueError(
+                    f"MoGe-2 {size} mirrored checkpoint SHA-256 mismatch: "
+                    f"expected {expected}, got {actual}."
+                )
             return
+
         size = next(
             (
                 size
@@ -151,11 +182,7 @@ class LibreMoGe2(BaseModel):
         if size is None:
             raise ValueError(f"Unrecognized MoGe-2 weight URL: {source_url}")
         expected = cls._OFFICIAL_WEIGHTS[size][1]
-        digest = hashlib.sha256()
-        with open(local_path, "rb") as stream:
-            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-                digest.update(chunk)
-        actual = digest.hexdigest()
+        actual = cls._sha256(local_path)
         if actual != expected:
             raise ValueError(
                 f"MoGe-2 {size} checkpoint SHA-256 mismatch: "

--- a/libreyolo/models/sam/model.py
+++ b/libreyolo/models/sam/model.py
@@ -38,10 +38,15 @@ class LibreSAM1(LibreSAMModel):
 
     FAMILY = "sam"
     FILENAME_PREFIX = "LibreSAM"
+    # SAM-1's weights are Apache-2.0, which permits redistribution, so these are
+    # mirrored on the LibreYOLO org rather than fetched from Meta. The mirrors
+    # carry Meta's weights and config byte for byte, plus the licence and a
+    # NOTICE; upstream's duplicate pytorch_model.bin and tf_model.h5 are not
+    # mirrored because the loader reads the safetensors file.
     HF_REPOS = {
-        "base": "facebook/sam-vit-base",
-        "large": "facebook/sam-vit-large",
-        "huge": "facebook/sam-vit-huge",
+        "base": "LibreYOLO/LibreSAMbase",
+        "large": "LibreYOLO/LibreSAMlarge",
+        "huge": "LibreYOLO/LibreSAMhuge",
     }
     INPUT_SIZES = {"base": 1024, "large": 1024, "huge": 1024}
 

--- a/scripts/_mirror_common.py
+++ b/scripts/_mirror_common.py
@@ -1,0 +1,64 @@
+"""Shared helpers for the scripts/mirror_*.py staging tools.
+
+Nothing here depends on the machine it runs on: staging goes to a temporary
+directory (override with --staging), and the licence texts and .gitattributes
+are fetched from their sources at run time rather than read out of a
+pre-populated folder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+import urllib.request
+from pathlib import Path
+
+# LFS rules, taken from a weight repo that already has them so a new mirror
+# stores its weights in LFS instead of as raw blobs.
+GITATTRIBUTES_SOURCE = (
+    "https://huggingface.co/LibreYOLO/LibreSegformerb5-sem/resolve/main/.gitattributes"
+)
+
+
+def fetch_text(url: str) -> str:
+    """Fetch a text asset (a licence, .gitattributes) from its source."""
+    with urllib.request.urlopen(url) as response:
+        return response.read().decode("utf-8")
+
+
+def gitattributes() -> str:
+    return fetch_text(GITATTRIBUTES_SOURCE)
+
+
+def parse_args(description: str, sizes: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "sizes",
+        nargs="*",
+        default=sizes,
+        help=f"sizes to stage (default: {' '.join(sizes)})",
+    )
+    parser.add_argument(
+        "--staging",
+        type=Path,
+        default=None,
+        help="where to build the repo directories (default: a temporary directory)",
+    )
+    parser.add_argument(
+        "--no-upload",
+        action="store_true",
+        help="stage only; do not create or push the Hugging Face repo",
+    )
+    args = parser.parse_args()
+    if args.staging is None:
+        args.staging = Path(tempfile.mkdtemp(prefix="libreyolo-mirror-"))
+    args.staging.mkdir(parents=True, exist_ok=True)
+    return args
+
+
+def check_five_file_contract(out: Path) -> list[str]:
+    """The contract in skills/libreyolo-upload-hf-model: exactly five files."""
+    files = sorted(p.name for p in out.iterdir() if p.is_file())
+    if len(files) != 5:
+        raise SystemExit(f"{out.name}: expected exactly 5 files, got {len(files)}: {files}")
+    return files

--- a/scripts/mirror_dinov2.py
+++ b/scripts/mirror_dinov2.py
@@ -1,0 +1,81 @@
+"""Build the LibreDINOv2 mirror checkpoint for the LibreYOLO Hugging Face org.
+
+    .venv/Scripts/python.exe scripts/mirror_dinov2.py <out-dir>
+
+Why this exists
+---------------
+LibreDINOv2 already asks for its weights at
+https://huggingface.co/LibreYOLO/LibreDINOv2n/resolve/main/LibreDINOv2n.pt,
+because the family does not override ``get_download_url``. Nothing was ever
+uploaded there, so every first run instead reached out to Meta through the
+backbone loader. Mirroring makes the documented path the real one.
+
+What ships
+----------
+The DINOv2-S backbone, unmodified, wrapped in LibreYOLO checkpoint format. The
+weights are Meta's Apache-2.0 release; this repackages them, it does not
+retrain them. Semantic and classification heads are deliberately NOT included:
+LibreYOLO publishes no trained head for this family, and shipping a randomly
+initialised one inside a file called "weights" would be a lie. The loader
+builds a fresh head exactly as it does today.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+
+from libreyolo.models.dinov2.model import LibreDINOv2
+from libreyolo.utils.serialization import (
+    validate_checkpoint_metadata,
+    wrap_libreyolo_checkpoint,
+)
+
+SIZE = "n"
+UPSTREAM = "facebook/dinov2-small"
+
+
+def main() -> int:
+    out_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "mirror-dinov2")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # task="embed" is the one head-free task, so the state dict that comes back
+    # is the backbone and nothing else.
+    print(f"building LibreDINOv2 size={SIZE} from {UPSTREAM} ...", flush=True)
+    model = LibreDINOv2(None, size=SIZE, task="embed")
+    state = model.model.state_dict()
+
+    non_backbone = [k for k in state if not k.startswith("backbone.")]
+    if non_backbone:
+        raise SystemExit(f"refusing to ship non-backbone tensors: {non_backbone[:5]}")
+
+    params = sum(v.numel() for v in state.values())
+    print(f"  {len(state)} tensors, {params / 1e6:.2f}M parameters", flush=True)
+
+    checkpoint = wrap_libreyolo_checkpoint(
+        {k: v.cpu() for k, v in state.items()},
+        model_family="dinov2",
+        size=SIZE,
+        task="semantic",  # the family default the filename implies
+        nc=0,             # no trained head ships, so no class count is claimed
+        imgsz=LibreDINOv2.INPUT_SIZES[SIZE],
+    )
+
+    errors = validate_checkpoint_metadata(checkpoint, strict=True)
+    if errors:
+        print("checkpoint metadata FAILED validation:", flush=True)
+        for e in errors:
+            print(f"  - {e}", flush=True)
+        return 1
+    print("  checkpoint metadata validates against the schema", flush=True)
+
+    out = out_dir / f"LibreDINOv2{SIZE}.pt"
+    torch.save(checkpoint, out)
+    print(f"  wrote {out} ({out.stat().st_size / 1e6:.1f} MB)", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mirror_midas.py
+++ b/scripts/mirror_midas.py
@@ -1,0 +1,162 @@
+"""Mirror the MiDaS depth weights onto the LibreYOLO org.
+
+    .venv/Scripts/python.exe scripts/mirror_midas.py s l
+
+Why now
+-------
+ADR 0006 says hosted depth weights must be trained only on data whose licence
+permits redistribution *and commercial use*. MiDaS trained on a twelve-dataset
+mixture that includes non-commercial sources, so it failed that bar and the
+family has been downloading from isl-org's GitHub releases ever since.
+
+The maintainer has ruled that the isl-org/MiDaS MIT licence extends to the
+released checkpoints, so LibreYOLO relies on the publisher's own grant for the
+bytes it redistributes. ADR 0006's consequence needs amending to match: it
+still states the stricter commercial-use bar.
+
+The mirror ships the converted LibreYOLO checkpoint, so the upstream SHA-256
+recorded in convert.py describes upstream's file and not ours.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+from huggingface_hub import HfApi
+
+from libreyolo.models.midas.convert import UPSTREAM_URLS
+from libreyolo.utils.serialization import validate_checkpoint_metadata
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WEIGHTS = REPO_ROOT / "weights"
+ASSETS = Path(
+    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
+    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-assets"
+)
+STAGING = Path(
+    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
+    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-staging"
+)
+
+ARCH = {"s": "EfficientNet-Lite3 (MiDaS v2.1 small, 256 px)",
+        "l": "ViT-L/16 (DPT-Large, 384 px)"}
+
+README = """---
+license: mit
+library_name: libreyolo
+tags:
+  - depth-estimation
+  - monocular-depth
+  - midas
+---
+
+# {repo}
+
+MiDaS {arch} monocular depth model, repackaged in LibreYOLO checkpoint format.
+
+## Source
+
+Derived from [isl-org/MiDaS](https://github.com/isl-org/MiDaS), release asset
+`{asset}`.
+Copyright (c) Intel ISL. Licensed under the MIT License.
+
+## Modifications
+
+State-dict key remapping only. Learned parameters are unchanged.
+See `weights/convert_midas_weights.py` in the
+[LibreYOLO source repository](https://github.com/LibreYOLO/libreyolo).
+
+## A note on the training data
+
+MiDaS was trained on a mixture of twelve datasets, several of which carry
+non-commercial terms of their own. LibreYOLO redistributes these weights under
+the MIT licence its publisher applied to them. If your use is commercial,
+satisfy yourself about the training-data terms before relying on it.
+
+## Usage
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("{repo}.pt")
+depth = model.predict("image.jpg")[0].depth_map
+```
+
+## License
+
+MIT License. See the [`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE) files in
+this repository.
+"""
+
+NOTICE = """LibreMiDaS weights
+------------------
+
+This product contains weights derived from MiDaS
+(https://github.com/isl-org/MiDaS).
+Copyright (c) Intel ISL.
+Licensed under the MIT License.
+
+MiDaS was trained on a mixture of twelve datasets whose individual terms are
+not all permissive. The redistribution here rests on the MIT licence applied
+by the publisher to the released checkpoints.
+"""
+
+
+def stage(size: str) -> Path:
+    repo = f"LibreMiDaS{size}-depth"
+    src = WEIGHTS / f"{repo}.pt"
+    if not src.exists():
+        raise FileNotFoundError(
+            f"{src} not found. Load it once so the converter produces it:\n"
+            f"  LibreYOLO('{repo}.pt')"
+        )
+
+    checkpoint = torch.load(src, map_location="cpu", weights_only=False)
+    errors = validate_checkpoint_metadata(checkpoint, strict=False)
+    if errors:
+        raise SystemExit(f"{repo}: checkpoint metadata invalid: {errors}")
+
+    out = STAGING / repo
+    out.mkdir(parents=True, exist_ok=True)
+    for name, text in (
+        (".gitattributes", (ASSETS / ".gitattributes").read_text(encoding="utf-8")),
+        ("LICENSE", (ASSETS / "LICENSE-midas").read_text(encoding="utf-8")),
+        ("NOTICE", NOTICE),
+        ("README.md", README.format(repo=repo, arch=ARCH[size],
+                                    asset=UPSTREAM_URLS[size].rsplit("/", 1)[-1])),
+    ):
+        (out / name).write_text(text, encoding="utf-8")
+
+    if not (out / f"{repo}.pt").exists():
+        (out / f"{repo}.pt").write_bytes(src.read_bytes())
+
+    files = sorted(p.name for p in out.iterdir())
+    print(f"  staged {repo}: {files} "
+          f"({(out / f'{repo}.pt').stat().st_size / 1e6:.0f} MB)", flush=True)
+    if len(files) != 5:
+        raise SystemExit(f"{repo}: expected 5 files, got {len(files)}")
+    return out
+
+
+def upload(size: str, folder: Path) -> None:
+    repo_id = f"LibreYOLO/LibreMiDaS{size}-depth"
+    api = HfApi()
+    api.create_repo(repo_id, repo_type="model", exist_ok=True)
+    url = api.upload_folder(
+        folder_path=str(folder), repo_id=repo_id, repo_type="model",
+        commit_message=f"Mirror MiDaS {size} depth weights (MIT)",
+    )
+    print(f"  uploaded {repo_id}: {url}", flush=True)
+
+
+def main() -> int:
+    for size in sys.argv[1:] or ["s"]:
+        print(f"\n=== {size} ===", flush=True)
+        upload(size, stage(size))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mirror_midas.py
+++ b/scripts/mirror_midas.py
@@ -24,24 +24,18 @@ import sys
 from pathlib import Path
 
 import torch
+from _mirror_common import fetch_text, gitattributes, parse_args
 from huggingface_hub import HfApi
 
-from libreyolo.models.midas.convert import UPSTREAM_URLS
+from libreyolo.models.midas.convert import UPSTREAM_SHA256, UPSTREAM_URLS
 from libreyolo.utils.serialization import validate_checkpoint_metadata
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WEIGHTS = REPO_ROOT / "weights"
-ASSETS = Path(
-    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
-    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-assets"
-)
-STAGING = Path(
-    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
-    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-staging"
-)
-
 ARCH = {"s": "EfficientNet-Lite3 (MiDaS v2.1 small, 256 px)",
         "l": "ViT-L/16 (DPT-Large, 384 px)"}
+
+LICENSE_URL = "https://raw.githubusercontent.com/isl-org/MiDaS/master/LICENSE"
 
 README = """---
 license: mit
@@ -98,13 +92,19 @@ This product contains weights derived from MiDaS
 Copyright (c) Intel ISL.
 Licensed under the MIT License.
 
+Source artifact:  {asset_url}
+Source SHA-256:   {upstream_sha256}
+Modification:     state-dict key remapping only, by
+                  weights/convert_midas_weights.py in LibreYOLO. Learned
+                  parameters are unchanged.
+
 MiDaS was trained on a mixture of twelve datasets whose individual terms are
 not all permissive. The redistribution here rests on the MIT licence applied
 by the publisher to the released checkpoints.
 """
 
 
-def stage(size: str) -> Path:
+def stage(size: str, staging: Path) -> Path:
     repo = f"LibreMiDaS{size}-depth"
     src = WEIGHTS / f"{repo}.pt"
     if not src.exists():
@@ -118,12 +118,15 @@ def stage(size: str) -> Path:
     if errors:
         raise SystemExit(f"{repo}: checkpoint metadata invalid: {errors}")
 
-    out = STAGING / repo
+    out = staging / repo
     out.mkdir(parents=True, exist_ok=True)
     for name, text in (
-        (".gitattributes", (ASSETS / ".gitattributes").read_text(encoding="utf-8")),
-        ("LICENSE", (ASSETS / "LICENSE-midas").read_text(encoding="utf-8")),
-        ("NOTICE", NOTICE),
+        (".gitattributes", gitattributes()),
+        ("LICENSE", fetch_text(LICENSE_URL)),
+        ("NOTICE", NOTICE.format(
+            asset_url=UPSTREAM_URLS[size],
+            upstream_sha256=UPSTREAM_SHA256[UPSTREAM_URLS[size].rsplit("/", 1)[-1]],
+        )),
         ("README.md", README.format(repo=repo, arch=ARCH[size],
                                     asset=UPSTREAM_URLS[size].rsplit("/", 1)[-1])),
     ):
@@ -152,9 +155,15 @@ def upload(size: str, folder: Path) -> None:
 
 
 def main() -> int:
-    for size in sys.argv[1:] or ["s"]:
+    args = parse_args(__doc__ or "Mirror MiDaS", ["s", "l"])
+    print(f"staging under {args.staging}", flush=True)
+    for size in args.sizes:
         print(f"\n=== {size} ===", flush=True)
-        upload(size, stage(size))
+        folder = stage(size, args.staging)
+        if args.no_upload:
+            print("  --no-upload: staged only", flush=True)
+        else:
+            upload(size, folder)
     return 0
 
 

--- a/scripts/mirror_moge2.py
+++ b/scripts/mirror_moge2.py
@@ -21,15 +21,12 @@ from pathlib import Path
 
 import torch
 
+from _mirror_common import fetch_text, gitattributes, parse_args
+
 from libreyolo.utils.serialization import validate_checkpoint_metadata
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WEIGHTS = REPO_ROOT / "weights"
-ASSETS = Path(
-    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
-    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-assets"
-)
-
 # Upstream repo and the exact revision LibreYOLO pins today, so the mirror
 # records which bytes it came from rather than "latest".
 SIZES = {
@@ -46,6 +43,8 @@ SIZES = {
         "arch": "MoGe-2 ViT-S/14",
     },
 }
+
+LICENSE_URL = "https://raw.githubusercontent.com/microsoft/MoGe/main/LICENSE"
 
 README = """---
 license: mit
@@ -99,6 +98,13 @@ This product contains weights derived from MoGe-2
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 
+Source artifact:  https://huggingface.co/{upstream}
+Source revision:  {revision}
+Source file:      model.pt
+Modification:     state-dict key remapping only, by
+                  weights/convert_moge2_weights.py in LibreYOLO. Learned
+                  parameters are unchanged.
+
 The DINOv2 encoder these weights build on is separately licensed under the
 Apache License, Version 2.0, by Meta AI
 (https://github.com/facebookresearch/dinov2).
@@ -119,9 +125,11 @@ def stage(size: str, spec: dict, out_root: Path) -> Path:
     out = out_root / repo
     out.mkdir(parents=True, exist_ok=True)
 
-    shutil.copy2(ASSETS / ".gitattributes", out / ".gitattributes")
-    shutil.copy2(ASSETS / "LICENSE", out / "LICENSE")
-    (out / "NOTICE").write_text(NOTICE, encoding="utf-8")
+    (out / ".gitattributes").write_text(gitattributes(), encoding="utf-8")
+    (out / "LICENSE").write_text(fetch_text(LICENSE_URL), encoding="utf-8")
+    (out / "NOTICE").write_text(
+        NOTICE.format(upstream=spec["upstream"], revision=spec["revision"]), encoding="utf-8"
+    )
     (out / "README.md").write_text(
         README.format(repo=repo, arch=spec["arch"], upstream=spec["upstream"],
                       revision=spec["revision"]),
@@ -139,12 +147,13 @@ def stage(size: str, spec: dict, out_root: Path) -> Path:
 
 
 def main() -> int:
-    out_root = Path(sys.argv[1] if len(sys.argv) > 1 else "mirror-staging")
-    out_root.mkdir(parents=True, exist_ok=True)
-    print(f"staging MoGe-2 mirrors under {out_root}", flush=True)
-    for size, spec in SIZES.items():
-        stage(size, spec, out_root)
-    print("staged. nothing uploaded yet.", flush=True)
+    args = parse_args(__doc__ or "Mirror MoGe-2", list(SIZES))
+    print(f"staging MoGe-2 mirrors under {args.staging}", flush=True)
+    for size in args.sizes:
+        if size not in SIZES:
+            raise SystemExit(f"unknown size {size!r}; expected one of {list(SIZES)}")
+        stage(size, SIZES[size], args.staging)
+    print("staged. upload with huggingface_hub.HfApi().upload_folder(...).", flush=True)
     return 0
 
 

--- a/scripts/mirror_moge2.py
+++ b/scripts/mirror_moge2.py
@@ -1,0 +1,152 @@
+"""Stage the LibreMoGe2 mirror repos for the LibreYOLO Hugging Face org.
+
+    .venv/Scripts/python.exe scripts/mirror_moge2.py <staging-dir>
+
+Why
+---
+LibreMoGe2 currently fetches from Ruicheng's Hugging Face repos at a pinned
+revision, so a first run depends on a third party staying put. The weights are
+MIT, which permits redistribution, so there is no reason for that dependency.
+
+This stages one directory per size following the 5-file contract in
+skills/libreyolo-upload-hf-model. It does not upload; upload is a separate,
+deliberate step.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import torch
+
+from libreyolo.utils.serialization import validate_checkpoint_metadata
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WEIGHTS = REPO_ROOT / "weights"
+ASSETS = Path(
+    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
+    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-assets"
+)
+
+# Upstream repo and the exact revision LibreYOLO pins today, so the mirror
+# records which bytes it came from rather than "latest".
+SIZES = {
+    "l": {
+        "converted": "LibreMoGe2l-normal-LibreMoGe2l-normal.pt",
+        "upstream": "Ruicheng/moge-2-vitl-normal",
+        "revision": "b135031bae30b5ac2ae141a0e68717795ce38340",
+        "arch": "MoGe-2 ViT-L/14",
+    },
+    "s": {
+        "converted": "LibreMoGe2s-normal-LibreMoGe2s-normal.pt",
+        "upstream": "Ruicheng/moge-2-vits-normal",
+        "revision": "679230677b4d282c6f304189a93e98e14f085902",
+        "arch": "MoGe-2 ViT-S/14",
+    },
+}
+
+README = """---
+license: mit
+library_name: libreyolo
+tags:
+  - image-to-image
+  - surface-normals
+  - moge
+---
+
+# {repo}
+
+{arch} surface-normal estimator, repackaged in LibreYOLO checkpoint format.
+
+## Source
+
+Derived from [{upstream}](https://huggingface.co/{upstream})
+at revision `{revision}`, the exact commit LibreYOLO pins.
+Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+The DINOv2 encoder MoGe-2 builds on is separately licensed Apache-2.0 by
+Meta AI.
+
+## Modifications
+
+State-dict key remapping only. Learned parameters are unchanged.
+See `weights/convert_moge2_weights.py` in the
+[LibreYOLO source repository](https://github.com/LibreYOLO/libreyolo).
+
+## Usage
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("{repo}.pt")
+result = model.predict("image.jpg")[0]
+normals = result.normals
+```
+
+## License
+
+MIT License. See the [`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE) files in
+this repository.
+"""
+
+NOTICE = """LibreMoGe2 weights
+------------------
+
+This product contains weights derived from MoGe-2
+(https://github.com/microsoft/MoGe).
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+
+The DINOv2 encoder these weights build on is separately licensed under the
+Apache License, Version 2.0, by Meta AI
+(https://github.com/facebookresearch/dinov2).
+"""
+
+
+def stage(size: str, spec: dict, out_root: Path) -> Path:
+    repo = f"LibreMoGe2{size}-normal"
+    src = WEIGHTS / spec["converted"]
+    if not src.exists():
+        raise FileNotFoundError(f"converted checkpoint missing: {src}")
+
+    checkpoint = torch.load(src, map_location="cpu", weights_only=False)
+    errors = validate_checkpoint_metadata(checkpoint, strict=False)
+    if errors:
+        raise SystemExit(f"{repo}: checkpoint metadata invalid: {errors}")
+
+    out = out_root / repo
+    out.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy2(ASSETS / ".gitattributes", out / ".gitattributes")
+    shutil.copy2(ASSETS / "LICENSE", out / "LICENSE")
+    (out / "NOTICE").write_text(NOTICE, encoding="utf-8")
+    (out / "README.md").write_text(
+        README.format(repo=repo, arch=spec["arch"], upstream=spec["upstream"],
+                      revision=spec["revision"]),
+        encoding="utf-8",
+    )
+    # Canonical filename, not the doubled name the converter leaves behind.
+    shutil.copy2(src, out / f"{repo}.pt")
+
+    files = sorted(p.name for p in out.iterdir())
+    size_mb = (out / f"{repo}.pt").stat().st_size / 1e6
+    print(f"  {repo}: {files} ({size_mb:.0f} MB)", flush=True)
+    if len(files) != 5:
+        raise SystemExit(f"{repo}: expected exactly 5 files, got {len(files)}")
+    return out
+
+
+def main() -> int:
+    out_root = Path(sys.argv[1] if len(sys.argv) > 1 else "mirror-staging")
+    out_root.mkdir(parents=True, exist_ok=True)
+    print(f"staging MoGe-2 mirrors under {out_root}", flush=True)
+    for size, spec in SIZES.items():
+        stage(size, spec, out_root)
+    print("staged. nothing uploaded yet.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mirror_sam.py
+++ b/scripts/mirror_sam.py
@@ -24,16 +24,16 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from _mirror_common import fetch_text, gitattributes, parse_args
 from huggingface_hub import HfApi, snapshot_download
 
-ASSETS = Path(
-    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
-    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-assets"
-)
-STAGING = Path(
-    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
-    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-staging"
-)
+# Exact upstream revisions the mirrors were taken from, recorded so a consumer
+# can identify the precise source. Refresh when re-mirroring.
+UPSTREAM_REVISIONS = {
+    "base": "70c1a07f894ebb5b307fd9eaaee97b9dfc16068f",
+    "large": "6851e0441005b0fb96f2cc4dfac472f3d1b14af1",
+    "huge": "87aecf0df4ce6b30cd7de76e87673c49644bdf67",
+}
 
 UPSTREAM = {
     "base": "facebook/sam-vit-base",
@@ -43,6 +43,8 @@ UPSTREAM = {
 
 # Everything transformers needs to rebuild the model and its processor.
 KEEP = ["config.json", "preprocessor_config.json", "model.safetensors"]
+
+LICENSE_URL = "https://raw.githubusercontent.com/facebookresearch/segment-anything/main/LICENSE"
 
 README = """---
 license: apache-2.0
@@ -95,14 +97,19 @@ This product contains weights from Segment Anything (SAM)
 Copyright (c) Meta Platforms, Inc. and affiliates.
 Licensed under the Apache License, Version 2.0.
 
-The weights are redistributed unmodified.
+Source artifact:  https://huggingface.co/{upstream}
+Source revision:  {revision}
+Source files:     config.json, preprocessor_config.json, model.safetensors
+Modification:     none. The weights and configuration are redistributed
+                  unmodified. Upstream's pytorch_model.bin (a duplicate of the
+                  safetensors weights) and tf_model.h5 are not mirrored.
 """
 
 
-def stage(size: str) -> Path:
+def stage(size: str, staging: Path) -> Path:
     upstream = UPSTREAM[size]
     repo_name = f"LibreSAM{size}"
-    out = STAGING / repo_name
+    out = staging / repo_name
     out.mkdir(parents=True, exist_ok=True)
 
     print(f"  downloading {upstream} ({', '.join(KEEP)}) ...", flush=True)
@@ -113,9 +120,12 @@ def stage(size: str) -> Path:
     )
 
     (out / "LICENSE").write_text(
-        (ASSETS / "LICENSE-sam").read_text(encoding="utf-8"), encoding="utf-8"
+        fetch_text(LICENSE_URL), encoding="utf-8"
     )
-    (out / "NOTICE").write_text(NOTICE, encoding="utf-8")
+    (out / "NOTICE").write_text(
+        NOTICE.format(upstream=upstream, revision=UPSTREAM_REVISIONS[size]),
+        encoding="utf-8",
+    )
     (out / "README.md").write_text(
         README.format(repo=repo_name, size=size, size_title=size.title(), upstream=upstream),
         encoding="utf-8",
@@ -141,12 +151,17 @@ def upload(size: str, folder: Path) -> None:
 
 
 def main() -> int:
-    sizes = sys.argv[1:] or ["base"]
-    for size in sizes:
+    args = parse_args(__doc__ or "Mirror SAM-1", list(UPSTREAM))
+    print(f"staging under {args.staging}", flush=True)
+    for size in args.sizes:
         if size not in UPSTREAM:
             raise SystemExit(f"unknown size {size!r}; expected one of {list(UPSTREAM)}")
         print(f"\n=== {size} ===", flush=True)
-        upload(size, stage(size))
+        folder = stage(size, args.staging)
+        if args.no_upload:
+            print("  --no-upload: staged only", flush=True)
+        else:
+            upload(size, folder)
     return 0
 
 

--- a/scripts/mirror_sam.py
+++ b/scripts/mirror_sam.py
@@ -1,0 +1,154 @@
+"""Mirror Meta's SAM-1 transformers snapshots onto the LibreYOLO org.
+
+    .venv/Scripts/python.exe scripts/mirror_sam.py base [large huge]
+
+Why
+---
+LibreSAM1 loads through ``transformers`` from facebook/sam-vit-{base,large,huge}.
+Those weights are Apache-2.0, which permits redistribution, so the dependency
+on Meta's repos is a choice rather than a constraint.
+
+Shape
+-----
+This family ships snapshot directories rather than a single ``.pt``, the same
+as LibreGroundingDINO and LibreOWLv2, so the 5-file contract does not apply
+verbatim; the repo mirrors the upstream layout plus a card, LICENSE and NOTICE.
+
+Only the PyTorch-relevant files are copied. Upstream also carries
+``pytorch_model.bin`` (a duplicate of the safetensors weights) and
+``tf_model.h5``; mirroring those would triple the repo for nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from huggingface_hub import HfApi, snapshot_download
+
+ASSETS = Path(
+    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
+    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-assets"
+)
+STAGING = Path(
+    "C:/Users/Usuario/AppData/Local/Temp/claude/C--Users-Usuario/"
+    "c6dfe57f-09e9-40c8-afb6-aaa1e472f308/scratchpad/mirror-staging"
+)
+
+UPSTREAM = {
+    "base": "facebook/sam-vit-base",
+    "large": "facebook/sam-vit-large",
+    "huge": "facebook/sam-vit-huge",
+}
+
+# Everything transformers needs to rebuild the model and its processor.
+KEEP = ["config.json", "preprocessor_config.json", "model.safetensors"]
+
+README = """---
+license: apache-2.0
+library_name: libreyolo
+tags:
+  - mask-generation
+  - image-segmentation
+  - sam
+---
+
+# {repo}
+
+Segment Anything (SAM-1) ViT-{size_title}, mirrored for LibreYOLO.
+
+## Source
+
+Mirrored from [{upstream}](https://huggingface.co/{upstream}).
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the Apache License, Version 2.0.
+
+## Modifications
+
+None. The weights and configuration are Meta's, byte for byte. This repository
+exists so LibreYOLO can serve them from its own organisation rather than
+depending on a third-party repository remaining available.
+
+Upstream also publishes `pytorch_model.bin` (a duplicate of the safetensors
+weights) and `tf_model.h5`. Neither is mirrored, because LibreYOLO loads the
+safetensors file.
+
+## Usage
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("LibreSAM{size}.pt")
+```
+
+## License
+
+Apache License 2.0. See the [`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE)
+files in this repository.
+"""
+
+NOTICE = """LibreSAM weights
+----------------
+
+This product contains weights from Segment Anything (SAM)
+(https://github.com/facebookresearch/segment-anything).
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the Apache License, Version 2.0.
+
+The weights are redistributed unmodified.
+"""
+
+
+def stage(size: str) -> Path:
+    upstream = UPSTREAM[size]
+    repo_name = f"LibreSAM{size}"
+    out = STAGING / repo_name
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"  downloading {upstream} ({', '.join(KEEP)}) ...", flush=True)
+    snapshot_download(
+        repo_id=upstream,
+        local_dir=str(out),
+        allow_patterns=KEEP,
+    )
+
+    (out / "LICENSE").write_text(
+        (ASSETS / "LICENSE-sam").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (out / "NOTICE").write_text(NOTICE, encoding="utf-8")
+    (out / "README.md").write_text(
+        README.format(repo=repo_name, size=size, size_title=size.title(), upstream=upstream),
+        encoding="utf-8",
+    )
+
+    total = sum(p.stat().st_size for p in out.rglob("*") if p.is_file())
+    print(f"  staged {repo_name}: {sorted(p.name for p in out.iterdir())} "
+          f"({total / 1e6:.0f} MB)", flush=True)
+    return out
+
+
+def upload(size: str, folder: Path) -> None:
+    repo_id = f"LibreYOLO/LibreSAM{size}"
+    api = HfApi()
+    api.create_repo(repo_id, repo_type="model", exist_ok=True)
+    url = api.upload_folder(
+        folder_path=str(folder),
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message=f"Mirror SAM-1 ViT-{size} from {UPSTREAM[size]} (Apache-2.0)",
+    )
+    print(f"  uploaded {repo_id}: {url}", flush=True)
+
+
+def main() -> int:
+    sizes = sys.argv[1:] or ["base"]
+    for size in sizes:
+        if size not in UPSTREAM:
+            raise SystemExit(f"unknown size {size!r}; expected one of {list(UPSTREAM)}")
+        print(f"\n=== {size} ===", flush=True)
+        upload(size, stage(size))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_midas.py
+++ b/tests/unit/test_midas.py
@@ -114,8 +114,15 @@ def test_filename_and_download_routing():
     assert LibreMiDaS.detect_size_from_filename("LibreMiDaSl-depth.pt") == "l"
     assert LibreMiDaS.detect_task_from_filename("LibreMiDaSl-depth.pt") == "depth"
     assert LibreMiDaS.detect_size_from_filename("LibreMiDaSs.pt") is None
-    assert LibreMiDaS.get_download_url("LibreMiDaSs-depth.pt") == UPSTREAM_URLS["s"]
-    assert LibreMiDaS.get_download_url("LibreMiDaSl-depth.pt") == UPSTREAM_URLS["l"]
+    # Mirrored sizes resolve to the LibreYOLO org; anything not mirrored still
+    # falls back to the official upstream asset.
+    for size in ("s", "l"):
+        url = LibreMiDaS.get_download_url(f"LibreMiDaS{size}-depth.pt")
+        assert url == (
+            f"https://huggingface.co/LibreYOLO/LibreMiDaS{size}-depth"
+            f"/resolve/main/LibreMiDaS{size}-depth.pt"
+        )
+        assert url != UPSTREAM_URLS[size]
     assert LibreMiDaS.get_download_url("LibreMiDaSs.pt") is None
 
 

--- a/tests/unit/test_moge2.py
+++ b/tests/unit/test_moge2.py
@@ -51,9 +51,20 @@ class TestMoGe2Metadata:
         filename = f"LibreMoGe2{size}-normal.pt"
         assert LibreMoGe2.detect_size_from_filename(filename) == size
         assert LibreMoGe2.detect_task_from_filename(filename) == "normal"
-        assert LibreMoGe2.get_download_url(filename) == (
-            f"https://huggingface.co/Ruicheng/{repo}/resolve/{revision}/model.pt"
-        )
+
+        if size in LibreMoGe2._MIRROR_SHA256:
+            # Mirrored sizes come from the LibreYOLO org, pinned by the digest
+            # of the converted checkpoint the mirror serves.
+            assert LibreMoGe2.get_download_url(filename) == (
+                f"https://huggingface.co/LibreYOLO/LibreMoGe2{size}-normal"
+                f"/resolve/main/LibreMoGe2{size}-normal.pt"
+            )
+            assert len(LibreMoGe2._MIRROR_SHA256[size]) == 64
+        else:
+            # Everything else still comes from upstream at a pinned revision.
+            assert LibreMoGe2.get_download_url(filename) == (
+                f"https://huggingface.co/Ruicheng/{repo}/resolve/{revision}/model.pt"
+            )
         assert LibreMoGe2.get_download_url(f"LibreMoGe2{size}.pt") is None
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Four families downloaded their weights from somebody else's server on every
cold start. All four are redistributable, so that was a choice rather than a
constraint. They now come from the LibreYOLO org.

| Family | Sizes mirrored | Licence | Was fetching from |
|---|---|---|---|
| MoGe-2 | `s`, `l` | MIT | `Ruicheng/moge-2-*` at a pinned revision |
| SAM-1 | `base`, `large`, `huge` | Apache-2.0 | `facebook/sam-vit-*` |
| MiDaS | `s`, `l` | MIT | `isl-org/MiDaS` GitHub release assets |

Face embeddings needed no change: `librefacerec-l` and `librefacerec-det` were
already on the org. The registry's `weights_hosted` flag was simply wrong about
that family.

MoGe-2 `b` is deliberately untouched. No converted checkpoint exists for it, so
it still downloads from upstream and stays SHA-256 pinned.

## Two things worth reviewing closely

**`verify_downloaded_file` now short-circuits for org-served URLs** in MoGe-2
and MiDaS. Both mirrors ship the *converted* LibreYOLO checkpoint, whose bytes
are not upstream's, so the recorded upstream SHA-256 cannot describe them.
Left unchanged, the checksum guard would have rejected our own files. Anything
not served from `huggingface.co/LibreYOLO/` is still pinned exactly as before.

**ADR 0006 is amended, not worked around.** Its consequence required hosted
depth weights to be trained only on data permitting redistribution *and
commercial use*. MiDaS trained on a twelve-dataset mixture including KITTI,
NYU and ApolloScape, so it could never clear that bar, and the family was
pinned to a GitHub release indefinitely.

That bar also asked a question LibreYOLO does not ask anywhere else: SegFormer
and the NVIDIA Source Code License tier are both hosted with non-commercial
terms shipped verbatim. What governs hosting is whether the publisher granted
redistribution over the bytes, and isl-org published these checkpoints under
MIT. The consequence now reads: hosted depth weights must be redistributable,
and inherited non-commercial terms are disclosed rather than disqualifying.
The MiDaS download notice changed accordingly, from explaining why nothing is
hosted to stating what the training mixture implies for commercial use.

If you disagree with that reading, the MiDaS commit is the one to revert; the
other two stand on their own.

## Repos created

`LibreMoGe2s-normal`, `LibreMoGe2l-normal`, `LibreSAMbase`, `LibreSAMlarge`,
`LibreSAMhuge`, `LibreMiDaSs-depth`, `LibreMiDaSl-depth`.

Each carries `LICENSE` (upstream text verbatim), `NOTICE`, `README.md` and the
weights, per `skills/libreyolo-upload-hf-model`. The SAM repos follow the
snapshot-directory shape used by `LibreGroundingDINO` and `LibreOWLv2` rather
than the 5-file contract, since that family loads through `transformers`.

The SAM mirrors carry only `config.json`, `preprocessor_config.json` and
`model.safetensors`. Upstream also publishes `pytorch_model.bin`, a duplicate
of the safetensors weights, and `tf_model.h5` for a framework LibreYOLO does
not load. Skipping both took base from 2251 MB to 375, large from 7498 to
1249, and huge from 15388 to 2564.

## Verification

Each family was tested cold, with the local copy moved aside first:

- `LibreMoGe2s-normal` downloaded 108.9 MB from the org and produced normals
  of shape `(1194, 1536, 3)`.
- `LibreSAM('sam-base')` logged `Downloading sam weights from
  LibreYOLO/LibreSAMbase`, produced `Masks`, and left Meta's HF cache entry
  empty after it had been deleted.
- `LibreMiDaSs-depth` downloaded 81.8 MB from the org and produced a depth map
  of shape `(1194, 1536)`.

## Not mirrored, and why

- **DexiNed, TEED** — MIT code, but the released checkpoints are BIPED-trained
  and BIPED grants use only, never redistribution.
- **L2CS** — Gaze360 forbids redistribution in as many words.
- **Dome-DETR** — the upstream card claims Apache-2.0 in metadata and
  research-only in prose. No grant either way.
- **LibreMODUS** — `license: other`, research-only, and gated behind the user's
  own acceptance upstream.
- **LocateAnything** — the licences do permit it (the NVIDIA SCL and the Qwen
  Research License both allow non-commercial redistribution with notices), but
  it is one of the wrapped VLM tiers, which are out of scope here.
- **DINOv2** — Apache-2.0, and `LibreDINOv2n.pt` already resolves to the org,
  but LibreYOLO publishes no trained head for the family. The model is 223
  backbone tensors and nothing else, while the checkpoint schema requires a
  positive `nc` and class names. Shipping it means inventing metadata for a
  randomly initialised head. `scripts/mirror_dinov2.py` is included as the
  record of that dead end; say the word and I will drop it.

## Code provenance

All code in this PR was written for it: the three `scripts/mirror_*.py` staging
helpers and the changes to `get_download_url` / `verify_downloaded_file` in
`libreyolo/models/{moge2,sam,midas}/model.py`. No third-party code is ported,
adapted, or vendored.

The PR does redistribute third-party **weights**, unmodified except for the
state-dict key remapping the existing `weights/convert_*.py` converters already
perform. Every one is permissively licensed and each mirror ships that licence
verbatim:

- MoGe-2 — MIT, Microsoft Corporation, from `microsoft/MoGe`.
- SAM-1 — Apache-2.0, Meta Platforms, from `facebookresearch/segment-anything`.
- MiDaS — MIT, Intel ISL, from `isl-org/MiDaS`.

MiDaS's training mixture includes non-commercial datasets; that is disclosed on
the model card and in the download notice rather than treated as a bar on
redistribution, per the amended ADR 0006 above.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR moves MoGe-2, SAM-1, and MiDaS downloads to LibreYOLO-hosted mirrors and adds integrity pins and reusable staging helpers. The SAM staging path still downloads mutable upstream state instead of the commit it records.
- Routes supported MoGe-2 and MiDaS checkpoints through LibreYOLO mirrors with SHA-256 verification.
- Redirects SAM-1 transformer snapshots to LibreYOLO repositories.
- Adds mirror staging/upload helpers and updates the depth-hosting ADR and URL-routing tests.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because rerunning the SAM mirror helper can publish mutable upstream artifacts under provenance that claims a different pinned commit.

The SAM staging flow has exact revisions available but does not pass them to snapshot_download or otherwise validate the downloaded files before uploading them to the trusted LibreYOLO organization.

**Files Needing Attention:** scripts/mirror_sam.py
</details>

<details open><summary><h3>Security Review</h3></summary>

The SAM mirror helper can promote mutable upstream contents into trusted LibreYOLO repositories while attributing them to a different pinned commit. **How this was verified:** `snapshot_download` omits the available revision, and the resulting unchecked folder is passed directly to `upload_folder`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/mirror_sam.py | Adds SAM mirror staging and upload support, but fetches mutable upstream snapshots instead of the recorded commits. |
| libreyolo/models/midas/model.py | Routes mirrored MiDaS sizes through LibreYOLO and verifies converted checkpoint digests. |
| libreyolo/models/moge2/model.py | Routes mirrored MoGe-2 sizes through LibreYOLO while preserving pinned upstream fallback behavior. |
| libreyolo/models/sam/model.py | Changes SAM-1 transformer repository identifiers to the LibreYOLO mirrors. |
| scripts/_mirror_common.py | Replaces machine-specific staging assumptions with shared temporary-directory and asset-fetch helpers. |
| docs/adr/0006-depth-task-contract.md | Revises the hosted depth-weight policy to permit redistributable checkpoints with inherited restrictions disclosed. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Recorded SAM revision] --> B[Generated NOTICE]
  C[Mutable upstream default branch] --> D[snapshot_download without revision]
  D --> E[Staging directory]
  E --> F[LibreYOLO mirror upload]
  F --> G[Downstream SAM cold start]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Ascripts%2Fmirror_sam.py%3A116-120%0A**SAM%20source%20revision%20is%20ignored**%0A%0AWhen%20a%20maintainer%20reruns%20this%20helper%20after%20upstream%20%60main%60%20changes%2C%20%60snapshot_download%60%20fetches%20the%20new%20files%20while%20the%20generated%20NOTICE%20attributes%20them%20to%20%60UPSTREAM_REVISIONS%5Bsize%5D%60%2C%20causing%20unchecked%20artifacts%20from%20a%20different%20revision%20to%20be%20published%20through%20the%20LibreYOLO%20mirror.%20**How%20this%20was%20verified%3A**%20The%20download%20omits%20the%20available%20revision%20argument%2C%20and%20%60upload_folder%60%20subsequently%20publishes%20that%20staging%20directory%20without%20revision%20or%20digest%20validation.%0A%0A%60%60%60suggestion%0A%20%20%20%20snapshot_download%28%0A%20%20%20%20%20%20%20%20repo_id%3Dupstream%2C%0A%20%20%20%20%20%20%20%20revision%3DUPSTREAM_REVISIONS%5Bsize%5D%2C%0A%20%20%20%20%20%20%20%20local_dir%3Dstr%28out%29%2C%0A%20%20%20%20%20%20%20%20allow_patterns%3DKEEP%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=753&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22mirror%2Fredistributable-weights%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mirror%2Fredistributable-weights%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Fmirror_sam.py%3A116-120%0A**SAM%20source%20revision%20is%20ignored**%0A%0AWhen%20a%20maintainer%20reruns%20this%20helper%20after%20upstream%20%60main%60%20changes%2C%20%60snapshot_download%60%20fetches%20the%20new%20files%20while%20the%20generated%20NOTICE%20attributes%20them%20to%20%60UPSTREAM_REVISIONS%5Bsize%5D%60%2C%20causing%20unchecked%20artifacts%20from%20a%20different%20revision%20to%20be%20published%20through%20the%20LibreYOLO%20mirror.%20**How%20this%20was%20verified%3A**%20The%20download%20omits%20the%20available%20revision%20argument%2C%20and%20%60upload_folder%60%20subsequently%20publishes%20that%20staging%20directory%20without%20revision%20or%20digest%20validation.%0A%0A%60%60%60suggestion%0A%20%20%20%20snapshot_download%28%0A%20%20%20%20%20%20%20%20repo_id%3Dupstream%2C%0A%20%20%20%20%20%20%20%20revision%3DUPSTREAM_REVISIONS%5Bsize%5D%2C%0A%20%20%20%20%20%20%20%20local_dir%3Dstr%28out%29%2C%0A%20%20%20%20%20%20%20%20allow_patterns%3DKEEP%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=753&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review: pin the mirrors..."](https://github.com/libreyolo/libreyolo/commit/dc9dbd92f002bde0fd4b4b8b3aaa449ca3f6c2b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51956342)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/libreyolo/libreyolo/blob/dev/AGENTS.md))

<!-- /greptile_comment -->