### PR TITLE
Speed up RF-DETR training: fast L1 cost, single-sync criterion, fused AdamW

### DIFF
--- a/libreyolo/models/rfdetr/loss.py
+++ b/libreyolo/models/rfdetr/loss.py
@@ -565,9 +565,12 @@ class SetCriterion(nn.Module):
                 mode="nearest",
             ).squeeze(1)
 
+        # The jit-scripted losses are annotated ``num_masks: float`` (and are
+        # shared with ec/seg_loss.py), while ``num_boxes`` is a 0-dim tensor
+        # here; run them unnormalized and divide outside — identical math.
         losses = {
-            "loss_mask_ce": sigmoid_ce_loss_jit(point_logits, point_labels, num_boxes),
-            "loss_mask_dice": dice_loss_jit(point_logits, point_labels, num_boxes),
+            "loss_mask_ce": sigmoid_ce_loss_jit(point_logits, point_labels, 1.0) / num_boxes,
+            "loss_mask_dice": dice_loss_jit(point_logits, point_labels, 1.0) / num_boxes,
         }
 
         del src_masks
@@ -646,14 +649,17 @@ class SetCriterion(nn.Module):
         if not self.sum_group_losses:
             num_boxes *= group_detr
         num_boxes = torch.as_tensor(
-            [num_boxes],
+            float(num_boxes),
             dtype=torch.float,
             device=next(iter(outputs.values())).device,
         )
         if self.distributed_normalize and is_dist_avail_and_initialized():
             torch.distributed.all_reduce(num_boxes)
             num_boxes = num_boxes / get_world_size()
