### PR TITLE
Add North Micro Vision and LFM2.5-VL-3B VLM detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- **North Micro Vision VLM detector.** New `northmicrovision` LibreVLM family
+  (issue #758): `LibreVLM("north-micro-vision")` loads Cohere Labs'
+  North-Micro-Vision-Instruct (2.4B, Apache-2.0, native-resolution) as an
+  open-vocabulary detector. The model answers single-class grounding queries
+  with unlabeled `[[x1, y1, x2, y2], ...]` boxes on a 0-1000 scale and does not
+  follow the tier's labeled-JSON ask, so the family runs one "Locate every
+  <label> ..." generation per vocabulary entry and assigns labels itself
+  (`predict()` cost scales with the vocabulary size; an absent but plausible
+  label can hallucinate a box). Requires transformers >= 5.16.0 (native
+  `CohereCompass` architecture, no remote code); the family fails fast with an
+  install hint on older versions instead of downloading ~5 GB first. `chat()`
+  is supported.
+- **LFM2.5-VL-3B.** The `lfm2-vl` family gains the largest LFM2.5-VL size:
+  `LibreVLM("lfm2-vl-3b")` (LFM Open License v1.0, same one-time notice as the
+  smaller sizes). Unlike the 450M/1.6B, the 3B emits boxes on a 0-1000 scale
+  regardless of the prompt's stated convention, and drifts between `bbox` and
+  Qwen-style `bbox_2d` keys, both verified on known boxes; the family now
+  carries a per-size coordinate divisor and the shared parser falls back
+  across the known box-key aliases.
+
 - **TinyFormer detection.** New trainable `tinyformer` family:
   `LibreYOLO("LibreTinyFormers.pt")` loads the DEIMv2-derived YOLO-DETR hybrid
   from "TinyFormer: Preserving Tiny Objects in YOLO-DETR Hybrid Real-time

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **OCR** | PP-OCR |
 | **Point detection** | FOMO, LocateAnything |
 | **Gaze** | L2CS |
-| **Open vocabulary and VLMs** | Grounding DINO, OWLv2, OmDet-Turbo, OV-DEIM, Florence-2, Kosmos-2, Qwen3-VL, InternVL3, LFM2-VL, SmolVLM2, MODUS |
+| **Open vocabulary and VLMs** | Grounding DINO, OWLv2, OmDet-Turbo, OV-DEIM, Florence-2, Kosmos-2, Qwen3-VL, InternVL3, LFM2-VL, North Micro Vision, SmolVLM2, MODUS |
 
 Per-family sizes, checkpoints and parity evidence live in the
 [model reference](https://www.libreyolo.com/docs/models).

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -64,6 +64,7 @@ in preflight.
 | mobilesam | segment |  |  |  |  |  |  |  |  |  |  |  |  |
 | moge2 | normal | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | available |  |  |  |
 | nafnet | restore | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
+| northmicrovision | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | omdet_turbo | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | ov_deim | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | owlv2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
@@ -1014,6 +1015,18 @@ These converter paths are callable with the recorded validation context.
 - `nafnet` / `restore` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `nafnet` / `restore` / `tflite`: onnx2tf 2.6.7 converts the fixed-canvas graph, but LiteRT 2.1.2 fails at invoke time because input tensor 4539 lacks data.
 - `nafnet` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `northmicrovision` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `paddle`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `mnn`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `rknn`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `northmicrovision` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `omdet_turbo` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `executorch`: Open-vocabulary runtime export is out of scope for v1.

--- a/docs/librevlm_design.md
+++ b/docs/librevlm_design.md
@@ -31,7 +31,8 @@ size marked with `*`. The authoritative alias tables are in
 | Aliases                                      | Family    | License             | Notes                                    |
 |----------------------------------------------|-----------|---------------------|------------------------------------------|
 | `qwen3-vl`, `-2b`, `-4b`*, `-8b`             | Qwen3-VL  | Apache-2.0          | default model; strongest detector here   |
-| `lfm2-vl`, `-450m`*, `-1.6b`                 | LFM2-VL   | LFM Open License v1.0 | edge VLM; non-permissive, logs notice   |
+| `lfm2-vl`, `-450m`*, `-1.6b`, `-3b`          | LFM2-VL   | LFM Open License v1.0 | edge VLM; non-permissive, logs notice   |
+| `north-micro-vision`, `-2.4b`*               | North Micro Vision | Apache-2.0    | Cohere Labs native-resolution VLM; needs transformers>=5.16 |
 | `internvl3`, `-1b`, `-2b`*, `-8b`            | InternVL3 | Qwen License        | Qwen-backbone weights, logs notice; weak small |
 | `florence-2`, `-base`*, `-large`             | Florence-2 | MIT                | small purpose-built detector; tight boxes |
 | `kosmos-2`*                                   | Kosmos-2  | MIT                 | 2023 grounder; loads clean, coarse boxes |
@@ -165,10 +166,12 @@ synthetic image with a known box and read back the numbers. Verified so far:
 | Model      | Box key   | Scale  | Layout | Knobs                                   |
 |------------|-----------|--------|--------|-----------------------------------------|
 | Qwen3-VL   | `bbox_2d` | 0-1000 | xyxy   | `COORD_DIVISOR=1000`                    |
-| LFM2-VL    | `bbox`    | [0, 1] | xyxy   | defaults                                |
+| LFM2-VL 450m/1.6b | `bbox` | [0, 1] | xyxy | defaults                              |
+| LFM2.5-VL-3B | `bbox`/`bbox_2d` | 0-1000 | xyxy | per-size divisor; the 3B keeps its trained 0-1000 scale no matter what the prompt asks, and drifts between the two key names |
 | SmolVLM2   | `bbox`    | [0, 1] | xyxy   | defaults                                |
 | InternVL3  | `bbox`    | 0-1000 | xyxy   | `COORD_DIVISOR=1000` + flatten override |
 | LocateAnything | `bbox` | 0-1000 | xyxy   | remote-code adapter, boxes + points     |
+| North Micro Vision | bare `[[x1,y1,x2,y2], ...]` | 0-1000 | xyxy | per-class grounding queries; labels assigned by the adapter |
 
 Three knobs cover the output variation without touching the parser:
 
@@ -184,9 +187,14 @@ InternVL3 wraps each object's boxes in an extra list, so its family overrides
 `_postprocess` to flatten before the shared builder runs; a grounding-token
 model whose boxes come from a processor `post_process_generation` call overrides
 `_preprocess`/`_forward`/`_postprocess` (Florence-2 and Kosmos-2 do exactly this).
-The tier ships seven distinct families (Qwen3-VL, LFM2-VL, SmolVLM2, InternVL3,
-Florence-2, Kosmos-2, LocateAnything) spanning all three integration styles,
-confirming it is
+North Micro Vision is a fourth style: a chat model that refuses labeled-JSON
+output but grounds single-class queries extremely well, so its family runs one
+"Locate every <label> ..." generation per vocabulary entry and assigns the
+labels itself (which also means `predict()` cost scales with the vocabulary
+size, and a query for an absent but plausible label can hallucinate a box).
+The tier ships eight distinct families (Qwen3-VL, LFM2-VL, SmolVLM2, InternVL3,
+Florence-2, Kosmos-2, LocateAnything, North Micro Vision) spanning all these
+integration styles, confirming it is
 genuinely model-agnostic. Detection *quality* varies a lot by model and size
 (Qwen3-VL, LFM2-VL, and Florence-2 are the strong ones); the framework is what is
 general, not every model's accuracy.

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -194,6 +194,7 @@ def __getattr__(name):
         "LibreFlorence2": (".models.vlm", "LibreFlorence2"),
         "LibreKosmos2": (".models.vlm", "LibreKosmos2"),
         "LibreLocateAnything": (".models.vlm", "LibreLocateAnything"),
+        "LibreNorthMicroVision": (".models.vlm", "LibreNorthMicroVision"),
         "LibreSenseNovaVision": (".models.sensenova", "LibreSenseNovaVision"),
         "LibreMODUS": (".models.modus", "LibreMODUS"),
         "LibreModus": (".models.modus", "LibreModus"),
@@ -322,6 +323,7 @@ __all__ = [
     "LibreFlorence2",
     "LibreKosmos2",
     "LibreLocateAnything",
+    "LibreNorthMicroVision",
     "LibreMODUS",
     "LibreModus",
     # Promptable-segmentation tier (optional, requires libreyolo[sam])

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -3704,6 +3704,7 @@ _FAMILY_BLOCKS = {
     "qwen3vl": "Generative VLM export is out of scope for v1.",
     "smolvlm2": "Generative VLM export is out of scope for v1.",
     "locateanything": "Generative VLM export is out of scope for v1.",
+    "northmicrovision": "Generative VLM export is out of scope for v1.",
 }
 
 _NCNN_BLOCKS = {

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -32,6 +32,12 @@ OPTIONAL_MODELS = (
         "vlm",
         "transformers",
     ),
+    (
+        "libreyolo.models.vlm.northmicro",
+        "LibreNorthMicroVision",
+        "vlm",
+        "transformers",
+    ),
     ("libreyolo.models.vlm.qwen3vl", "LibreQwen3VL", "vlm", "transformers"),
     ("libreyolo.models.vlm.smolvlm", "LibreSmolVLM2", "vlm", "transformers"),
     (

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -114,6 +114,7 @@ MODEL_GROUPS: dict[str, str] = {
     "internvl3": "s",
     "lfm2vl": "s",
     "locateanything": "s",
+    "northmicrovision": "s",
     "qwen3vl": "s",
     "smolvlm2": "s",
     "clip": "s",

--- a/libreyolo/models/vlm/__init__.py
+++ b/libreyolo/models/vlm/__init__.py
@@ -25,6 +25,7 @@ from .internvl3 import LibreInternVL3
 from .kosmos2 import LibreKosmos2
 from .lfm2 import LibreLFM2VL
 from .locateanything import LibreLocateAnything
+from .northmicro import LibreNorthMicroVision
 from .qwen3vl import LibreQwen3VL
 from .smolvlm import LibreSmolVLM2
 
@@ -37,6 +38,10 @@ _ALIASES: Dict[str, Tuple[Type[LibreVLMModel], str]] = {
     "lfm2-vl": (LibreLFM2VL, "450m"),
     "lfm2-vl-450m": (LibreLFM2VL, "450m"),
     "lfm2-vl-1.6b": (LibreLFM2VL, "1.6b"),
+    "lfm2-vl-3b": (LibreLFM2VL, "3b"),
+    "north-micro-vision": (LibreNorthMicroVision, "2.4b"),
+    "north-micro-vision-2.4b": (LibreNorthMicroVision, "2.4b"),
+    "northmicrovision": (LibreNorthMicroVision, "2.4b"),
     "internvl3": (LibreInternVL3, "2b"),
     "internvl3-1b": (LibreInternVL3, "1b"),
     "internvl3-2b": (LibreInternVL3, "2b"),
@@ -128,6 +133,7 @@ __all__ = [
     "LibreFlorence2",
     "LibreKosmos2",
     "LibreLocateAnything",
+    "LibreNorthMicroVision",
     "LibreSenseNovaVision",
     "LibreMODUS",
     "LibreModus",

--- a/libreyolo/models/vlm/lfm2.py
+++ b/libreyolo/models/vlm/lfm2.py
@@ -1,8 +1,9 @@
 """LibreYOLO wrapper for Liquid AI's LFM2-VL vision-language models.
 
-LFM2.5-VL is a compact (450M) on-device VLM with a native object-detection
-prompt that returns ``[{"label", "bbox": [x1, y1, x2, y2]}]`` with coordinates
-normalized to ``[0, 1]``. This family wraps it so it behaves like any LibreYOLO
+LFM2.5-VL is a compact on-device VLM family (450M to 3B) with a native object-detection
+prompt that returns ``[{"label", "bbox": [x1, y1, x2, y2]}]``. The coordinate
+scale is size-dependent: [0, 1] on the 450M/1.6B, 0-1000 on the 3B (see
+``_COORD_DIVISORS``). This family wraps it so it behaves like any LibreYOLO
 detector.
 
 Licensing note: LFM2-VL weights are published under the LFM Open License v1.0,
@@ -21,6 +22,15 @@ from .base import LibreVLMModel
 
 _LFM_LICENSE_URL = "https://www.liquid.ai/lfm-license"
 
+_PROMPT_1000 = (
+    "Detect all instances of: {labels}. "
+    "Response must be a JSON array: "
+    '[{{"label": ..., "bbox": [x1, y1, x2, y2]}}, ...]. '
+    "Coordinates are on a 0-1000 scale relative to the image. "
+    "Only include objects that are actually visible; if there are none, "
+    "respond with an empty array []."
+)
+
 
 class LibreLFM2VL(LibreVLMModel):
     """Liquid AI LFM2-VL repurposed as a closed-set object detector."""
@@ -28,16 +38,29 @@ class LibreLFM2VL(LibreVLMModel):
     FAMILY = "lfm2vl"
     FILENAME_PREFIX = "LibreLFM2VL"
 
-    # LFM2.5-VL family (latest). 450m = smallest, 1.6b = larger variant.
+    # LFM2.5-VL family (latest). 450m = smallest, 3b = largest.
     HF_REPOS: ClassVar[Dict[str, str]] = {
         "450m": "LiquidAI/LFM2.5-VL-450M",
         "1.6b": "LiquidAI/LFM2.5-VL-1.6B",
+        "3b": "LiquidAI/LFM2.5-VL-3B",
     }
     # Nominal input size: the LFM2-VL processor owns the real (native-resolution)
     # resize, so this value is only used as the runner's default ``imgsz``.
     INPUT_SIZES: ClassVar[Dict[str, int]] = {
         "450m": 512,
         "1.6b": 512,
+        "3b": 512,
+    }
+
+    # The 450M and 1.6B emit ``bbox`` normalized to [0, 1]; the 3B was trained
+    # on 0-1000 grounding boxes and emits that scale no matter which convention
+    # the prompt asks for (verified empirically on a known box: px
+    # [200,150,400,300] of 800x600 comes back as ~[250,250,500,500]).
+    # COORD_DIVISOR is a ClassVar, so the 3B shadows it per instance.
+    _COORD_DIVISORS: ClassVar[Dict[str, float]] = {
+        "450m": 1.0,
+        "1.6b": 1.0,
+        "3b": 1000.0,
     }
 
     _LICENSE_NOTICE = (
@@ -50,3 +73,14 @@ class LibreLFM2VL(LibreVLMModel):
         f"  {_LFM_LICENSE_URL}\n"
         "----------------------------------------------------------------\n"
     )
+
+    def __init__(self, size: str, **kwargs):
+        divisor = self._COORD_DIVISORS.get(size, 1.0)
+        if divisor != 1.0:
+            self.COORD_DIVISOR = divisor
+        super().__init__(size, **kwargs)
+
+    def _format_detection_prompt(self, labels: str) -> str:
+        if self.COORD_DIVISOR == 1000.0:
+            return _PROMPT_1000.format(labels=labels)
+        return super()._format_detection_prompt(labels)

--- a/libreyolo/models/vlm/northmicro.py
+++ b/libreyolo/models/vlm/northmicro.py
@@ -1,0 +1,155 @@
+"""LibreYOLO wrapper for Cohere Labs' North Micro Vision VLM.
+
+North Micro Vision (``CohereLabs/North-Micro-Vision-Instruct``, Apache-2.0) is
+a 2.4B native-resolution VLM: a 400M vision encoder over a 2B North Micro LLM,
+with grounding trained on boxes normalized to ``[x1, y1, x2, y2]`` on a 0-1000
+scale.
+
+It does not follow the tier's labeled-JSON detection ask: prompted for
+``[{"label", "bbox"}]`` objects it answers with bare box arrays (or ``[]``),
+matching its RefCOCO-style grounding training. So this family queries one class
+per generation ("Locate every <label> ...") and assigns the label itself,
+overriding ``_preprocess``/``_forward``/``_postprocess`` like the other
+non-chat-format families. Cost: ``predict()`` runs one generation per
+vocabulary entry, so keep ``set_classes()`` lists short; a query for an absent
+but plausible label can hallucinate a box (RefCOCO-style grounders always try
+to point at something).
+
+The architecture (``CohereCompassForConditionalGeneration``) is native to
+transformers from 5.16.0 (no remote code), so this family fails fast with an
+install hint on older transformers instead of downloading ~5 GB of weights and
+then crashing on an unknown ``model_type``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, Tuple
+
+from ...utils.image_loader import ImageInput, ImageLoader
+from .base import LibreVLMModel
+from .parsing import build_detection_dict, extract_bare_boxes
+
+_MIN_TRANSFORMERS = (5, 16)
+_VERSION_HINT = (
+    "North Micro Vision requires transformers>=5.16.0 (the CohereCompass "
+    "architecture). Upgrade with:\n"
+    "    pip install -U 'transformers>=5.16.0'\n"
+    "or, until 5.16.0 is on PyPI:\n"
+    "    pip install git+https://github.com/huggingface/transformers"
+)
+
+
+class _ImageCarrier:
+    """Wraps the loaded PIL image with the ``.to(device)`` no-op the shared
+    ``InferenceRunner`` calls on every ``_preprocess`` output. Tokenization
+    happens per class inside ``_forward``, so there is nothing to move yet."""
+
+    def __init__(self, img):
+        self.img = img
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+def _require_transformers() -> None:
+    """Fail before the snapshot download if transformers cannot load the model."""
+    import transformers
+
+    parts = transformers.__version__.split(".")
+    try:
+        version = (int(parts[0]), int(parts[1]))
+    except (IndexError, ValueError):  # exotic dev version string: let it try
+        return
+    if version < _MIN_TRANSFORMERS:
+        raise ImportError(
+            f"{_VERSION_HINT}\n(found transformers {transformers.__version__})"
+        )
+
+
+class LibreNorthMicroVision(LibreVLMModel):
+    """North Micro Vision repurposed as a closed-set object detector."""
+
+    FAMILY = "northmicrovision"
+    FILENAME_PREFIX = "LibreNorthMicroVision"
+
+    HF_REPOS: ClassVar[Dict[str, str]] = {
+        "2.4b": "CohereLabs/North-Micro-Vision-Instruct",
+    }
+    # Nominal only; the processor owns the real native-resolution handling.
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {
+        "2.4b": 1024,
+    }
+
+    # Boxes come back on a 0-1000 scale (verified empirically on a known box:
+    # px [200,150,400,300] of 800x600 comes back as ~[250,245,518,508]).
+    COORD_DIVISOR = 1000.0
+
+    # Per-class grounding ask. This is the phrasing the model actually follows;
+    # it answers with ``[[x1, y1, x2, y2], ...]`` (no labels) or with a prose
+    # refusal when the class is absent, which parses to zero boxes.
+    _CLASS_PROMPT = (
+        "Locate every {label} in the image and output the bounding boxes in "
+        "JSON format: [[x1, y1, x2, y2], ...]. "
+        "Coordinates are on a 0-1000 scale."
+    )
+
+    # Apache-2.0 weights: no restrictive-license notice needed.
+    _LICENSE_NOTICE = ""
+
+    def __init__(self, size: str, **kwargs):
+        _require_transformers()
+        super().__init__(size, **kwargs)
+
+    def _class_prompt(self, label: str) -> str:
+        # ``prompt=`` acts as a per-class template here; a ``{label}``
+        # placeholder is substituted, a literal prompt is used as-is.
+        template = self._custom_prompt or self._CLASS_PROMPT
+        return template.format(label=label) if "{label}" in template else template
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size=None,
+    ) -> Tuple[Any, Any, Tuple[int, int], float]:
+        # Generation happens once per class, so tokenization is deferred to
+        # ``_forward``; the "model input" is the loaded image itself.
+        img = ImageLoader.load(image, color_format=color_format)
+        return _ImageCarrier(img), img, img.size, 1.0
+
+    def _forward(self, inputs: Any) -> Any:
+        # One grounding query per vocabulary entry; the label is assigned by
+        # the caller, not parsed from the generated text.
+        return [
+            (class_id, self.chat(inputs.img, self._class_prompt(label)))
+            for class_id, label in sorted(self.names.items())
+        ]
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        items = [
+            {"label": self.names[class_id], "bbox": box}
+            for class_id, text in output
+            for box in extract_bare_boxes(text)
+        ]
+        return build_detection_dict(
+            items,
+            self._name_to_id,
+            original_size,
+            conf_thres=conf_thres,
+            max_det=max_det,
+            classes=kwargs.get("classes"),
+            default_score=self._score_detections(items),
+            bbox_key=self.BBOX_KEY,
+            coord_divisor=self.COORD_DIVISOR,
+            box_format=self.BOX_FORMAT,
+            iou_thres=iou_thres,
+        )

--- a/libreyolo/models/vlm/parsing.py
+++ b/libreyolo/models/vlm/parsing.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional, Tuple
 
 __all__ = [
     "extract_detections",
+    "extract_bare_boxes",
     "normalize_bbox",
     "to_xyxy",
     "resolve_label",
@@ -136,6 +137,25 @@ def extract_detections(text: str) -> List[dict]:
     if fallback is not None:
         return fallback
     return recovered
+
+
+_BARE_QUAD = re.compile(
+    r"\[\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,"
+    r"\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\]"
+)
+
+
+def extract_bare_boxes(text: str) -> List[List[float]]:
+    """Extract unlabeled ``[x1, y1, x2, y2]`` quads from model text.
+
+    For grounding-style models (North Micro Vision) that answer a single-class
+    query with ``[[x1, y1, x2, y2], ...]``, a flat ``[x1, y1, x2, y2]``, or
+    newline-separated quads, never with labeled objects. A prose refusal ("No
+    dogs are present ...") contains no numeric quad and maps to zero boxes.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return []
+    return [[float(v) for v in match] for match in _BARE_QUAD.findall(text)]
 
 
 def normalize_bbox(bbox) -> Optional[Tuple[float, float, float, float]]:
@@ -263,6 +283,15 @@ def build_detection_dict(
         if allowed_classes is not None and class_id not in allowed_classes:
             continue
         raw = item.get(bbox_key)
+        if raw is None:
+            # Generative models drift between key conventions even within one
+            # family (LFM2.5-VL-3B emits "bbox" on synthetic scenes but
+            # Qwen-style "bbox_2d" on natural photos), so fall back to the
+            # known aliases. The family's coord_divisor still applies.
+            for alt in ("bbox", "bbox_2d"):
+                if alt != bbox_key and alt in item:
+                    raw = item[alt]
+                    break
         box = None
         if isinstance(raw, (list, tuple)) and len(raw) == 4:
             try:

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -864,11 +864,13 @@
     "default_task": "detect",
     "sizes": {
       "450m": 512,
-      "1.6b": 512
+      "1.6b": 512,
+      "3b": 512
     },
     "default_imgsz": {
       "450m": 512,
-      "1.6b": 512
+      "1.6b": 512,
+      "3b": 512
     },
     "task_sizes": {},
     "export_override": "blocked",
@@ -1072,6 +1074,24 @@
     "optional_extra": null,
     "available": true,
     "group": "g2"
+  },
+  "northmicrovision": {
+    "class": "libreyolo.models.vlm.northmicro.LibreNorthMicroVision",
+    "tasks": [
+      "detect"
+    ],
+    "default_task": "detect",
+    "sizes": {
+      "2.4b": 1024
+    },
+    "default_imgsz": {
+      "2.4b": 1024
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": "vlm",
+    "available": true,
+    "group": null
   },
   "omdet_turbo": {
     "class": "libreyolo.models.openvocab.omdet_turbo.LibreOMDetTurbo",

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -1091,7 +1091,7 @@
     "export_override": "blocked",
     "optional_extra": "vlm",
     "available": true,
-    "group": null
+    "group": "s"
   },
   "omdet_turbo": {
     "class": "libreyolo.models.openvocab.omdet_turbo.LibreOMDetTurbo",

--- a/tests/unit/test_vlm_api.py
+++ b/tests/unit/test_vlm_api.py
@@ -81,8 +81,14 @@ class TestFactoryResolution:
 
         assert _ALIASES["qwen3-vl-8b"] == (LibreQwen3VL, "8b")
         assert _ALIASES["lfm2-vl-450m"] == (LibreLFM2VL, "450m")
+        assert _ALIASES["lfm2-vl-3b"] == (LibreLFM2VL, "3b")
         assert _ALIASES["smolvlm2"] == (LibreSmolVLM2, "2.2b")
         assert _ALIASES["locate-anything"] == (LibreLocateAnything, "3b")
+
+        from libreyolo.models.vlm.northmicro import LibreNorthMicroVision
+
+        assert _ALIASES["north-micro-vision"] == (LibreNorthMicroVision, "2.4b")
+        assert _ALIASES["north-micro-vision-2.4b"] == (LibreNorthMicroVision, "2.4b")
 
         from libreyolo.models.vlm.internvl3 import LibreInternVL3
 
@@ -100,6 +106,45 @@ class TestFactoryResolution:
         # Raises during resolution, before any model download/load.
         with pytest.raises(ValueError):
             LibreVLM("definitely-not-a-real-model")
+
+
+class TestLFM2CoordinateConvention:
+    """The 3B emits 0-1000 boxes; smaller sizes emit [0, 1] (offline)."""
+
+    def test_3b_shadows_divisor_and_prompt(self):
+        from libreyolo.models.vlm.lfm2 import LibreLFM2VL
+
+        assert LibreLFM2VL._COORD_DIVISORS["3b"] == 1000.0
+        assert LibreLFM2VL.COORD_DIVISOR == 1.0  # class default untouched
+
+        m = object.__new__(LibreLFM2VL)
+        m.COORD_DIVISOR = 1000.0
+        assert "0-1000 scale" in m._format_detection_prompt("boat")
+
+        small = object.__new__(LibreLFM2VL)  # falls back to the class attr
+        assert "[0,1]" in small._format_detection_prompt("boat")
+
+
+class TestNorthMicroTransformersGuard:
+    """North Micro Vision fails fast on transformers < 5.16 (offline)."""
+
+    def test_old_transformers_raises_with_hint(self, monkeypatch):
+        transformers = pytest.importorskip("transformers")
+        from libreyolo.models.vlm import northmicro
+
+        monkeypatch.setattr(transformers, "__version__", "5.15.0")
+        with pytest.raises(ImportError, match="transformers>=5.16.0"):
+            northmicro._require_transformers()
+
+    def test_new_transformers_passes(self, monkeypatch):
+        transformers = pytest.importorskip("transformers")
+        from libreyolo.models.vlm import northmicro
+
+        monkeypatch.setattr(transformers, "__version__", "5.16.0")
+        northmicro._require_transformers()
+        # dev builds of the next minor also pass
+        monkeypatch.setattr(transformers, "__version__", "5.16.0.dev0")
+        northmicro._require_transformers()
 
 
 class TestSnapshotComplete:

--- a/tests/unit/test_vlm_parsing.py
+++ b/tests/unit/test_vlm_parsing.py
@@ -285,10 +285,48 @@ class TestToXyxy:
         assert det["boxes"][0] == [300.0, 250.0, 600.0, 750.0]
         assert det["classes"][0] == 8
 
-    def test_bbox_key_mismatch_drops_item(self):
-        # With bbox_key="bbox_2d", a plain "bbox" item has no usable box.
-        items = [{"label": "ship", "bbox": [0.1, 0.1, 0.2, 0.2]}]
+    def test_bbox_key_mismatch_falls_back_to_alias_key(self):
+        # Generative models drift between key conventions (LFM2.5-VL-3B emits
+        # "bbox" on synthetic scenes but "bbox_2d" on photos), so a missing
+        # bbox_key falls back to the known alias keys, same divisor.
+        items = [{"label": "ship", "bbox_2d": [100, 100, 200, 200]}]
         det = build_detection_dict(
-            items, NAME_TO_ID, (100, 100), bbox_key="bbox_2d", coord_divisor=1000.0
+            items, NAME_TO_ID, (1000, 1000), bbox_key="bbox", coord_divisor=1000.0
         )
-        assert det["num_detections"] == 0
+        assert det["num_detections"] == 1
+        assert det["boxes"][0] == [100.0, 100.0, 200.0, 200.0]
+
+    def test_bbox_key_still_preferred_over_alias(self):
+        items = [{"label": "ship", "bbox": [0.1, 0.1, 0.2, 0.2], "bbox_2d": [900, 900, 990, 990]}]
+        det = build_detection_dict(items, NAME_TO_ID, (100, 100), bbox_key="bbox")
+        assert det["num_detections"] == 1
+        assert det["boxes"][0] == [10.0, 10.0, 20.0, 20.0]
+
+
+class TestExtractBareBoxes:
+    """Unlabeled-quad extraction for grounding-style output (North Micro Vision)."""
+
+    def test_nested_arrays(self):
+        from libreyolo.models.vlm.parsing import extract_bare_boxes
+
+        text = "[[21, 121, 487, 987], [533, 40, 999, 778]]"
+        assert extract_bare_boxes(text) == [
+            [21.0, 121.0, 487.0, 987.0],
+            [533.0, 40.0, 999.0, 778.0],
+        ]
+
+    def test_flat_quad_and_lines(self):
+        from libreyolo.models.vlm.parsing import extract_bare_boxes
+
+        assert extract_bare_boxes("[54, 135, 278, 253]\n[524, 155, 599, 393]") == [
+            [54.0, 135.0, 278.0, 253.0],
+            [524.0, 155.0, 599.0, 393.0],
+        ]
+
+    def test_prose_refusal_and_empty(self):
+        from libreyolo.models.vlm.parsing import extract_bare_boxes
+
+        assert extract_bare_boxes("No dogs are present in this image.") == []
+        assert extract_bare_boxes("[]") == []
+        assert extract_bare_boxes("") == []
+        assert extract_bare_boxes(None) == []


### PR DESCRIPTION
What: North Micro Vision and LFM2.5-VL-3B in the LibreVLM tier (issue #758).
Why: requested small open VLMs; both verified on real images before merging.

- New `northmicrovision` family: `LibreVLM("north-micro-vision")` loads CohereLabs/North-Micro-Vision-Instruct (2.4B, Apache-2.0). The model refuses the tier's labeled-JSON ask (returns bare `[[x1,y1,x2,y2],...]` on 0-1000, or `[]`), so the family runs one "Locate every <label> ..." grounding query per vocabulary entry and assigns labels itself; new `extract_bare_boxes` helper in the shared parser. `chat()` supported.
- North Micro Vision needs transformers>=5.16.0 (native `CohereCompass`, no remote code; today that means transformers git main). The family raises a clear install hint BEFORE the ~5 GB snapshot download; offline unit test covers the guard.
- `lfm2-vl-3b` size added to the existing `lfm2vl` family (LiquidAI/LFM2.5-VL-3B, same LFM Open License v1.0 notice).
- Coordinate conventions verified empirically on a known box (per the design doc rule): the 3B emits 0-1000 whatever scale the prompt asks (450m/1.6b stay [0,1]) and drifts between `bbox`/`bbox_2d` keys. Family got per-size `_COORD_DIVISORS`; `build_detection_dict` now falls back across the known box-key aliases (unit-tested).
- Real-image verification on CUDA: NMV finds 3/3 people (parkour), building + bridge + 6 streetlights (guggenheim), 2/2 cats + 2/2 remotes (COCO 39769), synthetic known-box round-trips within ~2 px. LFM 3B same suite: correct boxes, fewer recalls (model quality). Annotated `save=True` outputs inspected.
- Known limitation (documented): NMV `predict()` runs one generation per class, and an absent-but-plausible label can hallucinate a box (RefCOCO-style grounder).
- Registry/inventory wiring: aliases, top-level lazy exports, `MODEL_GROUPS`, `models/inventory.py`, export out-of-scope notes; `reports/export_inventory.json` and `docs/export_support.md` regenerated. CHANGELOG + design doc updated.
- Tests: 6034 unit tests pass; only failures are 3 openvino/ncnn runtime-parity tests that fail identically on clean dev in this environment (pre-existing). LFM 450m e2e smoke passes (no family regression).

Check: the `build_detection_dict` box-key fallback (shared parser behavior change, one test updated to match); NMV per-class `_forward` reusing `chat()`.
Not verified: NMV behavior on transformers 5.16.0 stable (unreleased; tested on git main @ 5.16.0.dev0); LFM 3B on CPU (tested CUDA bf16 only).
Opened by an agent.

## Code provenance

All adapter code in this PR (northmicro.py, lfm2.py changes, parsing helpers, tests, docs) is original code written for this PR against the existing LibreVLM base. No upstream model code is copied or vendored: both models load through the Apache-2.0 transformers API with trust_remote_code disabled, and no weights are redistributed (runtime download from the upstream Hugging Face repos under their own terms: Apache-2.0 for North Micro Vision, LFM Open License v1.0 with the existing one-time notice for LFM2.5-VL). No GPL/AGPL/LGPL/non-commercial/unknown-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds North Micro Vision as a new per-class grounding VLM and introduces the LFM2.5-VL-3B size with its model-specific coordinate convention.

- Wires North Micro Vision through aliases, lazy exports, inventory, registry, and export-support metadata.
- Adds bare bounding-box parsing and fallback between known generated box-key aliases.
- Adds tests and documentation for model loading, parsing, coordinate scaling, and unsupported exports.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code defect or security issue remains.

The new family satisfies the shared VLM inference contract, its aliases and lazy imports are consistently wired, and the LFM parser changes preserve correct per-size coordinate scaling for all current callers.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/vlm/northmicro.py | Implements the new North Micro family with fail-fast dependency validation, per-class grounding generations, and conversion to the shared detection contract. |
| libreyolo/models/vlm/lfm2.py | Adds the 3B checkpoint and selects its 0–1000 prompt and coordinate divisor without affecting smaller model instances. |
| libreyolo/models/vlm/parsing.py | Adds bare-box extraction and bounded fallback across generated bbox key aliases while preserving the caller’s scale contract. |
| libreyolo/models/vlm/__init__.py | Registers the new family aliases and lazy class export. |
| libreyolo/export/support.py | Enrolls North Micro Vision as a generative VLM with all graph export formats explicitly blocked. |
| tests/unit/test_vlm_api.py | Covers new alias resolution and the pre-download transformers version guard. |
| tests/unit/test_vlm_parsing.py | Covers bare-box extraction, key fallback precedence, and coordinate scaling. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[LibreVLM alias] --> B{VLM family}
  B -->|North Micro Vision| C[Load image]
  C --> D[One grounding generation per class]
  D --> E[Extract bare box arrays]
  B -->|LFM2.5-VL| F[Single labeled JSON generation]
  F --> G[Resolve bbox or bbox_2d]
  E --> H[Normalize with 1000 divisor]
  G --> I[Normalize with per-size divisor]
  H --> J[LibreYOLO detection Results]
  I --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Enroll northmicrovision in MODEL\_GROUPS ..."](https://github.com/libreyolo/libreyolo/commit/3135e9670bce5b5300aafd56264a7c8bc61f2bb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53116071)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)

<!-- /greptile_comment -->