### PR TITLE
Fix the VRAM sizing advice this skill contradicts itself on, and add what four campaigns taught

### DIFF
--- a/skills/run-rf100vl-benchmark/SKILL.md
+++ b/skills/run-rf100vl-benchmark/SKILL.md
@@ -244,20 +244,52 @@ same size, 1.7× apart. Activation memory, cuDNN workspace autotuning,
 allocator behaviour and CUDA-graph static buffers all dominate, and none of
 them follow parameter count.
 
-Measure instead. It costs about a minute per model:
+Measure instead, with a 2-epoch smoke campaign rather than the profiler:
 
 ```bash
-libreyolo profile run <data.yaml> --weights <W> --size <s> \
-  --imgsz 640 --batch 16 --steps 20 --device 0   # prints "peak VRAM"
+va-bench rf100vl-campaign --model <M> --recipe <R> \
+  --datasets <one-dense-dataset> --gpus 0 --jobs-per-gpu 1 --smoke-epochs 2
 ```
 
-Run the probe matrix on the target GPU before committing a campaign, and take
-~20% headroom. The registry's `params_millions`/`gflops` fields are `0.0` for
-most non-flagship specs, so they cannot stand in for this.
+**Do not size a lane with `libreyolo profile run`.** It does not capture CUDA
+graphs and does not run EMA or validation, so it under-reports the real lane.
+It measured yolo9-m at 15721 MB, which looks survivable on a 16 GB card; the
+graphed campaign then OOM'd on **all 100 datasets** with 13.61 GiB sitting in
+graph private pools. The profiler is the right tool for *where time goes*, not
+for how much memory a lane needs.
 
-Being wrong is survivable but not free: the harness falls back to grad-accum
-(keeping effective batch 16) and **restarts that dataset from epoch 0**, so a
-bad guess costs throughput and wasted epochs, not correctness.
+Pick a **dense** dataset for the smoke, not a convenient one. `actions` is
+sparse and gave ec-m 13939 MB; the real campaign peaked at 14787 MB on
+`gwhd2021` (43.6 boxes/image). The three dense outliers are `gwhd2021`,
+`recode-waste`, `uavdet-small`.
+
+Take ~20% headroom. The registry's `params_millions`/`gflops` fields are `0.0`
+for most non-flagship specs, and parameter count does not predict memory
+anyway: yolo9-m at 20.1M needs 15207 MB while yolonas-s at 19.05M needs 7615,
+2x apart at nearly identical size.
+
+Being wrong is survivable but not free: for `rfdetr` the harness falls back to
+grad-accum and **restarts that dataset from epoch 0**. For every other family
+the fallback is not wired up (`_batch_plan` gates it on
+`spec.family == "rfdetr"`), so a mid-run OOM is fatal for that dataset even
+though the scheduler asks for a fallback.
+
+### Packing: decide by utilisation, not by free memory
+
+Two lanes fit is not the same as two lanes help. Run one lane and read
+`utilization.gpu`:
+
+| model | 1 lane VRAM | 1 lane util | verdict |
+|---|---|---|---|
+| ec-s | 7.0 GB | 44% | 2 lanes: **~2x throughput**, second lane nearly free |
+| ec-m | 10.3 GB | ~100% | 1 lane: packing buys nothing, and 2 would not fit |
+| yolonas-s | 9-11 GB | 88-100% | 1 lane |
+
+Measured on ec-s: 78.0 s/epoch alone against 80.3 s with a neighbour, so the
+second lane cost ~2% and doubled the work. On a saturated model there is no
+idle capacity to sell, and packing only adds OOM risk. Sample utilisation over
+30 s or so, because ~20% of each epoch is validation, where a single sample
+legitimately reads 0%.
 
 ### Disk: project it, do not eyeball it
 
@@ -297,7 +329,20 @@ op. Total self-CUDA ≪ total self-CPU ⇒ launch-bound (CUDA graphs).
 **First check that the GPU counters attached at all.** On a rented box where
 CUPTI fails to load, the profiler still prints a full report, but every
 device-side number is zero and the VERDICT line is then an artifact rather