-        return torch.clamp(num_boxes, min=1).item()
+        # Returned as a 0-dim device tensor rather than ``.item()``: the value
+        # is only ever a divisor, and ``.item()`` here cost one full GPU
+        # pipeline drain per training step.
+        return torch.clamp(num_boxes, min=1)
 
     def forward(self, outputs, targets):
         """This performs the loss computation.
@@ -665,8 +671,23 @@ class SetCriterion(nn.Module):
         group_detr = self.group_detr if self.training else 1
         outputs_without_aux = {k: v for k, v in outputs.items() if k != "aux_outputs"}
 
-        # Retrieve the matching between the outputs of the last layer and the targets
-        indices = self.matcher(outputs_without_aux, targets, group_detr=group_detr)
+        # Match every output level with a single host transfer: build all the
+        # cost matrices on the GPU first (no syncs between levels), then let
+        # the first ``.cpu()`` drain the pipeline once for all of them, then
+        # run the Hungarian solves. This replaces one full GPU drain per
+        # level (main + each aux + enc) with one per step.
+        aux_outputs_list = outputs.get("aux_outputs", [])
+        levels = [outputs_without_aux, *aux_outputs_list]
+        if "enc_outputs" in outputs:
+            levels.append(outputs["enc_outputs"])
+        cost_matrices = [
+            self.matcher.compute_cost_matrix(level, targets) for level in levels
+        ]
+        level_indices = [
+            self.matcher.solve(cost.cpu(), targets, group_detr=group_detr)
+            for cost in cost_matrices
+        ]
+        indices = level_indices[0]
 
         # Training uses the global average box count. Rank-0-only validation
         # selects the local path so it never enters a collective while other
@@ -679,21 +700,20 @@ class SetCriterion(nn.Module):
             losses.update(self.get_loss(loss, outputs, targets, indices, num_boxes))
 
         # In case of auxiliary losses, we repeat this process with the output of each intermediate layer.
-        if "aux_outputs" in outputs:
-            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
-                indices = self.matcher(aux_outputs, targets, group_detr=group_detr)
-                for loss in self.losses:
-                    kwargs = {}
-                    if loss == "labels":
-                        # Logging is enabled only for the last layer
-                        kwargs = {"log": False}
-                    l_dict = self.get_loss(loss, aux_outputs, targets, indices, num_boxes, **kwargs)
-                    l_dict = {k + f"_{i}": v for k, v in l_dict.items()}
-                    losses.update(l_dict)
+        for i, aux_outputs in enumerate(aux_outputs_list):
+            indices = level_indices[1 + i]
+            for loss in self.losses:
+                kwargs = {}
+                if loss == "labels":
+                    # Logging is enabled only for the last layer
+                    kwargs = {"log": False}
+                l_dict = self.get_loss(loss, aux_outputs, targets, indices, num_boxes, **kwargs)
+                l_dict = {k + f"_{i}": v for k, v in l_dict.items()}
+                losses.update(l_dict)
 
         if "enc_outputs" in outputs:
             enc_outputs = outputs["enc_outputs"]
-            indices = self.matcher(enc_outputs, targets, group_detr=group_detr)
+            indices = level_indices[-1]
             for loss in self.losses:
                 kwargs = {}
                 if loss == "labels":

--- a/libreyolo/models/rfdetr/matcher.py
+++ b/libreyolo/models/rfdetr/matcher.py
@@ -173,24 +173,17 @@ class HungarianMatcher(nn.Module):
         return sanitized_cost_matrix
 
     @torch.no_grad()
-    def forward(self, outputs, targets, group_detr=1):
-        """Performs the matching
-        Params:
-            outputs: This is a dict that contains at least these entries:
-                 "pred_logits": Tensor of dim [batch_size, num_queries, num_classes] with the classification logits
-                 "pred_boxes": Tensor of dim [batch_size, num_queries, 4] with the predicted box coordinates
-            targets: This is a list of targets (len(targets) = batch_size), where each target is a dict containing:
-                 "labels": Tensor of dim [num_target_boxes] (where num_target_boxes is the number of ground-truth
-                           objects in the target) containing the class labels
-                 "boxes": Tensor of dim [num_target_boxes, 4] containing the target box coordinates
-                 "masks": Tensor of dim [num_target_boxes, H, W] containing the target mask coordinates
-            group_detr: Number of groups used for matching.
+    def compute_cost_matrix(self, outputs, targets):
+        """Build the pairwise matching cost on the predictions' device.
+
+        Split out from :meth:`forward` so a caller matching several output
+        levels (main + aux + enc) can enqueue every level's cost on the GPU
+        before the first host transfer, paying one pipeline drain instead of
+        one per level (see ``SetCriterion.forward``).
+
         Returns:
-            A list of size batch_size, containing tuples of (index_i, index_j) where:
-                - index_i is the indices of the selected predictions (in order)
-                - index_j is the indices of the corresponding selected targets (in order)
-            For each batch element, it holds:
-                len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+            Cost matrix of dim [batch_size, num_queries, total_num_targets],
+            float32, on the predictions' device.
         """
         bs, num_queries = outputs["pred_logits"].shape[:2]
 
@@ -243,8 +236,11 @@ class HungarianMatcher(nn.Module):
             cls_tgt_ids = map_labels_to_keypoint_schema(tgt_ids, self.num_keypoints_per_class)
         cost_class = pos_cost_class[:, cls_tgt_ids] - neg_cost_class[:, cls_tgt_ids]
 
-        # Compute the L1 cost between boxes
-        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+        # Compute the L1 cost between boxes. The broadcast form is bit-identical
+        # to ``torch.cdist(out_bbox, tgt_bbox, p=1)`` but avoids cdist's slow
+        # one-thread-per-pair p=1 CUDA kernel, which alone cost 15% of all GPU
+        # time in an rfdetr-s training step.
+        cost_bbox = (out_bbox[:, None, :] - tgt_bbox[None, :, :]).abs().sum(-1)
         cost_angle = 0
         if out_angles is not None and tgt_angles is not None and self.cost_angle:
             cost_angle = 1.0 - torch.cos(2.0 * (out_angles[:, None] - tgt_angles[None, :]))
@@ -340,10 +336,21 @@ class HungarianMatcher(nn.Module):
                 + self.keypoint_visible_loss_coef * cost_visible
                 + self.keypoint_nll_loss_coef * cost_nll
             )
-        cost_matrix = (
-            cost_matrix.view(bs, num_queries, -1).float().cpu()
-        )  # convert to float because bfloat16 doesn't play nicely with CPU
+        # convert to float because bfloat16 doesn't play nicely with CPU
+        return cost_matrix.view(bs, num_queries, -1).float()
 
