### PR TITLE
Training-speed quick wins across G0/G1: broadcast L1 cost, fused-on-CUDA optimizers, yolo9 sync removal (#763 items 1-3)

### DIFF
--- a/libreyolo/models/deim/matcher.py
+++ b/libreyolo/models/deim/matcher.py
@@ -69,7 +69,10 @@ class HungarianMatcher(nn.Module):
         else:
             cost_class = -out_prob[:, tgt_ids]
 
-        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+        # The broadcast form is bit-identical to ``torch.cdist(out_bbox,
+        # tgt_bbox, p=1)`` but avoids cdist's slow one-thread-per-pair p=1
+        # CUDA kernel (issue #763; measured on rfdetr in PR #761).
+        cost_bbox = (out_bbox[:, None, :] - tgt_bbox[None, :, :]).abs().sum(-1)
 
         cost_giou = -generalized_box_iou(
             box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox)

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -47,6 +47,7 @@ from ...data import (
 from ...data.dataset import COCODataset, YOLODataset
 from ...training.config import DEIMConfig, TrainConfig
 from ...training.scheduler import FlatCosineScheduler
+from ...training.optim import build_optimizer
 from ...training.trainer import BaseTrainer
 from .loss import DEIMCriterion
 from .matcher import HungarianMatcher
@@ -282,7 +283,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                 }
             )
 
-        return torch.optim.AdamW(param_groups, betas=(0.9, 0.999))
+        return build_optimizer(torch.optim.AdamW, param_groups, betas=(0.9, 0.999))
 
     def _targets_to_detr(self, imgs: torch.Tensor, targets: torch.Tensor):
         """Translate padded LibreYOLO labels to DETR target dictionaries."""

--- a/libreyolo/models/deimv2/matcher.py
+++ b/libreyolo/models/deimv2/matcher.py
@@ -93,7 +93,10 @@ class HungarianMatcher(nn.Module):
             else:
                 cost_class = -out_prob[:, tgt_ids]
 
-            cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+            # The broadcast form is bit-identical to ``torch.cdist(out_bbox,
+            # tgt_bbox, p=1)`` but avoids cdist's slow one-thread-per-pair
+            # p=1 CUDA kernel (issue #763; measured on rfdetr in PR #761).
+            cost_bbox = (out_bbox[:, None, :] - tgt_bbox[None, :, :]).abs().sum(-1)
             cost_giou = -generalized_box_iou(
                 box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox)
             )

--- a/libreyolo/models/deimv2/trainer.py
+++ b/libreyolo/models/deimv2/trainer.py
@@ -18,6 +18,7 @@ from ...training.config import (
     DEIMv2Config,
     TrainConfig,
 )
+from ...training.optim import build_optimizer
 from ..deim.trainer import DEIMTrainer
 from .loss import DEIMv2Criterion
 from .matcher import HungarianMatcher
@@ -274,7 +275,7 @@ class DEIMv2Trainer(DEIMTrainer):
                 }
             )
 
-        return torch.optim.AdamW(param_groups, betas=(0.9, 0.999))
+        return build_optimizer(torch.optim.AdamW, param_groups, betas=(0.9, 0.999))
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         target_list = self._targets_to_detr(imgs, targets)

--- a/libreyolo/models/dfine/matcher.py
+++ b/libreyolo/models/dfine/matcher.py
@@ -102,7 +102,10 @@ class HungarianMatcher(nn.Module):
         else:
             cost_class = -out_prob[:, tgt_ids]
 
-        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+        # The broadcast form is bit-identical to ``torch.cdist(out_bbox,
+        # tgt_bbox, p=1)`` but avoids cdist's slow one-thread-per-pair p=1
+        # CUDA kernel (issue #763; measured on rfdetr in PR #761).
+        cost_bbox = (out_bbox[:, None, :] - tgt_bbox[None, :, :]).abs().sum(-1)
 
         cost_giou = -generalized_box_iou(
             box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox)

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -52,6 +52,7 @@ from ...training.config import (
     resolve_dfine_base_size_repeat,
 )
 from ...training.scheduler import FlatCosineScheduler
+from ...training.optim import build_optimizer
 from ...training.trainer import BaseTrainer
 from .loss import DFINECriterion
 from .matcher import HungarianMatcher
@@ -324,7 +325,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                 }
             )
 
