### PR TITLE
Default AMP on for G0/G1 training, matching upstream recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,23 @@ before 1.4.0 are documented in the
   Self-supervised encoder pretraining, predictor pretraining and full encoder
   fine-tuning all reject with actionable messages before a dataset is built.
 
+### Changed
+
+- **D-FINE, DEIM, RT-DETRv4 and YOLO-NAS now train with AMP by default**,
+  matching the recipes their upstream projects publish. With those four
+  flipped, every G0 and G1 detection family defaults to `amp=True` with
+  `amp_dtype="float16"` rather than silently training in FP32. D-FINE, DEIM
+  and RT-DETRv4 upstream pass `--use-amp` in every documented training
+  command; the D-FINE decoder's clamp to ±65504 is the FP16-range guard that
+  makes that safe, not evidence that FP32 is required, which is what the
+  previous default assumed. YOLO-NAS upstream trains its released COCO recipe
+  with `mixed_precision: True`. Dome-DETR stays FP32 and now pins `amp=False`
+  explicitly instead of inheriting from D-FINE, because its `dist_train.sh` is
+  the one upstream launcher that omits `--use-amp`; PP-YOLOE and YOLO-NAS OBB
+  keep their existing FP32 defaults. Pass `amp=False` to restore the previous
+  behavior on any family, or `amp_dtype="bfloat16"` for BF16 on Ampere and
+  newer.
+
 ## [1.5.0] - 2026-08-09
 
 The largest release so far: 28 new model families, four new tasks (`edge`,

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -19,6 +19,8 @@ from .nn import LibreDEIMModel
 from ...postprocess.deim import postprocess
 from .utils import preprocess_image, unwrap_deim_checkpoint
 
+_TRAIN_DEFAULTS = DEIMConfig()
+
 
 class LibreDEIM(BaseModel):
     """LibreYOLO wrapper for DEIM.
@@ -205,7 +207,7 @@ class LibreDEIM(BaseModel):
         name: str = "deim_exp",
         exist_ok: bool = False,
         resume: bool = False,
-        amp: bool = False,
+        amp: bool = _TRAIN_DEFAULTS.amp,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
         loggers=None,

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -12,6 +12,7 @@ import torch.nn as nn
 from libreyolo.training.ddp_spawn import ddp_aware
 
 from ...training.callbacks import TrainCallbacks
+from ...training.config import DFINEConfig
 from ...tasks import normalize_task
 from ...utils.image_loader import ImageInput
 from ...validation.preprocessors import DFINEValPreprocessor
@@ -21,6 +22,8 @@ from ...postprocess.dfine import postprocess, postprocess_seg
 from .utils import preprocess_image, unwrap_dfine_checkpoint
 
 logger = logging.getLogger(__name__)
+
+_TRAIN_DEFAULTS = DFINEConfig()
 
 
 class LibreDFINE(BaseModel):
@@ -296,7 +299,7 @@ class LibreDFINE(BaseModel):
         name: str = "dfine_exp",
         exist_ok: bool = False,
         resume: bool = False,
-        amp: bool = False,
+        amp: bool = _TRAIN_DEFAULTS.amp,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
         loggers=None,

--- a/libreyolo/models/domedetr/model.py
+++ b/libreyolo/models/domedetr/model.py
@@ -20,6 +20,8 @@ from ..base import BaseModel
 from .nn import DEFAULT_VARIANT, VARIANT_QUERY_BUDGET, LibreDOMEDETRModel
 from .utils import preprocess_image, unwrap_domedetr_checkpoint
 
+_TRAIN_DEFAULTS = DOMEDETRConfig()
+
 logger = logging.getLogger(__name__)
 
 # The stride-4 encoder projection width is the cheapest size fingerprint:
@@ -292,7 +294,7 @@ class LibreDOMEDETR(BaseModel):
         name: str = "domedetr_exp",
         exist_ok: bool = False,
         resume: bool = False,
-        amp: bool = False,
+        amp: bool = _TRAIN_DEFAULTS.amp,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
         loggers=None,

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -91,7 +91,7 @@ class LibreRTDETRv4(LibreDFINE):
         name: str = _TRAIN_DEFAULTS.name,
         exist_ok: bool = False,
         resume: bool = False,
-        amp: bool = False,
+        amp: bool = _TRAIN_DEFAULTS.amp,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
         loggers=None,

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 from libreyolo.training.ddp_spawn import ddp_aware
 
 from ...training.callbacks import TrainCallbacks
+from ...training.config import YOLONASConfig, YOLONASPoseConfig
 from ..base import BaseModel
 from ...tasks import normalize_task
 from ...utils.image_loader import ImageInput
@@ -698,7 +699,11 @@ class LibreYOLONAS(BaseModel):
         if epochs is None:
             epochs = 1000 if self.task == "pose" else 300
         if amp is None:
-            amp = self.task == "pose"
+            amp = (
+                YOLONASPoseConfig().amp
+                if self.task == "pose"
+                else YOLONASConfig().amp
+            )
 
         if self.task == "pose":
             return self._train_pose(

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -402,9 +402,10 @@ class DFINEConfig(TrainConfig):
     """D-FINE-specific training defaults.
 
     Training is a v1 cut: AdamW with no-wd on norms/biases, flat LR with
-    warmup + cosine tail, hflip-only aug, no mosaic/mixup. AMP off by
-    default — D-FINE's decoder clamps activations to ±65504 (FP16 max)
-    which strongly suggests FP32 is required.
+    warmup + cosine tail, hflip-only aug, no mosaic/mixup. AMP on by
+    default: upstream's official training commands all pass ``--use-amp``,
+    and the decoder's ±65504 clamp is the FP16-range guard that makes that
+    safe (it is not evidence that FP32 is required).
     """
 
     optimizer: str = "adamw"
@@ -448,7 +449,7 @@ class DFINEConfig(TrainConfig):
     mask_match_cost: float = 1.0
     mask_dice_match_cost: float = 1.0
 
-    amp: bool = False
+    amp: bool = True
     epochs: int = 132
     name: str = "dfine_exp"
 
@@ -487,6 +488,10 @@ class DOMEDETRConfig(DFINEConfig):
     defe_density_map_weight: float = 1.0
     density_recall_penalty: float = 0.3
     defe_reg_loss_weight: float = 1.0
+
+    # Upstream's dist_train.sh trains WITHOUT --use-amp (unlike D-FINE), so
+    # Dome-DETR pins fp32 rather than inheriting D-FINE's AMP default.
+    amp: bool = False
 
     epochs: int = 160
     name: str = "domedetr_exp"
@@ -538,7 +543,8 @@ class DEIMConfig(TrainConfig):
     multi_scale: bool = True
     aug_stop_epoch_ratio: float = 0.91
 
-    amp: bool = False
+    # Upstream's official training commands pass --use-amp, same as D-FINE.
+    amp: bool = True
     epochs: int = 132
     name: str = "deim_exp"
 
@@ -944,7 +950,8 @@ class YOLONASConfig(TrainConfig):
     mixup_scale: Tuple[float, float] = (0.5, 1.5)
     shear: float = 0.0
     ema_decay: float = 0.9997
-    amp: bool = False
+    # Upstream's coco2017_yolo_nas_s.yaml trains with mixed_precision: True.
+    amp: bool = True
     name: str = "yolonas_exp"
 
 


### PR DESCRIPTION
## What

Four G0/G1 families trained in FP32 by default. Their upstream projects all train with mixed precision. Flipped to match.

- `dfine` -> `amp=True`. Upstream README passes `--use-amp` in every train command.
- `deim` -> `amp=True`. Same. `rtdetrv4` inherits from `DEIMConfig`.
- `yolonas` -> `amp=True`. Upstream `coco2017_yolo_nas_s.yaml` sets `mixed_precision: True`.
- `domedetr` -> now pins `amp=False` explicitly. Its upstream `dist_train.sh` is the one launcher that omits `--use-amp`, so without the pin it would have silently flipped along with its D-FINE parent.

Result: all 12 G0/G1 families default to `amp=True` with `amp_dtype="float16"`.

## The old D-FINE rationale was backwards

Old docstring: "decoder clamps activations to +/-65504 (FP16 max) which strongly suggests FP32 is required".

Inverted. The clamp is upstream's FP16-range guard, it exists so AMP training works, and upstream passes `--use-amp` everywhere. `deim` and `rtdetrv4` then inherited FP32 from that misreading.

## Second commit: public API was shadowing the config

Caught by Greptile pre-review, confirmed by signature introspection.

The first commit only reached the CLI. `model.train()` hardcoded `amp=False` in the signature for `dfine`, `deim`, `rtdetrv4`, `domedetr`, and `yolonas` resolved `amp=None` to `False` for detect. Those defaults shadowed the config dataclasses, so Python-API users would have kept training FP32 while the changelog advertised AMP.

Signatures now read `_TRAIN_DEFAULTS.amp`, the idiom `yolo9` and `rtdetr` already used. `domedetr` still resolves `False`, now from its config rather than by coincidence.

Already correct, not touched: `deimv2` (its `None` is filtered out so the config wins), `rfdetr`, `rtdetrv2`, `yolo9_p2` (inherit).

## Not in scope

- `ppyoloe` and `yolonas` OBB keep explicit FP32 defaults.
- `rtdetr`/`rtdetrv2` were already AMP-on with deliberate FP32 loss casts, even though upstream `runtime.yml` says `use_amp: False`. Existing engineered behavior, left alone.
- `ec/model.py` hardcodes `amp=True` in two signatures. Currently agrees with `ECConfig`, so not a bug, but it is the same latent-drift pattern. Left for a follow-up.
- AMP/`amp_dtype` are still undocumented in `docs/`. Only discoverable via `--help`. Follow-up owed, ideally on the docs-v2 training page.

## Impact

Behavior change for anyone relying on the old defaults. `amp=False` restores FP32 on any family. `amp_dtype="bfloat16"` selects BF16 (Ampere and newer, no GradScaler).

Prior measurement on `yolonas-s`, 640px, 8x RTX 5060 Ti: BF16 was 1.46x faster with 33% less VRAM than FP32 at the same batch. FP16 was not separately benchmarked.

Does not touch the RF100-VL campaign protocol, which pins its own precision and has published checkpoints at FP32.

## Test

295 unit tests pass: `test_amp_dtype`, all of `tests/unit/cli`, D-FINE / DEIM / DEIMv2 trainer smokes, model registry, YOLO-NAS OBB and OBB training.

Trainer smoke tests pin `amp=False` explicitly, so they were never coupled to the defaults.

Verified by direct signature introspection: dfine/deim/rtdetrv4/rtdetr `train(amp=)` -> `True`, domedetr -> `False`; yolonas detect -> `True`, pose -> `True`, obb -> `False`.

## Code provenance

All code in this PR is original LibreYOLO code. No third-party code was copied, ported, adapted, or derived.

The changes are default values, a corrected docstring, and comments in `libreyolo/training/config.py`; `_TRAIN_DEFAULTS` wiring in five `libreyolo/models/*/model.py` files, following the pattern already present in `libreyolo/models/rtdetr/model.py`; and a CHANGELOG entry.

Upstream projects were consulted for their published training recipes only (which flags and YAML keys their own documented commands use). No source was read into this change:

- D-FINE, https://github.com/Peterande/D-FINE, Apache-2.0: README training commands.
- DEIM, https://github.com/ShihuaHuang95/DEIM, Apache-2.0: README training commands.
- RT-DETRv4, https://github.com/RT-DETRs/RT-DETRv4, Apache-2.0: README training commands.
- Dome-DETR, https://github.com/RicePasteM/Dome-DETR: `dist_train.sh`.
- SuperGradients, https://github.com/Deci-AI/super-gradients, Apache-2.0: `coco2017_yolo_nas_s.yaml`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns mixed-precision defaults with upstream training recipes while preserving Dome-DETR and YOLO-NAS OBB in FP32.

- Enables AMP by default for D-FINE, DEIM, RT-DETRv4, and YOLO-NAS detection.
- Derives public Python training defaults from the corresponding family configuration.
- Explicitly pins Dome-DETR to FP32 and documents the behavior change in the changelog.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defect identified.

The family configuration defaults propagate through the public training methods and matching trainer configuration classes, while Dome-DETR and YOLO-NAS OBB retain their explicit FP32 paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/config.py | Enables AMP for the intended family configurations while explicitly retaining Dome-DETR's FP32 default. |
| libreyolo/models/dfine/model.py | Replaces the stale literal API default with the D-FINE configuration default and forwards it to the trainer. |
| libreyolo/models/deim/model.py | Derives the public DEIM training API's AMP default from DEIMConfig. |
| libreyolo/models/domedetr/model.py | Derives the public default from DOMEDETRConfig, which remains explicitly FP32. |
| libreyolo/models/rtdetrv4/model.py | Exposes RT-DETRv4's inherited DEIM AMP default through the Python training API. |
| libreyolo/models/yolonas/model.py | Resolves detection and pose AMP defaults from their task configurations while leaving the earlier OBB-specific FP32 branch intact. |
| CHANGELOG.md | Documents the affected family defaults, opt-out behavior, and preserved FP32 exceptions. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config[Family TrainConfig amp default] --> API[model.train amp default]
  API --> Trainer[Family trainer config]
  Trainer --> Device{CUDA device?}
  Device -->|Yes and amp=true| AMP[FP16 autocast and GradScaler]
  Device -->|No or amp=false| FP32[Standard precision path]
  DFINE[D-FINE] --> Config
  DEIM[DEIM / RT-DETRv4] --> Config
  YNAS[YOLO-NAS detect] --> Config
  DOME[Dome-DETR amp=false] --> FP32
  OBB[YOLO-NAS OBB amp=false] --> FP32
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Source train() amp defaults from the fam..."](https://github.com/libreyolo/libreyolo/commit/aedbfb413b6ea2fe3d7d4b4549a32243fe357c4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51969086)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)

<!-- /greptile_comment -->