+    def solve(self, cost_matrix, targets, group_detr=1):
+        """Run the Hungarian assignment on a CPU cost matrix.
+
+        Args:
+            cost_matrix: [batch_size, num_queries, total_num_targets] float32
+                CPU tensor from :meth:`compute_cost_matrix` (after ``.cpu()``).
+            targets: Same target list the cost matrix was built from.
+            group_detr: Number of groups used for matching.
+
+        Returns:
+            A list of size batch_size, containing tuples of (index_i, index_j).
+        """
         # We assume any good match will not cause NaN or Inf, so replace invalid
         # entries with a finite value that is larger than every valid cost.
         finite_mask = torch.isfinite(cost_matrix)
@@ -357,6 +364,7 @@ class HungarianMatcher(nn.Module):
                 self._warned_non_finite_costs = True
             cost_matrix = self._sanitize_cost_matrix(cost_matrix)
 
+        num_queries = cost_matrix.shape[1]
         sizes = [len(v["boxes"]) for v in targets]
         indices = []
         g_num_queries = num_queries // group_detr
@@ -375,6 +383,29 @@ class HungarianMatcher(nn.Module):
                     for indice1, indice2 in zip(indices, indices_g)
                 ]
         return [(torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64)) for i, j in indices]
+
+    @torch.no_grad()
+    def forward(self, outputs, targets, group_detr=1):
+        """Performs the matching
+        Params:
+            outputs: This is a dict that contains at least these entries:
+                 "pred_logits": Tensor of dim [batch_size, num_queries, num_classes] with the classification logits
+                 "pred_boxes": Tensor of dim [batch_size, num_queries, 4] with the predicted box coordinates
+            targets: This is a list of targets (len(targets) = batch_size), where each target is a dict containing:
+                 "labels": Tensor of dim [num_target_boxes] (where num_target_boxes is the number of ground-truth
+                           objects in the target) containing the class labels
+                 "boxes": Tensor of dim [num_target_boxes, 4] containing the target box coordinates
+                 "masks": Tensor of dim [num_target_boxes, H, W] containing the target mask coordinates
+            group_detr: Number of groups used for matching.
+        Returns:
+            A list of size batch_size, containing tuples of (index_i, index_j) where:
+                - index_i is the indices of the selected predictions (in order)
+                - index_j is the indices of the corresponding selected targets (in order)
+            For each batch element, it holds:
+                len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+        """
+        cost_matrix = self.compute_cost_matrix(outputs, targets).cpu()
+        return self.solve(cost_matrix, targets, group_detr=group_detr)
 
 
 def build_matcher(args):

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -689,6 +689,23 @@ class RFDETRTrainer(BaseTrainer):
                 self.wrapper_model.num_keypoints = self.config.num_keypoints
                 self.wrapper_model.keypoint_dim = self.config.keypoint_dim
 