-        return torch.optim.AdamW(param_groups, betas=(0.9, 0.999))
+        return build_optimizer(torch.optim.AdamW, param_groups, betas=(0.9, 0.999))
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         """Forward + loss in one go.

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -35,6 +35,7 @@ from ...data import (
 )
 from ...training.config import ECPoseConfig, TrainConfig
 from ...training.scheduler import FlatCosineScheduler
+from ...training.optim import build_optimizer
 from ...training.trainer import BaseTrainer
 from .pose_loss import ECPoseCriterion, PoseHungarianMatcher, default_oks_sigmas
 from .pose_transforms import ECPoseTrainTransform, ECPoseValTransform
@@ -181,7 +182,7 @@ class ECPoseTrainer(BaseTrainer):
             groups.append({"params": backbone_wd, "lr": lr * bb_mult, "weight_decay": wd, "lr_mult": bb_mult})
         if backbone_no_wd:
             groups.append({"params": backbone_no_wd, "lr": lr * bb_mult, "weight_decay": 0.0, "lr_mult": bb_mult})
-        return torch.optim.AdamW(groups, betas=(0.9, 0.999))
+        return build_optimizer(torch.optim.AdamW, groups, betas=(0.9, 0.999))
 
     def _scale_lr(self, base_lr: float, param_group: dict) -> float:
         return base_lr * float(param_group.get("lr_mult", 1.0))

--- a/libreyolo/models/ec/seg_loss.py
+++ b/libreyolo/models/ec/seg_loss.py
@@ -107,7 +107,10 @@ class ECSegHungarianMatcher(nn.Module):
         else:
             cost_class = -out_prob[:, tgt_ids]
 
-        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+        # The broadcast form is bit-identical to ``torch.cdist(out_bbox,
+        # tgt_bbox, p=1)`` but avoids cdist's slow one-thread-per-pair p=1
+        # CUDA kernel (issue #763; measured on rfdetr in PR #761).
+        cost_bbox = (out_bbox[:, None, :] - tgt_bbox[None, :, :]).abs().sum(-1)
         cost_giou = -generalized_box_iou(
             box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox)
         )

--- a/libreyolo/models/ec/seg_trainer.py
+++ b/libreyolo/models/ec/seg_trainer.py
@@ -21,6 +21,7 @@ import torch
 
 from ...training.config import ECSegConfig, TrainConfig
 from ...training.scheduler import FlatCosineScheduler
+from ...training.optim import build_optimizer
 from ...training.trainer import BaseTrainer
 from ..rfdetr.seg_transforms import RFDETRSegPassThroughDataset, RFDETRSegTransform
 from .seg_loss import ECSegCriterion, ECSegHungarianMatcher
@@ -159,7 +160,7 @@ class ECSegTrainer(BaseTrainer):
             groups.append({"params": backbone_wd, "lr": lr * bb_mult, "weight_decay": wd, "lr_mult": bb_mult})
         if backbone_no_wd:
             groups.append({"params": backbone_no_wd, "lr": lr * bb_mult, "weight_decay": 0.0, "lr_mult": bb_mult})
-        return torch.optim.AdamW(groups, betas=(0.9, 0.999))
+        return build_optimizer(torch.optim.AdamW, groups, betas=(0.9, 0.999))
 
     def _scale_lr(self, base_lr: float, param_group: dict) -> float:
         return base_lr * float(param_group.get("lr_mult", 1.0))

--- a/libreyolo/models/lingbotvision/trainer.py
+++ b/libreyolo/models/lingbotvision/trainer.py
@@ -17,6 +17,7 @@ import torch
 
 from ...training.config import LingBotVisionConfig, TrainConfig
 from ...training.distributed import is_main_process, unwrap_model
+from ...training.optim import build_optimizer
 from ...training.scheduler import FlatCosineScheduler, LinearLRScheduler
 from ...training.trainer import BaseTrainer
 from ..base.semantic_cuda_graph import SemanticLogitsCudaGraphMixin
@@ -75,7 +76,7 @@ class LingBotVisionTrainer(
             {"params": params, "lr": base_lr, "weight_decay": group_wd}
             for (_, group_wd), params in buckets.items()
         ]
-        optimizer = torch.optim.AdamW(param_groups, lr=base_lr)
+        optimizer = build_optimizer(torch.optim.AdamW, param_groups, lr=base_lr)
         if is_main_process():
             n_trainable = sum(len(g["params"]) for g in param_groups)
             logger.info(

--- a/libreyolo/models/ppliteseg/trainer.py
+++ b/libreyolo/models/ppliteseg/trainer.py
@@ -20,6 +20,7 @@ import torch
 
 from ...training.config import PPLiteSegConfig, TrainConfig
 from ...training.distributed import is_main_process, unwrap_model
+from ...training.optim import build_optimizer
 from ...training.scheduler import PolyLRScheduler
 from ...training.trainer import BaseTrainer
 from ..base.semantic_cuda_graph import SemanticLogitsCudaGraphMixin
@@ -88,7 +89,8 @@ class PPLiteSegTrainer(SemanticLogitsCudaGraphMixin, SemanticValidationLossMixin
             }
             for (lr_mult, group_wd), params in buckets.items()
         ]
-        optimizer = torch.optim.SGD(
+        optimizer = build_optimizer(
+            torch.optim.SGD,
             param_groups,
             lr=base_lr,
             momentum=float(getattr(self.config, "momentum", 0.9)),

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -25,6 +25,7 @@ from ...data import (
 from ...training.config import TrainConfig
 from ...training.distributed import is_main_process, unwrap_model
 from ...training.freezing import FreezeGroup
+from ...training.optim import build_optimizer
 from ...training.scheduler import BaseScheduler, CosineAnnealingScheduler, FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import RFDETRConfig
@@ -691,20 +692,14 @@ class RFDETRTrainer(BaseTrainer):
 
     @staticmethod
     def _adamw(groups, **kwargs) -> torch.optim.Optimizer:
-        """AdamW, preferring the fused CUDA implementation.
+        """AdamW via the shared fused-on-CUDA construction helper.
 
-        The fused step is one multi-tensor kernel per dtype instead of the
-        foreach implementation's per-op launches, and under a GradScaler it
-        also consumes the scale/found_inf tensors directly, skipping the
-        per-group unscale pass and its device sync. Measured on rfdetr-s
-        512px b8 fp16: optimizer phase 62 -> 24 ms (1.16x on the whole
-        step). Falls back to the default implementation where fused is
-        unsupported (CPU params, exotic dtypes, older builds).
+        The previous inline try/except requested ``fused=True`` uncondition-
+        ally, which recent torch silently accepts for CPU (and MPS) params
+        too — the device gate in ``build_optimizer`` restores stock behavior
+        off-CUDA. See ``libreyolo.training.optim`` for the full rationale.
         """