-than a measurement. Measured 2026-08 on an 8x RTX 5060 Ti box:
+than a measurement. The cause is a version mismatch, not a permissions
+problem, so the NVIDIA doc link the error prints is a red herring:
+
+```
+CUPTI initialization failed: CUPTI_ERROR_INVALID_DEVICE (2)
+```
+
+CUPTI has to match the DRIVER, not the toolkit. A Vast host on driver
+595.58.03 (CUDA 13.2) with an sm_120 card meets the `cu128` wheel's bundled
+`nvidia-cuda-cupti-cu12 12.8.90` and cannot enumerate the device. There is no
+cheap fix: `nvidia-cuda-cupti-cu13` on PyPI is a 0.0.1 stub, the image ships
+no system CUPTI, and a real fix needs torch built for CUDA 13. **Rent a host
+whose driver CUDA major matches the wheel's CUPTI major, or accept
+wall-clock-only profiling.** Measured 2026-08 on an 8x RTX 5060 Ti box:
 
 ```
 REAL step 362.3 ms = dataload 0.1 ms + compute 362.3 ms  ->  44.2 img/s
@@ -389,6 +434,13 @@ it, rather than carrying a private patch on the box.
 - **Ctrl-C mid-checkpoint can corrupt `last.pt`** and poison resume for that
   dataset. Stop gracefully: `tmux send-keys -t bench C-c`, wait for the
   orchestrator to exit, then `vastai stop instance` if keeping the box.
+- **`pkill` on live workers does the same thing, and an agent restarting a
+  campaign will reach for it.** One dataset out of 33 came back as a 0.5 MB
+  `last.pt` after a routine restart, and the next attempt died on
+  `PytorchStreamReader ... failed finding central directory`. The recovery is
+  to delete the corrupt file so the dataset restarts clean; the retry pass
+  then picks it up. Worth sweeping every `last.pt` with a `torch.load` after
+  any hard kill, because the corruption is silent until the resume.
 - A **stopped** box bills disk only; restart needs those exact GPUs still
   free. Decide stop-vs-destroy from disk $/day, re-stage cost (~35 min,
   nearly free bandwidth), and whether banked checkpoints are usable
@@ -465,6 +517,20 @@ result, it is a bug report.** Adjacent sizes land ~3 points apart.
 - Package-cleaned data only. Raw Universe exports keep the dummy class and
   score near zero.
 - Dataset named `-grccs`: `--datasets=-grccs` (space form is eaten by argparse).
+  The same leading hyphen breaks any shell tooling you write around the
+  campaign: `grep -qxF "$d"` parses it as options and exits 2, so a cleanup
+  guard written that way fails open and deletes the cache of a dataset that is
+  actively training. Use `grep -qxF -- "$d"`.
+- **Anything that fails at worker startup destroys the most expensive datasets
+  first.** Longest-first scheduling puts the biggest datasets in the opening
+  batch, which is exactly the batch that races on a shared resource. A weight
+  auto-conversion race took out `flir-camera-objects` (8792 images),
+  `paper-parts` (8423) and `underwater-objects` (5253) on every launch, while
+  the small datasets sailed through. If the same names keep failing, suspect
+  startup contention rather than the datasets.
+- **A single `nvidia-smi` sample is not a health check.** Roughly 20% of each
+  epoch is validation, where utilisation legitimately reads 0% while ~12 GB
+  stays allocated. Sample over 30 s, or read epoch progress instead.
 - Never resume after changing physical batch, accumulation, **or recipe
   fields covered by the run signature** (including `cuda_graph` / `cache`).
 - Dense datasets can OOM rfdetr; harness falls back to grad-accum and


### PR DESCRIPTION
Four RF100-VL campaigns ran this week (yolonas-s, yolonas-m, ec-s, ec-m,
yolov9-m). Everything below is measured on an 8x RTX 5060 Ti box.

## The contradiction, which is mine

"Sizing a box: measure VRAM, never predict it" tells you to use
`libreyolo profile run`. The section I added in #739 says that tool
under-reports because it does not capture CUDA graphs. Both are on `dev`
right now.

Sizing now points at a 2-epoch smoke campaign, which exercises the real path
including capture, EMA and validation. And it says to pick a **dense**
dataset: `actions` measured ec-m at 13939 MB, while the real campaign peaked
at **14787 MB** on `gwhd2021`. Choosing a convenient dataset is how a lane
looks safe and then is not.

## Packing: utilisation, not free memory

| model | 1 lane VRAM | 1 lane util | verdict |
|---|---|---|---|
| ec-s | 7.0 GB | 44% | 2 lanes, ~2x throughput |
| ec-m | 10.3 GB | ~100% | 1 lane, packing buys nothing |

ec-s ran 78.0 s/epoch alone and 80.3 s with a neighbour, so the second lane
cost ~2% and doubled the work. Free memory said ec-m could take a second lane
too; utilisation said there was nothing to sell.

## CUPTI

The failure is `CUPTI_ERROR_INVALID_DEVICE`, a driver/CUPTI major mismatch,
not the permissions problem the printed doc link describes. Driver 595.58.03
(CUDA 13.2) plus the `cu128` wheel's CUPTI 12.8 on sm_120. No cheap fix:
`nvidia-cuda-cupti-cu13` is a 0.0.1 stub and the image ships no system CUPTI.

## pkill corrupts last.pt

The skill warns about Ctrl-C. It matters more for `pkill`, because that is
what an agent restarting a campaign reaches for. One dataset in 33 came back
as a 0.5 MB `last.pt` and died on the resume with
`failed finding central directory`. Sweep every `last.pt` with `torch.load`
after a hard kill; the corruption is silent until resume.

## Two more traps

Startup failures destroy the **most expensive** datasets first, because
longest-first puts the biggest ones in the racing batch: a weight-conversion
race took out flir-camera-objects, paper-parts and underwater-objects on every
launch while small datasets sailed through.

A single `nvidia-smi` sample is not a health check; ~20% of each epoch is
validation at 0% utilisation with memory still held.

Also records that the mid-run OOM fallback is gated on
`spec.family == "rfdetr"`, so for every other family an OOM is fatal for that
dataset even though the scheduler asks for a fallback. That one needs a
protocol decision (dropping physical batch changes BatchNorm statistics), so
it is documented here rather than changed.

## Code provenance

Documentation only, no code. Prose written for this PR by me, an AI agent,
from measurements taken on our own RF100-VL campaign boxes this week. Log and
profiler excerpts are output produced by LibreYOLO and the
vision-analysis-benchmark harness on those runs. No third party code or text
was copied or adapted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR replaces profiler-based VRAM sizing with a two-epoch campaign smoke test and records operational lessons about GPU packing, CUPTI failures, checkpoint recovery, startup contention, and monitoring.

- Recommends dense-dataset smoke campaigns for lane sizing.
- Adds utilization-based packing guidance and CUDA graph memory observations.
- Expands failure-recovery and campaign-monitoring guidance.
- Leaves the smoke command’s validation behavior internally inconsistent with the skill’s earlier warning.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation is safe to merge after addressing the non-blocking ambiguity over whether the proposed two-epoch sizing smoke actually runs validation.

The new sizing procedure is internally inconsistent: the skill says short runs require eval_interval=1 to validate, while the replacement command omits it but claims validation is included.

**Files Needing Attention:** skills/run-rf100vl-benchmark/SKILL.md
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| skills/run-rf100vl-benchmark/SKILL.md | Substantially expands RF100-VL operational guidance; the new sizing command needs clarification or an explicit validation interval to support its stated purpose. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Askills%2Frun-rf100vl-benchmark%2FSKILL.md%3A250-251%0A**Clarify%20smoke-test%20validation%20behavior**%0A%0AThe%20skill%20says%20a%20short%20run%20never%20validates%20without%20%60eval_interval%3D1%60%2C%20but%20this%20two-epoch%20sizing%20command%20omits%20that%20setting%20while%20claiming%20to%20exercise%20validation%20memory.%20Add%20the%20required%20validation%20option%20or%20explicitly%20document%20that%20%60--smoke-epochs%60%20overrides%20the%20default%3B%20otherwise%20operators%20cannot%20tell%20whether%20this%20procedure%20measures%20the%20full%20campaign%20path.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=757&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22skill-rf100vl-lessons%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22skill-rf100vl-lessons%22.%0A%0A%23%23%23%20Issue%201%0Askills%2Frun-rf100vl-benchmark%2FSKILL.md%3A250-251%0A**Clarify%20smoke-test%20validation%20behavior**%0A%0AThe%20skill%20says%20a%20short%20run%20never%20validates%20without%20%60eval_interval%3D1%60%2C%20but%20this%20two-epoch%20sizing%20command%20omits%20that%20setting%20while%20claiming%20to%20exercise%20validation%20memory.%20Add%20the%20required%20validation%20option%20or%20explicitly%20document%20that%20%60--smoke-epochs%60%20overrides%20the%20default%3B%20otherwise%20operators%20cannot%20tell%20whether%20this%20procedure%20measures%20the%20full%20campaign%20path.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=757&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix the VRAM sizing advice this skill co..."](https://github.com/libreyolo/libreyolo/commit/bc90c013dccb72dd2fca883fe804acaf6019f5c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52655171)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->