+    @staticmethod
+    def _adamw(groups, **kwargs) -> torch.optim.Optimizer:
+        """AdamW, preferring the fused CUDA implementation.
+
+        The fused step is one multi-tensor kernel per dtype instead of the
+        foreach implementation's per-op launches, and under a GradScaler it
+        also consumes the scale/found_inf tensors directly, skipping the
+        per-group unscale pass and its device sync. Measured on rfdetr-s
+        512px b8 fp16: optimizer phase 62 -> 24 ms (1.16x on the whole
+        step). Falls back to the default implementation where fused is
+        unsupported (CPU params, exotic dtypes, older builds).
+        """
+        try:
+            return torch.optim.AdamW(groups, **kwargs, fused=True)
+        except (RuntimeError, ValueError, TypeError):
+            return torch.optim.AdamW(groups, **kwargs)
+
     def _setup_optimizer(self) -> torch.optim.Optimizer:
         if getattr(getattr(self, "wrapper_model", None), "task", "detect") in (
             "classify",
@@ -711,10 +728,10 @@ class RFDETRTrainer(BaseTrainer):
                 groups.append({"params": decay, "weight_decay": self.config.weight_decay})
             if no_decay:
                 groups.append({"params": no_decay, "weight_decay": 0.0})
-            return torch.optim.AdamW(groups, lr=self.effective_lr, betas=(0.9, 0.999))
+            return self._adamw(groups, lr=self.effective_lr, betas=(0.9, 0.999))
         upstream_groups = self._setup_upstream_optimizer_groups()
         if upstream_groups:
-            return torch.optim.AdamW(
+            return self._adamw(
                 upstream_groups,
                 lr=self.effective_lr,
                 weight_decay=self.config.weight_decay,
@@ -753,7 +770,7 @@ class RFDETRTrainer(BaseTrainer):
                 "No trainable parameters remain after layer freezing; "
                 "reduce the freeze value or choose a narrower selector."
             )
-        return torch.optim.AdamW(groups, betas=(0.9, 0.999))
+        return self._adamw(groups, betas=(0.9, 0.999))
 
     def _setup_upstream_optimizer_groups(self) -> list[dict]:
         core_model = getattr(self.model, "model", self.model)
@@ -986,30 +1003,47 @@ class RFDETRTrainer(BaseTrainer):
             value = outputs.get("sem", 0)
             return {"sem": value.item() if isinstance(value, torch.Tensor) else float(value)}
 
-        def _sum_with_prefix(prefix: str) -> float:
-            total = 0.0
-            for key, value in outputs.items():
-                if key == prefix or key.startswith(prefix + "_"):
-                    total += value.item() if isinstance(value, torch.Tensor) else float(value)
-            return total
-
-        components = {
-            "ce": _sum_with_prefix("loss_ce"),
-            "bbox": _sum_with_prefix("loss_bbox"),
-            "giou": _sum_with_prefix("loss_giou"),
-        }
-        if getattr(getattr(self, "wrapper_model", None), "task", "detect") == "segment":
-            components["mask_ce"] = _sum_with_prefix("loss_mask_ce")
-            components["mask_dice"] = _sum_with_prefix("loss_mask_dice")
-        if getattr(getattr(self, "wrapper_model", None), "task", "detect") == "pose":
+        prefixes = {"ce": "loss_ce", "bbox": "loss_bbox", "giou": "loss_giou"}
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task == "segment":
+            prefixes["mask_ce"] = "loss_mask_ce"
+            prefixes["mask_dice"] = "loss_mask_dice"
+        if task == "pose":
             # --- GroupPose keypoint additions (ported from RF-DETR v1.8.0). ---
-            components["keypoints_l1"] = _sum_with_prefix("loss_keypoints_l1")
-            components["keypoints_findable"] = _sum_with_prefix("loss_keypoints_findable")
-            components["keypoints_visible"] = _sum_with_prefix("loss_keypoints_visible")
-            components["keypoints_nll"] = _sum_with_prefix("loss_keypoints_nll")
-        if getattr(getattr(self, "wrapper_model", None), "task", "detect") == "obb":
-            components["angle"] = _sum_with_prefix("loss_angle")
-        return components
+            prefixes["keypoints_l1"] = "loss_keypoints_l1"
+            prefixes["keypoints_findable"] = "loss_keypoints_findable"
+            prefixes["keypoints_visible"] = "loss_keypoints_visible"
+            prefixes["keypoints_nll"] = "loss_keypoints_nll"
+        if task == "obb":
+            prefixes["angle"] = "loss_angle"
+
+        # Sum on device and transfer everything with ONE .cpu() call: the old
+        # per-key ``.item()`` was a dozen GPU pipeline drains every step.
+        tensor_sums: Dict[str, list] = {name: [] for name in prefixes}
+        float_sums = {name: 0.0 for name in prefixes}
+        device = None
+        for key, value in outputs.items():
+            for name, prefix in prefixes.items():
+                if key == prefix or key.startswith(prefix + "_"):
+                    if isinstance(value, torch.Tensor):
+                        tensor_sums[name].append(value.detach().reshape(()))
+                        device = value.device
+                    else:
+                        float_sums[name] += float(value)
+        if device is None:
+            return dict(float_sums)
+        names = list(prefixes)
+        stacked = torch.stack(
+            [
+                torch.stack(tensor_sums[name]).sum()
+                if tensor_sums[name]
+                else torch.zeros((), device=device)
+                for name in names
+            ]
+        ).cpu()
+        return {
+            name: float_sums[name] + float(stacked[i]) for i, name in enumerate(names)
+        }
 
     def _checkpoint_extra_metadata(self) -> Dict:
         if getattr(self.wrapper_model, "task", "detect") != "pose":

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -287,11 +287,15 @@ class MSDeformAttn(nn.Module):
         # Eq(u0, 1)"). The check is a developer sanity check over spatial
         # shapes that are constant for a fixed export canvas, so evaluate it
         # in Python when the shapes are concrete and skip the tensor path.
-        if self._export and input_spatial_shapes_hw is not None:
-            # Export callers already carry the fixed canvas geometry as Python
-            # integer pairs. Validate against those values instead of reading
-            # back from input_spatial_shapes, which creates an unbacked symbol
-            # under strict torch.export capture.
+        if input_spatial_shapes_hw is not None and not isinstance(
+            len_input, torch.Tensor
+        ):
+            # Callers that carry the geometry as Python integer pairs (the
+            # RF-DETR decoder always does) validate against those values: it
+            # avoids the unbacked symbol under strict torch.export capture,
+            # and it avoids the device readback below, which is a full GPU
+            # pipeline drain per decoder layer in eager training
+            # (Tensor.__int__ syncs, invisibly to Python-level profiling).
             expected_len_in = sum(h * w for h, w in input_spatial_shapes_hw)
             assert expected_len_in == len_input, error_msg
         # The int() readback below is a host sync, which CUDA graph capture

--- a/tests/unit/test_rfdetr_train_speedups.py
+++ b/tests/unit/test_rfdetr_train_speedups.py
@@ -1,0 +1,208 @@
+"""Parity tests for the RF-DETR training-speed changes.
+
+Covers: broadcast L1 cost == cdist cost (bitwise), split
+compute_cost_matrix/solve == the one-call forward, the single-sync
+SetCriterion.forward == a per-level matcher reference, tensor num_boxes ==
+float num_boxes, and the fused-AdamW construction fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F  # noqa: N812
+
+from libreyolo.models.rfdetr.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
+from libreyolo.models.rfdetr.loss import SetCriterion
+from libreyolo.models.rfdetr.matcher import HungarianMatcher
+from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+pytestmark = pytest.mark.unit
+
+GROUP_DETR = 3
+NUM_QUERIES = 30 * GROUP_DETR
+NUM_CLASSES = 7
+
+
+def _matcher():
+    return HungarianMatcher(cost_class=2, cost_bbox=5, cost_giou=2, focal_alpha=0.25)
+
+
+def _outputs(bs, generator, num_queries=NUM_QUERIES):
+    return {
+        "pred_logits": torch.randn(bs, num_queries, NUM_CLASSES, generator=generator) * 3,
+        "pred_boxes": torch.rand(bs, num_queries, 4, generator=generator).clamp(1e-3, 1.0),
+    }
+
+
+def _targets(bs, generator, counts=None):
+    targets = []
+    for i in range(bs):
+        n = counts[i] if counts is not None else int(torch.randint(1, 9, (1,), generator=generator))
+        targets.append(
+            {
+                "labels": torch.randint(0, NUM_CLASSES, (n,), generator=generator),
+                "boxes": torch.rand(n, 4, generator=generator).clamp(1e-3, 1.0),
+            }
+        )
+    return targets
+
+
+def _reference_cost(matcher, outputs, targets):
+    """The pre-change cost formula, with torch.cdist for the L1 term."""
+    bs, num_queries = outputs["pred_logits"].shape[:2]
+    flat_logits = outputs["pred_logits"].flatten(0, 1)
+    out_prob = flat_logits.sigmoid()
+    out_bbox = outputs["pred_boxes"].flatten(0, 1)
+    tgt_ids = torch.cat([v["labels"] for v in targets])
+    tgt_bbox = torch.cat([v["boxes"] for v in targets])
+    giou = generalized_box_iou(box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox))
+    alpha, gamma = 0.25, 2.0
+    neg = (1 - alpha) * (out_prob**gamma) * (-F.logsigmoid(-flat_logits))
+    pos = alpha * ((1 - out_prob) ** gamma) * (-F.logsigmoid(flat_logits))
+    cost_class = pos[:, tgt_ids] - neg[:, tgt_ids]
+    cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+    cost = (
+        matcher.cost_bbox * cost_bbox
+        + matcher.cost_class * cost_class
+        + matcher.cost_giou * (-giou)
+    )
+    return cost.view(bs, num_queries, -1).float()
+
+
+def test_broadcast_l1_cost_is_bitwise_identical_to_cdist():
+    generator = torch.Generator().manual_seed(7)
+    matcher = _matcher()
+    for _ in range(5):
+        outputs = _outputs(2, generator)
+        targets = _targets(2, generator)
+        got = matcher.compute_cost_matrix(outputs, targets)
+        ref = _reference_cost(matcher, outputs, targets)
+        assert torch.equal(got, ref)
+
+
+def test_forward_equals_split_cost_and_solve():
+    generator = torch.Generator().manual_seed(11)
+    matcher = _matcher()
+    outputs = _outputs(3, generator)
+    targets = _targets(3, generator)
+    via_forward = matcher(outputs, targets, group_detr=GROUP_DETR)
+    via_split = matcher.solve(
+        matcher.compute_cost_matrix(outputs, targets).cpu(),
+        targets,
+        group_detr=GROUP_DETR,
+    )
+    for (fi, fj), (si, sj) in zip(via_forward, via_split):
+        assert torch.equal(fi, si)
+        assert torch.equal(fj, sj)
+
+
+def _criterion():
+    weight_dict = {"loss_ce": 1, "loss_bbox": 5, "loss_giou": 2}
+    return SetCriterion(
+        NUM_CLASSES,
+        matcher=_matcher(),
+        weight_dict=weight_dict,
+        focal_alpha=0.25,
+        losses=["labels", "boxes", "cardinality"],
+        group_detr=GROUP_DETR,
+    )
+
+
+def _criterion_outputs(bs, generator):
+    outputs = _outputs(bs, generator)
+    outputs["aux_outputs"] = [_outputs(bs, generator) for _ in range(2)]
+    outputs["enc_outputs"] = _outputs(bs, generator)
+    return outputs
+
+
+def _reference_criterion_losses(criterion, outputs, targets):
+    """Per-level matcher calls, float num_boxes: the pre-change control flow."""
+    group_detr = criterion.group_detr if criterion.training else 1
+    outputs_without_aux = {k: v for k, v in outputs.items() if k != "aux_outputs"}
+    indices = criterion.matcher(outputs_without_aux, targets, group_detr=group_detr)
+    num_boxes = float(
+        max(1, sum(len(t["labels"]) for t in targets) * (1 if criterion.sum_group_losses else group_detr))
+    )
+    losses = {}
+    for loss in criterion.losses:
+        losses.update(criterion.get_loss(loss, outputs, targets, indices, num_boxes))
+    for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+        indices = criterion.matcher(aux_outputs, targets, group_detr=group_detr)
+        for loss in criterion.losses:
+            kwargs = {"log": False} if loss == "labels" else {}
+            l_dict = criterion.get_loss(loss, aux_outputs, targets, indices, num_boxes, **kwargs)
+            losses.update({k + f"_{i}": v for k, v in l_dict.items()})
+    enc_outputs = outputs["enc_outputs"]
+    indices = criterion.matcher(enc_outputs, targets, group_detr=group_detr)
+    for loss in criterion.losses:
+        kwargs = {"log": False} if loss == "labels" else {}
+        l_dict = criterion.get_loss(loss, enc_outputs, targets, indices, num_boxes, **kwargs)
+        losses.update({k + "_enc": v for k, v in l_dict.items()})
+    return losses
+
+
+def test_single_sync_criterion_matches_per_level_reference():
+    generator = torch.Generator().manual_seed(13)
+    criterion = _criterion()
+    criterion.train()
+    outputs = _criterion_outputs(2, generator)
+    targets = _targets(2, generator)
+    got = criterion(outputs, targets)
+    ref = _reference_criterion_losses(criterion, outputs, targets)
+    assert set(got.keys()) == set(ref.keys())
+    for key in ref:
+        torch.testing.assert_close(got[key], ref[key], rtol=0, atol=0, msg=key)
+
+
+def test_criterion_eval_path_matches_reference_group1():
+    generator = torch.Generator().manual_seed(17)
+    criterion = _criterion()
+    criterion.eval()
+    outputs = _criterion_outputs(2, generator)
+    targets = _targets(2, generator)
+    got = criterion(outputs, targets)
+    ref = _reference_criterion_losses(criterion, outputs, targets)
+    for key in ref:
+        torch.testing.assert_close(got[key], ref[key], rtol=0, atol=0, msg=key)
+
+
+def test_num_boxes_is_tensor_and_losses_stay_scalar():
+    generator = torch.Generator().manual_seed(19)
+    criterion = _criterion()
+    criterion.train()
+    outputs = _criterion_outputs(1, generator)
+    targets = _targets(1, generator)
+    num_boxes = criterion._box_count_normalizer(outputs, targets, GROUP_DETR)
+    assert isinstance(num_boxes, torch.Tensor)
+    assert num_boxes.dim() == 0
+    losses = criterion(outputs, targets)
+    total = sum(losses[k] * criterion.weight_dict[k] for k in losses if k in criterion.weight_dict)
+    assert total.dim() == 0  # backward() must see a scalar
+
+
+def test_adamw_helper_falls_back_when_fused_unsupported(monkeypatch):
+    param = torch.nn.Parameter(torch.randn(3))
+    real_adamw = torch.optim.AdamW
+    calls = []
+
+    class Picky(real_adamw):
+        def __init__(self, params, **kwargs):
+            calls.append(dict(kwargs))
+            if kwargs.get("fused"):
+                raise RuntimeError("fused not supported here")
+            super().__init__(params, **kwargs)
+
+    monkeypatch.setattr(torch.optim, "AdamW", Picky)
+    opt = RFDETRTrainer._adamw([{"params": [param]}], lr=1e-3, betas=(0.9, 0.999))
+    assert isinstance(opt, real_adamw)
+    assert calls[0].get("fused") is True
+    assert "fused" not in calls[1]
+
+
+def test_adamw_helper_constructs_and_steps():
+    param = torch.nn.Parameter(torch.randn(4))
+    opt = RFDETRTrainer._adamw([{"params": [param]}], lr=1e-3, betas=(0.9, 0.999))
+    (param.sum() ** 2).backward()
+    opt.step()
+    assert param.grad is not None


### PR DESCRIPTION
Profiled rfdetr-s fp16 training end to end; every phase is host-bound (forward 44 ms GPU / 148 ms wall, backward 57/107, optimizer 6/48). Four fixes, same math:

- matcher: torch.cdist(p=1) was 15% of ALL GPU time (16 ms/step, slow one-pair-per-thread kernel); replaced with broadcast |diff|.sum(-1). Bit-identical: test proves cost matrices torch.equal and assignments identical
- criterion: one .cpu() pipeline drain per output level (4/step) -> matcher split into compute_cost_matrix/solve, all levels enqueued on GPU before one drain. num_boxes stays a 0-dim tensor (.item() dropped); per-key loss-logging .item() (12/step) -> single stacked transfer. ~17 hard syncs/step -> ~6
- optimizer: AdamW fused=True with construction fallback. Optimizer phase 62 -> 24 ms; with GradScaler the fused step also skips per-group unscale + found_inf sync
- MSDeformAttn shape assert did int(tensor.sum()) = hidden GPU drain per decoder layer (Tensor.__int__ bypasses Python-level profiling); now validates against the Python (H, W) pairs already threaded through

Measured (rfdetr-s, coco128, 512px, b8, fp16, 5070 Ti, interleaved A/B x3): step 266 -> 234 ms end-to-end; 1.25-1.30x step-only. Convergence sanity: 3-epoch run, loss and mAP normal. 7 new parity tests; rfdetr obb/pose/seg/valloss/gradaccum/domedetr/ec suites green (231 tests)

Findings for the RF100-VL campaign (not in this PR):
- seg matcher path RNG order shifts (point-sample draws reordered); detect is bit-identical
- bf16 measured 4% SLOWER than fp16 on Blackwell consumer cards; keep fp16
- CUDA graphs recapture per multi-scale shape; confirmed net-negative, keep off
- torch.compile works on Windows now (triton-windows): +1.41x total with these fixes, recipe in the session artifact
- stacks with #760 (fused deformable-attn under autocast)

## Code provenance

No new third-party code. Rearrangement of the existing RF-DETR port's control flow plus torch built-ins; matcher/criterion files keep their existing RF-DETR/LW-DETR attribution headers.

https://claude.ai/code/session_01SRWs83fH27APjK5bu3iF7j

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces RF-DETR training synchronization and optimizer overhead while preserving matching and loss behavior.

- Replaces `torch.cdist` L1 matching cost with broadcast subtraction.
- Computes all output-level costs before a consolidated host synchronization.
- Keeps the box-count normalizer on device and batches loss-metric transfer.
- Prefers fused AdamW with construction-time fallback.
- Avoids a tensor-to-Python shape synchronization in deformable attention.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking concern that retaining all output-level cost matrices may cause memory-constrained training runs to exhaust GPU memory.

The mathematical and control-flow changes are supported by focused parity tests, while the criterion synchronization optimization introduces a concrete peak-memory increase whose impact depends on batch size, target count, and available GPU headroom.

**Files Needing Attention:** libreyolo/models/rfdetr/loss.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/rfdetr/loss.py | Consolidates matching synchronization and keeps normalization on device, but concurrently retaining every level's cost matrix increases peak GPU memory. |
| libreyolo/models/rfdetr/matcher.py | Splits cost construction from assignment solving and replaces cdist with parity-tested broadcast L1 computation. |
| libreyolo/models/rfdetr/trainer.py | Adds fused AdamW preference with fallback and consolidates loss-component transfers. |
| libreyolo/models/rfdetr/transformer.py | Uses existing Python spatial-shape metadata to avoid eager tensor readback synchronization. |
| tests/unit/test_rfdetr_train_speedups.py | Adds broad mathematical and control-flow parity tests, although matching allocations are exercised only at small query counts. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Outputs[Main, auxiliary, and encoder outputs] --> Costs[Compute GPU cost matrix for each level]
  Costs --> Retain[Retain all matrices on GPU]
  Retain --> Transfer[Copy matrices to CPU]
  Transfer --> Solve[Hungarian solve per level]
  Solve --> Losses[Compute normalized losses]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20libreyolo%2Flibreyolo%20PR%20%23761%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=761&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Frfdetr%2Floss.py%3A683-685%0A**Cost%20matrices%20raise%20peak%20memory**%0A%0AIf%20a%20training%20batch%20has%20many%20targets%20and%20grouped%20queries%2C%20this%20list%20retains%20four%20to%20seven%20float32%20cost%20matrices%20on%20the%20GPU%20at%20once%2C%20increasing%20peak%20device%20memory%20and%20causing%20memory-constrained%20runs%20to%20exhaust%20GPU%20memory%20during%20matching.%20Consider%20preserving%20the%20single%20synchronization%20without%20retaining%20every%20level's%20device%20matrix%20concurrently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=761&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22rfdetr-train-speed%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22rfdetr-train-speed%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Frfdetr%2Floss.py%3A683-685%0A**Cost%20matrices%20raise%20peak%20memory**%0A%0AIf%20a%20training%20batch%20has%20many%20targets%20and%20grouped%20queries%2C%20this%20list%20retains%20four%20to%20seven%20float32%20cost%20matrices%20on%20the%20GPU%20at%20once%2C%20increasing%20peak%20device%20memory%20and%20causing%20memory-constrained%20runs%20to%20exhaust%20GPU%20memory%20during%20matching.%20Consider%20preserving%20the%20single%20synchronization%20without%20retaining%20every%20level's%20device%20matrix%20concurrently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=761&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Speed up RF-DETR training: fast L1 cost,..."](https://github.com/libreyolo/libreyolo/commit/7267031efa4a730e598106752ba168e3ee676cbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52933813)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->