-        try:
-            return torch.optim.AdamW(groups, **kwargs, fused=True)
-        except (RuntimeError, ValueError, TypeError):
-            return torch.optim.AdamW(groups, **kwargs)
+        return build_optimizer(torch.optim.AdamW, groups, **kwargs)
 
     def _setup_optimizer(self) -> torch.optim.Optimizer:
         if getattr(getattr(self, "wrapper_model", None), "task", "detect") in (

--- a/libreyolo/models/rtdetr/loss.py
+++ b/libreyolo/models/rtdetr/loss.py
@@ -99,8 +99,10 @@ class HungarianMatcher(nn.Module):
         else:
             cost_class = -out_prob[:, tgt_ids]
 
-        # L1 cost
-        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+        # L1 cost. The broadcast form is bit-identical to ``torch.cdist(
+        # out_bbox, tgt_bbox, p=1)`` but avoids cdist's slow one-thread-per-
+        # pair p=1 CUDA kernel (issue #763; measured on rfdetr in PR #761).
+        cost_bbox = (out_bbox[:, None, :] - tgt_bbox[None, :, :]).abs().sum(-1)
 
         # GIoU cost
         cost_giou = -generalized_box_iou(

--- a/libreyolo/models/rtdetr/trainer.py
+++ b/libreyolo/models/rtdetr/trainer.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Type
 import torch
 
 from libreyolo.training.distributed import is_main_process
+from libreyolo.training.optim import build_optimizer
 from libreyolo.training.trainer import BaseTrainer
 from libreyolo.training.config import TrainConfig
 from libreyolo.training.scheduler import (
@@ -337,15 +338,16 @@ class RTDETRTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
 
         optimizer_name = config.optimizer.lower()
         if optimizer_name == "adamw":
-            optimizer = torch.optim.AdamW(
-                opt_groups, lr=base_lr, betas=betas, weight_decay=base_wd
+            optimizer = build_optimizer(
+                torch.optim.AdamW, opt_groups, lr=base_lr, betas=betas, weight_decay=base_wd
             )
         elif optimizer_name == "adam":
-            optimizer = torch.optim.Adam(
-                opt_groups, lr=base_lr, betas=betas, weight_decay=base_wd
+            optimizer = build_optimizer(
+                torch.optim.Adam, opt_groups, lr=base_lr, betas=betas, weight_decay=base_wd
             )
         elif optimizer_name == "sgd":
-            optimizer = torch.optim.SGD(
+            optimizer = build_optimizer(
+                torch.optim.SGD,
                 opt_groups,
                 lr=base_lr,
                 momentum=config.momentum,

--- a/libreyolo/models/segformer/trainer.py
+++ b/libreyolo/models/segformer/trainer.py
@@ -17,6 +17,7 @@ import torch
 
 from ...training.config import SegformerConfig, TrainConfig
 from ...training.distributed import is_main_process, unwrap_model
+from ...training.optim import build_optimizer
 from ...training.scheduler import FlatCosineScheduler, LinearLRScheduler
 from ...training.trainer import BaseTrainer
 from ..base.semantic_cuda_graph import SemanticLogitsCudaGraphMixin
@@ -89,7 +90,7 @@ class SegformerTrainer(
             for (lr_mult, group_wd), params in buckets.items()
         ]
 
-        optimizer = torch.optim.AdamW(param_groups, lr=base_lr)
+        optimizer = build_optimizer(torch.optim.AdamW, param_groups, lr=base_lr)
         if is_main_process():
             logger.info("SegFormer optimizer: AdamW, backbone base lr=%s", base_lr)
             for (lr_mult, group_wd), params in buckets.items():

--- a/libreyolo/models/tinyformer/trainer.py
+++ b/libreyolo/models/tinyformer/trainer.py
@@ -20,6 +20,7 @@ from ...training.config import (
     TinyFormerConfig,
     TrainConfig,
 )
+from ...training.optim import build_optimizer
 from ..deimv2.trainer import DEIMv2Trainer
 from ..deimv2.transforms import DEIMPassThroughDataset, DEIMTrainTransform
 from .nn import normalize_size
@@ -128,4 +129,4 @@ class TinyFormerTrainer(DEIMv2Trainer):
                 }
             )
 
-        return torch.optim.AdamW(param_groups, betas=(0.9, 0.999))
+        return build_optimizer(torch.optim.AdamW, param_groups, betas=(0.9, 0.999))

--- a/libreyolo/models/vjepa2/trainer.py
+++ b/libreyolo/models/vjepa2/trainer.py
@@ -16,6 +16,7 @@ import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from ...training.config import TrainConfig
+from ...training.optim import build_optimizer
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
 from ..base.classify_validation_loss import ClassifyValidationLossMixin
@@ -107,8 +108,8 @@ class VJEPA2Trainer(ClassifyValidationLossMixin, BaseTrainer):
             len(trainable),
             ", ".join(trainable[:3]),
         )
-        return torch.optim.AdamW(
-            params, lr=self.config.lr0, weight_decay=self.config.weight_decay
+        return build_optimizer(
+            torch.optim.AdamW, params, lr=self.config.lr0, weight_decay=self.config.weight_decay
         )
 
     def _setup_data(self):

--- a/libreyolo/models/yolo9/loss.py
+++ b/libreyolo/models/yolo9/loss.py
@@ -12,7 +12,7 @@ from torch import Tensor, nn
 from torch.nn import BCEWithLogitsLoss
 
 from libreyolo.data import default_oks_sigmas
-from libreyolo.training.distributed import all_reduce_avg_scalar
+from libreyolo.training.distributed import all_reduce_avg_scalar_tensor
 from libreyolo.utils.box_ops import compute_iou as calculate_iou
 
 
@@ -565,8 +565,8 @@ class YOLO9Loss:
         if self.vec2box is None or self.vec2box.image_size != image_size:
             self._init_vec2box(image_size)
 
-    def _global_cls_norm(self, targets_cls: Tensor) -> float:
-        """Positive count for loss normalization.
+    def _global_cls_norm(self, targets_cls: Tensor) -> Tensor:
+        """Positive count for loss normalization, as a 0-dim device tensor.
 
         Multi-GPU training must divide by the global count so DDP's gradient
         averaging matches single-GPU on the same global batch (issue #484).
@@ -574,10 +574,14 @@ class YOLO9Loss:
         yolo9 task losses so the normalizer contract lives in one place.
         Rank-0-only validation explicitly selects the local path because it
         cannot enter a collective while the other ranks wait at a barrier.
+
+        Returned as a tensor rather than ``.item()``-ed: the value is only
+        ever a divisor, and the ``.item()`` here cost one full GPU pipeline
+        drain per training step (issue #763).
         """
         if self.distributed_normalize:
-            return all_reduce_avg_scalar(targets_cls.sum())
-        return float(targets_cls.detach().float().sum().clamp_min(1.0).item())
+            return all_reduce_avg_scalar_tensor(targets_cls.sum())
+        return targets_cls.detach().float().sum().clamp_min(1.0)
 
     def __call__(
         self, predictions: List[Tensor], targets: Tensor
@@ -662,17 +666,14 @@ class YOLO9Loss:
             "box_loss": loss_box_weighted,
             "dfl_loss": loss_dfl_weighted,
             "cls_loss": loss_cls_weighted,
-            # Scalar values for logging
-            "box": loss_box_weighted.item()
-            if isinstance(loss_box_weighted, Tensor)
-            else loss_box_weighted,
-            "dfl": loss_dfl_weighted.item()
-            if isinstance(loss_dfl_weighted, Tensor)
-            else loss_dfl_weighted,
-            "cls": loss_cls_weighted.item()
-            if isinstance(loss_cls_weighted, Tensor)
-            else loss_cls_weighted,
-            "num_fg": valid_masks.sum().item() / max(B, 1),
+            # Logging values, kept as detached 0-dim tensors: the four
+            # per-key ``.item()`` calls here were four GPU pipeline drains
+            # every training step (issue #763). The float conversion happens
+            # once, batched, in ``get_loss_components``.
+            "box": loss_box_weighted.detach(),
+            "dfl": loss_dfl_weighted.detach(),
+            "cls": loss_cls_weighted.detach(),
+            "num_fg": valid_masks.sum().detach() / max(B, 1),
         }
 
         return loss_dict

--- a/libreyolo/models/yolo9/trainer.py
+++ b/libreyolo/models/yolo9/trainer.py
@@ -136,14 +136,18 @@ class YOLO9Trainer(BaseTrainer):
             raise ValueError(f"Unknown scheduler: {scheduler_name}")
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
-        def _scalar(v):
-            return v.item() if isinstance(v, torch.Tensor) else v
-
-        return {
-            "box": _scalar(outputs.get("box", 0)),
-            "cls": _scalar(outputs.get("cls", 0)),
-            "dfl": _scalar(outputs.get("dfl", 0)),
-        }
+        # Transfer every logging scalar with ONE .cpu() call (the rfdetr
+        # pattern from PR #761): a per-key ``.item()`` here would be one GPU
+        # pipeline drain each per logged step (issue #763).
+        values = {name: outputs.get(name, 0) for name in ("box", "cls", "dfl")}
+        tensor_names = [n for n, v in values.items() if isinstance(v, torch.Tensor)]
+        if tensor_names:
+            stacked = torch.stack(
+                [values[n].detach().reshape(()).float() for n in tensor_names]
+            ).cpu()
+            for i, name in enumerate(tensor_names):
+                values[name] = stacked[i]
+        return {name: float(v) for name, v in values.items()}
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         return self.model(imgs, targets=targets)

--- a/libreyolo/models/yolo9_e2e/loss.py
+++ b/libreyolo/models/yolo9_e2e/loss.py
@@ -81,17 +81,20 @@ class YOLO9E2ELoss:
         dfl_loss = loss_many["dfl_loss"] + loss_one["dfl_loss"]
         cls_loss = loss_many["cls_loss"] + loss_one["cls_loss"]
 
+        # Logging values stay detached 0-dim tensors: the per-key ``.item()``
+        # calls here were GPU pipeline drains every step (issue #763). Float
+        # conversion happens once, batched, in ``get_loss_components``.
         num_fg = loss_many.get("num_fg", 0) + loss_one.get("num_fg", 0)
         if isinstance(num_fg, Tensor):
-            num_fg = num_fg.item()
+            num_fg = num_fg.detach()
 
         return {
             "total_loss": total_loss,
             "box_loss": box_loss,
             "dfl_loss": dfl_loss,
             "cls_loss": cls_loss,
-            "box": box_loss.item() if isinstance(box_loss, Tensor) else box_loss,
-            "dfl": dfl_loss.item() if isinstance(dfl_loss, Tensor) else dfl_loss,
-            "cls": cls_loss.item() if isinstance(cls_loss, Tensor) else cls_loss,
+            "box": box_loss.detach(),
+            "dfl": dfl_loss.detach(),
+            "cls": cls_loss.detach(),
             "num_fg": num_fg,
         }

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -234,6 +234,29 @@ def all_reduce_avg_scalar(
     This is a COLLECTIVE under DDP: every rank must reach it or the callers
     deadlock. Only call it from code that runs symmetrically on all ranks
     (the training loss); never from rank-0-only paths like validation.
+
+    The trailing ``.item()`` is a full pipeline drain every step. Hot loss
+    paths that only need a divisor should call
+    ``all_reduce_avg_scalar_tensor`` and keep the value on device
+    (issue #763); this float form stays for callers that genuinely need a
+    Python number.
+    """
+    return float(
+        all_reduce_avg_scalar_tensor(value, device=device, min_value=min_value).item()
+    )
+
+
+def all_reduce_avg_scalar_tensor(
+    value: Union[float, torch.Tensor],
+    *,
+    device: Optional[torch.device] = None,
+    min_value: float = 1.0,
+) -> torch.Tensor:
+    """``all_reduce_avg_scalar`` without the final device sync.
+
+    Returns the clamped global average as a 0-dim fp32 tensor on the input
+    tensor's device, so callers that use it as a loss normalizer never force
+    a GPU-to-CPU transfer. Same collective contract as the float form.
     """
     if isinstance(value, torch.Tensor):
         # .sum() materializes a fresh tensor even for 0-dim input, so the
@@ -249,9 +272,8 @@ def all_reduce_avg_scalar(
                 "GPU) so the collective can run."
             )
         dist.all_reduce(v)
-        v = v.clamp_min(min_value) / float(get_world_size())
-        return float(v.item())
-    return float(v.clamp_min(min_value).item())
+        return v.clamp_min(min_value) / float(get_world_size())
+    return v.clamp_min(min_value)
 
 
 def scale_loss_for_ddp(loss: torch.Tensor) -> torch.Tensor:

--- a/libreyolo/training/optim.py
+++ b/libreyolo/training/optim.py
@@ -1,0 +1,90 @@
+"""Optimizer construction shared by every family trainer.
+
+Promoted from the rfdetr ``_adamw`` helper (PR #761) so all families get the
+fused CUDA optimizer path with one implementation and one safety story.
+"""
+
+from typing import Any, Dict, Iterable, List, Type, Union
+
+import torch
+
+ParamsLike = Iterable[Union[torch.Tensor, Dict[str, Any]]]
+
+
+def _materialized_groups(params: ParamsLike) -> List[Union[torch.Tensor, Dict[str, Any]]]:
+    """Materialize params (and each group's params) so they can be inspected
+    for the device gate and still be consumed by the optimizer afterwards."""
+    groups = list(params)
+    for group in groups:
+        if isinstance(group, dict):
+            group["params"] = list(group["params"])
+    return groups
+
+
+def _all_params_cuda(groups: List[Union[torch.Tensor, Dict[str, Any]]]) -> bool:
+    tensors: List[torch.Tensor] = []
+    for group in groups:
+        if isinstance(group, dict):
+            tensors.extend(p for p in group["params"] if isinstance(p, torch.Tensor))
+        elif isinstance(group, torch.Tensor):
+            tensors.append(group)
+    return bool(tensors) and all(p.is_cuda for p in tensors)
+
+
+def build_optimizer(
+    optim_cls: Type[torch.optim.Optimizer], params: ParamsLike, **kwargs
+) -> torch.optim.Optimizer:
+    """Construct ``optim_cls``, preferring the fused implementation on CUDA.
+
+    The fused step is one multi-tensor kernel per dtype instead of the
+    foreach implementation's per-op launches, and under a GradScaler it
+    consumes the scale/found_inf tensors directly, skipping the per-group
+    unscale pass and its device sync. Measured on rfdetr-s 512px b8 fp16:
+    optimizer phase 62 -> 24 ms (1.16x on the whole step). Numerics note:
+    fused uses a different fp reduction order than foreach (~1e-7 relative
+    per step), same algorithm.
+
+    ``fused=True`` is requested only when every parameter is on CUDA. Recent
+    torch also ships fused CPU and MPS kernels and would silently accept
+    those params, changing the reduction order on machines that never asked
+    for it; the explicit device gate keeps non-CUDA construction, and
+    therefore non-CUDA training, byte-identical to stock. The gate cannot
+    be replaced by the try/except: torch validates fused device support
+    lazily at the first ``step()``, not at construction, so a construction-
+    time except never sees that error. The except handles older torch
+    builds where the kwarg or the fused path itself is missing.
+    """
+    groups = _materialized_groups(params)
+    if _all_params_cuda(groups):
+        try:
+            return optim_cls(groups, **kwargs, fused=True)
+        except (RuntimeError, ValueError, TypeError):
+            pass
+    return optim_cls(groups, **kwargs)
+
+
+#: Param-group keys that select the step implementation rather than describe
+#: the training run. They must reflect the CURRENT construction, never the
+#: checkpoint's: a checkpoint written on CUDA carries ``fused: True``, and
+#: ``load_state_dict`` copies group hyperparameters wholesale, so resuming on
+#: CPU/MPS would re-enable fused on a device the gate above deliberately
+#: excluded (step-time RuntimeError on older torch, silent reduction-order
+#: change on recent torch).
+_IMPL_SELECTION_KEYS = ("fused", "foreach", "capturable", "differentiable")
+
+
+def restore_optimizer_state(
+    optimizer: torch.optim.Optimizer, state_dict: Dict[str, Any]
+) -> None:
+    """``optimizer.load_state_dict`` that keeps the live optimizer's
+    implementation-selection keys (``fused``/``foreach``/...) instead of the
+    checkpoint's, so a resume never changes which step implementation runs."""
+    snapshots = [
+        {key: group[key] for key in _IMPL_SELECTION_KEYS if key in group}
+        for group in optimizer.param_groups
+    ]
+    optimizer.load_state_dict(state_dict)
+    for group, snapshot in zip(optimizer.param_groups, snapshots):
+        for key in _IMPL_SELECTION_KEYS:
+            group.pop(key, None)
+        group.update(snapshot)

--- a/libreyolo/training/optim.py
+++ b/libreyolo/training/optim.py
@@ -13,10 +13,15 @@ ParamsLike = Iterable[Union[torch.Tensor, Dict[str, Any]]]
 
 def _materialized_groups(params: ParamsLike) -> List[Union[torch.Tensor, Dict[str, Any]]]:
     """Materialize params (and each group's params) so they can be inspected
-    for the device gate and still be consumed by the optimizer afterwards."""
+    for the device gate and still be consumed by the optimizer afterwards.
+
+    A group's ``params`` may legally be one bare tensor (torch wraps it in a
+    list); it must NOT be ``list()``-ed, which would iterate its rows into
+    non-leaf views (rfdetr builds per-parameter groups exactly this way).
+    """
     groups = list(params)
     for group in groups:
-        if isinstance(group, dict):
+        if isinstance(group, dict) and not isinstance(group["params"], torch.Tensor):
             group["params"] = list(group["params"])
     return groups
 
@@ -25,7 +30,10 @@ def _all_params_cuda(groups: List[Union[torch.Tensor, Dict[str, Any]]]) -> bool:
     tensors: List[torch.Tensor] = []
     for group in groups:
         if isinstance(group, dict):
-            tensors.extend(p for p in group["params"] if isinstance(p, torch.Tensor))
+            group_params = group["params"]
+            if isinstance(group_params, torch.Tensor):
+                group_params = [group_params]
+            tensors.extend(p for p in group_params if isinstance(p, torch.Tensor))
         elif isinstance(group, torch.Tensor):
             tensors.append(group)
     return bool(tensors) and all(p.is_cuda for p in tensors)

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -52,6 +52,7 @@ from .distributed import (
     wants_distributed,
 )
 from .ema import ModelEMA
+from .optim import build_optimizer, restore_optimizer_state
 from .freezing import FreezeGroup, apply_freeze, default_freeze_groups
 from ..data.dataset import YOLODataset, COCODataset, create_dataloader
 from ..data import (
@@ -566,16 +567,17 @@ class BaseTrainer(ABC):
             )
 
         if opt_name == "sgd":
-            optimizer = torch.optim.SGD(
+            optimizer = build_optimizer(
+                torch.optim.SGD,
                 param_groups,
                 lr=lr,
                 momentum=self.config.momentum,
                 nesterov=self.config.nesterov,
             )
         elif opt_name == "adam":
-            optimizer = torch.optim.Adam(param_groups, lr=lr)
+            optimizer = build_optimizer(torch.optim.Adam, param_groups, lr=lr)
         elif opt_name == "adamw":
-            optimizer = torch.optim.AdamW(param_groups, lr=lr)
+            optimizer = build_optimizer(torch.optim.AdamW, param_groups, lr=lr)
         else:
             raise ValueError(f"Unknown optimizer: {opt_name}")
 
@@ -1586,7 +1588,7 @@ class BaseTrainer(ABC):
         # _initialize_scheduler_lr() sets the correct LR on top.
         if getattr(self, "_resume_optimizer_state", None) is not None:
             try:
-                self.optimizer.load_state_dict(self._resume_optimizer_state)
+                restore_optimizer_state(self.optimizer, self._resume_optimizer_state)
                 logger.info("Optimizer state restored from resume checkpoint")
             except Exception as e:
                 logger.warning(f"Could not load deferred optimizer state: {e}")
@@ -3225,7 +3227,7 @@ class BaseTrainer(ABC):
         if "optimizer" in checkpoint:
             if self.optimizer is not None:
                 try:
-                    self.optimizer.load_state_dict(checkpoint["optimizer"])
+                    restore_optimizer_state(self.optimizer, checkpoint["optimizer"])
                     logger.info("Optimizer state restored")
                 except Exception as e:
                     logger.warning(f"Could not load optimizer state: {e}")

--- a/tests/unit/test_rfdetr_train_speedups.py
+++ b/tests/unit/test_rfdetr_train_speedups.py
@@ -182,6 +182,11 @@ def test_num_boxes_is_tensor_and_losses_stay_scalar():
 
 
 def test_adamw_helper_falls_back_when_fused_unsupported(monkeypatch):
+    # The helper now routes through libreyolo.training.optim.build_optimizer,
+    # whose device gate skips fused off-CUDA; force the gate open so the
+    # construction-time fallback path is exercised on CPU params.
+    import libreyolo.training.optim as optim_mod
+
     param = torch.nn.Parameter(torch.randn(3))
     real_adamw = torch.optim.AdamW
     calls = []
@@ -193,11 +198,20 @@ def test_adamw_helper_falls_back_when_fused_unsupported(monkeypatch):
                 raise RuntimeError("fused not supported here")
             super().__init__(params, **kwargs)
 
+    monkeypatch.setattr(optim_mod, "_all_params_cuda", lambda groups: True)
     monkeypatch.setattr(torch.optim, "AdamW", Picky)
     opt = RFDETRTrainer._adamw([{"params": [param]}], lr=1e-3, betas=(0.9, 0.999))
     assert isinstance(opt, real_adamw)
     assert calls[0].get("fused") is True
     assert "fused" not in calls[1]
+
+
+def test_adamw_helper_keeps_cpu_construction_stock():
+    # Non-CUDA params must never be handed fused=True, even though recent
+    # torch would silently accept them (issue #763 portability guarantee).
+    param = torch.nn.Parameter(torch.randn(3))
+    opt = RFDETRTrainer._adamw([{"params": [param]}], lr=1e-3, betas=(0.9, 0.999))
+    assert not any(group.get("fused") for group in opt.param_groups)
 
 
 def test_adamw_helper_constructs_and_steps():

--- a/tests/unit/test_train_speed_quick_wins.py
+++ b/tests/unit/test_train_speed_quick_wins.py
@@ -1,0 +1,294 @@
+"""Parity and portability tests for the issue #763 training-speed quick wins.
+
+Covers: the broadcast-L1-equals-cdist bitwise identity, every ported matcher
+running cdist-free (including empty targets), and the shared fused-optimizer
+construction helper's CUDA-only gate, which keeps non-CUDA machines
+byte-identical to stock construction.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import libreyolo.training.optim as optim_mod
+from libreyolo.training.optim import build_optimizer
+
+pytestmark = pytest.mark.unit
+
+WEIGHTS = {"cost_class": 2, "cost_bbox": 5, "cost_giou": 2}
+
+
+# ---------------------------------------------------------------------------
+# Broadcast L1 == cdist, bitwise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n,m", [(300, 20), (300, 0), (7, 3), (1, 1)])
+def test_broadcast_l1_is_bitwise_identical_to_cdist(n, m):
+    generator = torch.Generator().manual_seed(763)
+    for _ in range(10):
+        a = torch.rand(n, 4, generator=generator)
+        b = torch.rand(m, 4, generator=generator)
+        assert torch.equal(
+            torch.cdist(a, b, p=1),
+            (a[:, None, :] - b[None, :, :]).abs().sum(-1),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Every ported matcher runs cdist-free, on normal and empty targets
+# ---------------------------------------------------------------------------
+
+
+def _outputs(bs, num_queries, num_classes, generator):
+    return {
+        "pred_logits": torch.randn(bs, num_queries, num_classes, generator=generator) * 3,
+        "pred_boxes": torch.rand(bs, num_queries, 4, generator=generator).clamp(1e-3, 1.0),
+    }
+
+
+def _targets(bs, num_classes, generator, counts):
+    return [
+        {
+            "labels": torch.randint(0, num_classes, (n,), generator=generator),
+            "boxes": torch.rand(n, 4, generator=generator).clamp(1e-3, 1.0),
+        }
+        for n in counts
+    ]
+
+
+def _dfine_matcher():
+    from libreyolo.models.dfine.matcher import HungarianMatcher
+
+    return HungarianMatcher(WEIGHTS)
+
+
+def _deim_matcher():
+    from libreyolo.models.deim.matcher import HungarianMatcher
+
+    return HungarianMatcher(WEIGHTS)
+
+
+def _deimv2_matcher():
+    from libreyolo.models.deimv2.matcher import HungarianMatcher
+
+    return HungarianMatcher(WEIGHTS)
+
+
+def _rtdetr_matcher():
+    from libreyolo.models.rtdetr.loss import HungarianMatcher
+
+    return HungarianMatcher(WEIGHTS, use_focal_loss=False)
+
+
+def _ec_seg_matcher():
+    from libreyolo.models.ec.seg_loss import ECSegHungarianMatcher
+
+    return ECSegHungarianMatcher(WEIGHTS)
+
+
+MATCHERS = {
+    "dfine": _dfine_matcher,
+    "deim": _deim_matcher,
+    "deimv2": _deimv2_matcher,
+    "rtdetr": _rtdetr_matcher,
+    "ec_seg": _ec_seg_matcher,
+}
+
+
+def _normalize_indices(result):
+    """Both return conventions -> list of (pred_idx, tgt_idx) tensor pairs."""
+    return result["indices"] if isinstance(result, dict) else result
+
+
+@pytest.mark.parametrize("family", sorted(MATCHERS))
+@pytest.mark.parametrize("counts", [(4, 7), (0, 0)], ids=["targets", "empty"])
+def test_matcher_is_cdist_free_and_deterministic(family, counts, monkeypatch):
+    def _no_cdist(*args, **kwargs):
+        raise AssertionError("matcher hot path still calls torch.cdist")
+
+    monkeypatch.setattr(torch, "cdist", _no_cdist)
+    matcher = MATCHERS[family]()
+    generator = torch.Generator().manual_seed(42)
+    outputs = _outputs(2, 30, 5, generator)
+    targets = _targets(2, 5, generator, counts)
+
+    first = _normalize_indices(matcher(outputs, targets))
+    second = _normalize_indices(matcher(outputs, targets))
+
+    assert len(first) == 2
+    for (pi, ti), (pj, tj), n in zip(first, second, counts):
+        assert torch.equal(torch.as_tensor(pi), torch.as_tensor(pj))
+        assert torch.equal(torch.as_tensor(ti), torch.as_tensor(tj))
+        assert len(pi) == len(ti) == n
+
+
+# ---------------------------------------------------------------------------
+# Fused-optimizer construction helper
+# ---------------------------------------------------------------------------
+
+
+def _cpu_params():
+    return [torch.nn.Parameter(torch.randn(3, 3)) for _ in range(2)]
+
+
+def test_build_optimizer_never_fuses_on_cpu():
+    opt = build_optimizer(torch.optim.AdamW, _cpu_params(), lr=1e-3)
+    assert not any(group.get("fused") for group in opt.param_groups)
+
+
+def test_build_optimizer_cpu_step_is_bitwise_stock():
+    torch.manual_seed(0)
+    base = torch.randn(4, 4)
+    p_helper = torch.nn.Parameter(base.clone())
+    p_stock = torch.nn.Parameter(base.clone())
+    opt_helper = build_optimizer(torch.optim.AdamW, [p_helper], lr=1e-2)
+    opt_stock = torch.optim.AdamW([p_stock], lr=1e-2)
+    for _ in range(3):
+        grad = torch.randn(4, 4)
+        p_helper.grad = grad.clone()
+        p_stock.grad = grad.clone()
+        opt_helper.step()
+        opt_stock.step()
+    assert torch.equal(p_helper, p_stock)
+
+
+def test_build_optimizer_materializes_generators_and_group_dicts():
+    params = (p for p in _cpu_params())
+    opt = build_optimizer(torch.optim.SGD, params, lr=0.1)
+    assert sum(len(g["params"]) for g in opt.param_groups) == 2
+
+    groups = iter(
+        [
+            {"params": (p for p in _cpu_params()), "lr": 0.1},
+            {"params": _cpu_params(), "lr": 0.2, "weight_decay": 0.0},
+        ]
+    )
+    opt = build_optimizer(torch.optim.SGD, groups, lr=0.1)
+    assert [len(g["params"]) for g in opt.param_groups] == [2, 2]
+
+
+def test_build_optimizer_falls_back_when_fused_unsupported(monkeypatch):
+    calls = []
+
+    class _NoFusedSGD(torch.optim.SGD):
+        def __init__(self, params, **kwargs):
+            calls.append(sorted(kwargs))
+            if "fused" in kwargs:
+                raise TypeError("unexpected keyword argument 'fused'")
+            super().__init__(params, **kwargs)
+
+    monkeypatch.setattr(optim_mod, "_all_params_cuda", lambda groups: True)
+    opt = build_optimizer(_NoFusedSGD, _cpu_params(), lr=0.1)
+    assert isinstance(opt, _NoFusedSGD)
+    assert calls == [["fused", "lr"], ["lr"]]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_build_optimizer_fuses_on_cuda():
+    params = [torch.nn.Parameter(torch.randn(3, 3, device="cuda")) for _ in range(2)]
+    opt = build_optimizer(torch.optim.AdamW, params, lr=1e-3)
+    assert all(group.get("fused") for group in opt.param_groups)
+    params[0].grad = torch.zeros_like(params[0])
+    params[1].grad = torch.zeros_like(params[1])
+    opt.step()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_build_optimizer_mixed_devices_stay_unfused():
+    params = [
+        torch.nn.Parameter(torch.randn(3, 3, device="cuda")),
+        torch.nn.Parameter(torch.randn(3, 3)),
+    ]
+    opt = build_optimizer(torch.optim.AdamW, params, lr=1e-3)
+    assert not any(group.get("fused") for group in opt.param_groups)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint resume must not resurrect the checkpoint's step implementation
+# ---------------------------------------------------------------------------
+
+
+def test_restore_optimizer_state_keeps_live_impl_selection():
+    from libreyolo.training.optim import restore_optimizer_state
+
+    donor_param = torch.nn.Parameter(torch.randn(3, 3))
+    donor = torch.optim.AdamW([donor_param], lr=5e-4)
+    donor_param.grad = torch.randn(3, 3)
+    donor.step()
+    state = donor.state_dict()
+    # Simulate a checkpoint written by a fused CUDA run.
+    state["param_groups"][0]["fused"] = True
+    state["param_groups"][0]["foreach"] = False
+
+    live_param = torch.nn.Parameter(torch.randn(3, 3))
+    live = torch.optim.AdamW([live_param], lr=1e-3)
+    live_impl = {
+        key: live.param_groups[0][key]
+        for key in ("fused", "foreach", "capturable", "differentiable")
+    }
+    restore_optimizer_state(live, state)
+
+    # Implementation-selection keys stay as constructed for THIS device...
+    for key, value in live_impl.items():
+        assert live.param_groups[0][key] == value
+    assert live.param_groups[0]["fused"] is not True
+    # ...while real hyperparameters and state do come from the checkpoint.
+    assert live.param_groups[0]["lr"] == 5e-4
+    assert len(live.state) == 1
+    live_param.grad = torch.randn(3, 3)
+    live.step()
+
+
+# ---------------------------------------------------------------------------
+# yolo9 loss-path sync removal (issue #763 item 3)
+# ---------------------------------------------------------------------------
+
+
+def test_yolo9_cls_norm_is_tensor_and_value_preserved():
+    from libreyolo.models.yolo9.loss import YOLO9Loss
+
+    stub = type("Stub", (), {"distributed_normalize": False})()
+    targets_cls = torch.zeros(2, 8400, 5)
+    targets_cls[0, :3, 1] = 1.0
+    norm = YOLO9Loss._global_cls_norm(stub, targets_cls)
+    assert isinstance(norm, torch.Tensor) and norm.ndim == 0
+    assert float(norm) == 3.0
+    # The empty batch keeps the clamp floor the old float path had.
+    assert float(YOLO9Loss._global_cls_norm(stub, torch.zeros(2, 10, 5))) == 1.0
+
+
+def test_yolo9_get_loss_components_single_transfer_matches_item(monkeypatch):
+    from libreyolo.models.yolo9.trainer import YOLO9Trainer
+
+    outputs = {
+        "box": torch.tensor(1.25),
+        "cls": torch.tensor(0.5),
+        "dfl": torch.tensor(2.0),
+        "num_fg": torch.tensor(3.0),
+    }
+    transfers = []
+    original_cpu = torch.Tensor.cpu
+
+    def _counting_cpu(self, *args, **kwargs):
+        transfers.append(tuple(self.shape))
+        return original_cpu(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "cpu", _counting_cpu)
+    components = YOLO9Trainer.get_loss_components(None, outputs)
+    assert components == {"box": 1.25, "cls": 0.5, "dfl": 2.0}
+    assert all(isinstance(v, float) for v in components.values())
+    assert transfers == [(3,)]  # one stacked transfer, not one per key
+
+
+def test_all_reduce_avg_scalar_tensor_matches_float_form():
+    from libreyolo.training.distributed import (
+        all_reduce_avg_scalar,
+        all_reduce_avg_scalar_tensor,
+    )
+
+    for value in (torch.tensor(7.0), torch.tensor(0.0), 4.5, 0.2):
+        as_tensor = all_reduce_avg_scalar_tensor(value)
+        assert isinstance(as_tensor, torch.Tensor) and as_tensor.ndim == 0
+        assert float(as_tensor) == all_reduce_avg_scalar(value)

--- a/tests/unit/test_train_speed_quick_wins.py
+++ b/tests/unit/test_train_speed_quick_wins.py
@@ -169,6 +169,28 @@ def test_build_optimizer_materializes_generators_and_group_dicts():
     assert [len(g["params"]) for g in opt.param_groups] == [2, 2]
 
 
+def test_build_optimizer_accepts_bare_tensor_group_params():
+    # rfdetr builds per-parameter groups as {"params": tensor} with a BARE
+    # tensor; list()-ing it would iterate rows into non-leaf views and torch
+    # would raise "can't optimize a non-leaf Tensor" (found by the #765
+    # all-family smoke).
+    p1, p2 = _cpu_params()
+    opt = build_optimizer(
+        torch.optim.AdamW,
+        [{"params": p1, "lr": 1e-3}, {"params": p2, "lr": 2e-3}],
+        lr=1e-3,
+    )
+    assert [g["params"] for g in opt.param_groups] == [[p1], [p2]]
+    assert opt.param_groups[0]["params"][0] is p1
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_build_optimizer_bare_tensor_groups_fuse_on_cuda():
+    p = torch.nn.Parameter(torch.randn(3, 3, device="cuda"))
+    opt = build_optimizer(torch.optim.AdamW, [{"params": p, "lr": 1e-3}], lr=1e-3)
+    assert all(group.get("fused") for group in opt.param_groups)
+
+
 def test_build_optimizer_falls_back_when_fused_unsupported(monkeypatch):
     calls = []
 


### PR DESCRIPTION
Part of #763 (items 1, 2, 3). Items 4 and 5 are not in this PR: they need the RNG-pinned denoising parity work budgeted separately.

## What

- Item 1: `torch.cdist(p=1)` replaced with the broadcast L1 form in the five remaining matchers: `dfine/matcher.py`, `deim/matcher.py`, `deimv2/matcher.py`, `rtdetr/loss.py`, `ec/seg_loss.py`. Bit-identical in fp32 (the only dtype cdist supports; it has no half kernels, so under autocast the old site silently forced fp32).
- Item 2: new shared helper `libreyolo/training/optim.py::build_optimizer`, routed through BaseTrainer and 12 family trainer sites plus `rtdetr`'s plain `Adam` branch the issue list missed. rfdetr's `_adamw` now delegates to it.
- Item 3: yolo9 loss-path syncs removed: `_global_cls_norm` returns a 0-dim tensor (new `all_reduce_avg_scalar_tensor` variant for the DDP branch, the shared float helper is untouched for its six other consumer families), the four per-key logging `.item()` calls in `yolo9/loss.py` and `yolo9_e2e/loss.py` return detached tensors, `get_loss_components` converts them with ONE stacked `.cpu()` transfer (rfdetr pattern from #761). Covers yolo9_p2 automatically: it has no loss of its own.

## Non-CUDA safety (the design driver)

- `fused=True` is requested only when every param is on CUDA. Recent torch silently accepts fused CPU and MPS params and validates device support at the first `step()`, not at construction, so the old try/except-only pattern was not a fallback on non-CUDA machines: it silently changed the reduction order. CPU and MPS construction is now byte-identical to stock (test-enforced). This also fixes rfdetr, which was already fused on CPU via the old helper.
- New resume guard `restore_optimizer_state`: `optimizer.load_state_dict` copies group hyperparameters wholesale, so a CUDA-written checkpoint carrying `fused: True` would re-enable fused when resumed on CPU/MPS (step-time RuntimeError on older torch, silent numerics change on recent torch). Both BaseTrainer load sites now strip `fused`/`foreach`/`capturable`/`differentiable` from the incoming state and keep the live construction's values.
- Sync removals are device-neutral: no-op on CPU, and the tensor values never leak past the trainer boundary: BaseTrainer routes every consumer (CSV, JSONL, tqdm, loggers, monitor) through `_scalar_mapping`, verified by consumer sweep.
- Numerics note, same as #761: fused vs foreach on CUDA is a different fp reduction order (~1e-7 relative per step), same algorithm. Everything else in this PR is exact.

## Verification

- New `tests/unit/test_train_speed_quick_wins.py` (24 tests): broadcast-L1 bitwise identity incl. empty targets, all five matchers run cdist-free and deterministic, fused gate (CPU stays stock and bitwise-identical, mixed devices stay unfused, CUDA fuses, construction fallback), resume guard, yolo9 tensor contract, single stacked transfer (asserted: one `.cpu()` for all keys), DDP tensor variant equals the float form.
- Existing suites green: rfdetr_train_speedups (one test updated to the gated contract plus a new CPU-stays-stock test), ddp_distributed, deim/dfine/deimv2/ec/rtdetr/tinyformer/segformer/ppliteseg/lingbotvision/vjepa2 trainer suites, yolo9/yolo9_e2e/yolo9_p2 suites.
- In-vivo smoke on a synthetic dataset: yolo9-t 2-epoch CPU train (stock path), yolo9-t 2-epoch CUDA train (checkpoint records `fused: True`, fused SGD live), that CUDA checkpoint resumed on CPU through the real resume API (post-restore fused flags all None), dfine-n 1-epoch CUDA train (broadcast matcher live).

## Code provenance

All code in this PR is original work written for this PR, re-deriving and generalizing patterns from this repository's own prior PRs #760, #761, #762 (MIT). No third-party code was ported, adapted, or consulted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces shared fused-on-CUDA optimizer construction and device-safe optimizer restoration, replaces five matcher L1 `cdist` calls with broadcast subtraction, and removes repeated YOLO9 loss-path device synchronizations.

- Routes base and family optimizer creation through a CUDA-gated shared helper.
- Preserves live-device optimizer implementation settings when loading checkpoints.
- Batches YOLO9 logging-scalar transfer into one CPU operation.
- Adds parity, fallback, resume, matcher, and distributed-normalization tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/optim.py | Adds centralized CUDA-gated optimizer construction and preserves live implementation-selection flags during checkpoint restoration. |
| libreyolo/training/trainer.py | Routes base optimizer creation and both optimizer-state restore paths through the new shared helpers. |
| libreyolo/training/distributed.py | Adds a tensor-returning scalar all-reduce while preserving the existing Python-float API. |
| libreyolo/models/yolo9/loss.py | Keeps normalization and logging scalars as detached device tensors to avoid per-step synchronization. |
| libreyolo/models/yolo9/trainer.py | Converts YOLO9 logging tensors with one stacked CPU transfer before returning Python floats. |
| libreyolo/models/yolo9_e2e/loss.py | Aligns E2E loss logging values with the detached-tensor contract consumed by YOLO9Trainer. |
| tests/unit/test_train_speed_quick_wins.py | Covers matcher parity, optimizer device gating and fallback, checkpoint restoration, and YOLO9 scalar-transfer behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Trainer parameter groups] --> B{All parameters on CUDA?}
  B -->|Yes| C[Try optimizer with fused=true]
  C -->|Construction supported| D[Fused optimizer]
  C -->|Construction rejected| E[Stock optimizer]
  B -->|No| E
  F[Resume checkpoint] --> G[Snapshot live implementation settings]
  G --> H[Load optimizer state]
  H --> I[Restore live fused/foreach/capturable settings]
  I --> J[Continue training]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Keep bare-tensor group params intact in ..."](https://github.com/libreyolo/libreyolo/commit/d016e0cbca43f4b15c5df4147e5878249cd9875f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53129946)</sub>

**Context used:**

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)

<!-- /greptile_comment -->