### PR TITLE
Separate the two kinds of dataset density this skill conflated

### DIFF
--- a/skills/run-rf100vl-benchmark/SKILL.md
+++ b/skills/run-rf100vl-benchmark/SKILL.md
@@ -39,12 +39,28 @@ knowledge those two do not cover.
 | Selection | validate every epoch, EMA weights, keep best AP50:95 | Roboflow reference code |
 | Epoch budget | fixed 100, early stopping DISABLED (`patience: 0`) | Roboflow reference code; the harness enforces it |
 | Effective batch | 16 (physical batch x gradient accumulation) | Roboflow reference code |
-| Precision | fp32; bf16 only via explicit `amp_dtype`; never fp16 autocast | LibreYOLO policy |
+| Precision | whatever the family's upstream reference trains at, declared in the recipe and recorded in every submission. fp32 for the YOLO trio, fp16 for `ec`, bf16 for `rfdetr`. Never a precision its authors do not use, in either direction | harness #10; measured 2026-08 |
 | Eval thresholds | conf 0.001; NMS IoU 0.65 for NMS families, identical at selection and final eval; DETR families are NMS-free top-k | LibreYOLO policy |
 | Seed | 0 | LibreYOLO policy |
 | Recipes | one pinned JSON per family in the harness (`va_bench/recipes/rf100vl/`), sha recorded in every run, same recipe for all 100 datasets | LibreYOLO policy |
 | Execution (YOLO) | `cuda_graph: true` and `cache: "disk"` in the recipe protocol when the installed LibreYOLO supports them (bit-identical; covered by recipe hash). Verify capture per family, per commit and per card: see "CUDA graphs and cache" | measured 2026-08 |
 | COCO evaluator | faster-coco-eval (Apache-2.0), now the LibreYOLO default; record the backend in artifacts | measured 2026-08 |
+
+**"Roboflow reference code" means what they RAN, not what the library
+defaults to.** For RF-DETR those differ, and the difference is invisible in a
+result table. Their maintainer states it in
+[rf-detr#266](https://github.com/roboflow/rf-detr/issues/266): the published
+RF100-VL numbers used "the default arguments but with batch size 16 and grad
+accum 1", posted three hours after the 1.2.0 release, so read the defaults off
+that tag rather than off `develop`, which has since drifted (`batch_size` now
+takes `"auto"`, `amp_dtype` became a selector). The library default is batch 4
+with accum 4. Both give effective batch 16, but `multi_scale` draws a fresh
+resolution per forward, so accum 4 averages four scales into an optimizer step
+where they averaged one. Two things in their numbers are not reproducible at
+all and belong in the recipe as disclosed deviations: they initialised from
+private Objects365 checkpoints that were never released (they estimate ~0.1
+mAP), and their table predates their own fix for an incorrectly initialised
+head.
 
 Never report toolkit-native trapezoidal mAP; it inflates up to 2.7 AP on
 RF100-VL versus pycocotools (paper, App B). LibreYOLO validation is
@@ -59,8 +75,9 @@ scoring against 112 s training** — 4.4×, and 6.9 of that dataset's 9.6 h.
 faster-coco-eval removes it: verified across all 100 test splits at
 max_det=500, **1381/1400 metric values bit-identical, max deviation 2.22e-16
 (one float64 ULP), headline mean AP delta exactly 0**, wall 131.4 s → 8.4 s
-(15.6× overall, 56× on gwhd2021). The dense outliers to expect are
-`gwhd2021`, `recode-waste`, `uavdet-small`. Keep stock pycocotools as the
+(15.6× overall, 56× on gwhd2021). Scoring cost tracks the MEAN boxes/image, so
+the datasets to expect it on are `uavdet-small` (75.9), `recode-waste` (44.3)
+and `gwhd2021` (42.9), against a median of 4.9. Keep stock pycocotools as the
 reference implementation for audit; do not silently swap backends without
 recording which one ran.
 
@@ -260,8 +277,22 @@ for how much memory a lane needs.
 
 Pick a **dense** dataset for the smoke, not a convenient one. `actions` is
 sparse and gave ec-m 13939 MB; the real campaign peaked at 14787 MB on
-`gwhd2021` (43.6 boxes/image). The three dense outliers are `gwhd2021`,
-`recode-waste`, `uavdet-small`.
+`gwhd2021` (43.6 boxes/image).
+
+**Dense for memory and dense for scoring are different lists, and this skill
+used to give the scoring one for both jobs.** Peak VRAM is set by the WORST
+SINGLE IMAGE in a batch, not the average, so size a lane against max
+boxes/image: `exploratorium-daphnia` (349), `all-elements` (279),
+`penguin-finder-seg` (246). The scoring-cost trio above is a poor proxy for it:
+`gwhd2021` maxes at 190 and `uavdet-small`, densest of all by mean, at only
+109. Measured on the train splits, which is what the harness reads when it
+builds the batch plan.
+
+The same asymmetry sets the OOM fallback: `dense_oom_fallback` triggers on
+`max_annotations_per_image`, so at the recipes' threshold of 200 exactly those
+three datasets drop to the fallback batch, on every family. That is a protocol
+deviation on 3 of 100 datasets which fires whether or not the lane would
+actually have OOM'd, so check it is the trade you want before dataset one.
 
 Take ~20% headroom. The registry's `params_millions`/`gflops` fields are `0.0`
 for most non-flagship specs, and parameter count does not predict memory


### PR DESCRIPTION
Three corrections to `skills/run-rf100vl-benchmark/SKILL.md`, all measured on the staged RF100-VL copy while running the rfdetr-s campaign.

## 1. Density: one list was doing two jobs

The skill named `gwhd2021`, `recode-waste`, `uavdet-small` as "the dense outliers" and used that list for both scoring cost and VRAM sizing. Those are different metrics.

**Scoring cost** tracks MEAN boxes/image. List was right, and incomplete:

| dataset | mean boxes/img |
|---|---|
| uavdet-small | **75.9** |
| recode-waste | 44.3 |
| gwhd2021 | 42.9 |
| (median) | 4.9 |

**Peak VRAM** is set by the worst SINGLE image in a batch. Completely different list:

| dataset | max boxes/img |
|---|---|
| exploratorium-daphnia | **349** |
| all-elements | 279 |
| penguin-finder-seg | 246 |
| gwhd2021 | 190 |
| uavdet-small | 109 |

So `Pick a dense dataset for the smoke` pointed at datasets that are mild by the metric that decides whether the lane OOMs. Both lists are now given, labelled by what they predict.

Also documented: `dense_oom_fallback` keys off `max_annotations_per_image`, so at the recipes' threshold of 200 exactly those top three take the fallback batch on **every** family, whether or not the lane would have OOM'd. That is a protocol deviation on 3 of 100 datasets and it should be a decision, not a surprise.

## 2. Precision row described a policy that no longer holds

Row said `fp32; bf16 only via explicit amp_dtype; never fp16 autocast`. Harness #10 replaced that with per-family upstream precision, and `ec` has trained fp16 under it since 2026-08-10. Row now states the actual policy: fp32 for the YOLO trio, fp16 for `ec`, bf16 for `rfdetr`, never a precision the authors do not use in either direction.

## 3. "Roboflow reference code" means what they ran, not the library defaults

The table cites it as the authority for effective batch. For RF-DETR the two differ, and the difference does not show up in a result table. Per [rf-detr#266](https://github.com/roboflow/rf-detr/issues/266):

> The RF-DETR numbers for the current release are using the default arguments but with batch size 16 and grad accum 1

Library default is batch 4 / accum 4. Both give effective batch 16, but `multi_scale` draws a fresh resolution per forward, so accum 4 averages four scales into an optimizer step where they averaged one. Comment was posted 3 hours after the 1.2.0 release, so the defaults must be read off that tag, not `develop`, which has drifted.

Also recorded: two parts of their setup nobody can reproduce (private Objects365 init, and a table predating their own head-init fix), so they land in a recipe as disclosed deviations instead of an unexplained gap.

## Code provenance

Documentation only. All prose written for this PR. The measurements come from running LibreYOLO against the RF100-VL datasets and reading their COCO annotation JSONs; the quoted line is from Roboflow's own issue tracker (rf-detr, Apache-2.0), cited by link. No third-party code copied or adapted.

https://claude.ai/code/session_01Gy5rL27krK8eMZGCP7xozD

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR revises the RF100-VL benchmark skill to distinguish scoring density from peak-memory density and updates precision and RF-DETR reproducibility guidance.
- Documents separate mean-box and maximum-box density lists.
- Describes the annotation-density fallback and its protocol implications.
- Updates per-family precision guidance.
- Clarifies RF-DETR reference batch, accumulation, and reproducibility deviations.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The fallback-family contradiction should be corrected before merging because it can cause operators to expect OOM protection that non-RF-DETR runs do not receive.

The changed documentation says dense datasets switch to a fallback batch on every family, while the same operational guide states that the planner enables this fallback only for RF-DETR and leaves other families vulnerable to fatal mid-run OOMs.

**Files Needing Attention:** skills/run-rf100vl-benchmark/SKILL.md
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| skills/run-rf100vl-benchmark/SKILL.md | Documentation improvements are generally focused and useful, but the new claim that every family takes the dense fallback contradicts the same skill’s RF-DETR-only family gate. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20libreyolo%2Flibreyolo%20PR%20%23766%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=766&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Askills%2Frun-rf100vl-benchmark%2FSKILL.md%3A291-295%0A**Fallback%20family%20scope%20is%20wrong**%0A%0AWhen%20an%20operator%20plans%20a%20non-RF-DETR%20run%20for%20one%20of%20these%20dense%20datasets%2C%20this%20paragraph%20says%20the%20dataset%20will%20use%20the%20fallback%20batch%2C%20but%20%60_batch_plan%60%20enables%20that%20fallback%20only%20for%20%60rfdetr%60%2C%20causing%20the%20operator%20to%20expect%20OOM%20protection%20that%20the%20run%20does%20not%20receive.%0A%0A%60%60%60suggestion%0AThe%20same%20asymmetry%20sets%20the%20OOM%20fallback%3A%20%60dense_oom_fallback%60%20triggers%20on%0A%60max_annotations_per_image%60%2C%20so%20at%20the%20recipes'%20threshold%20of%20200%20exactly%20those%0Athree%20datasets%20exceed%20the%20threshold.%20For%20%60rfdetr%60%2C%20they%20drop%20to%20the%20fallback%0Abatch%20whether%20or%20not%20the%20lane%20would%20actually%20have%20OOM'd%2C%20creating%20a%20protocol%0Adeviation%20on%203%20of%20100%20datasets.%20Check%20that%20this%20is%20the%20trade%20you%20want%20before%0Adataset%20one.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=766&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22skill-rf100vl-density-precision%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22skill-rf100vl-density-precision%22.%0A%0A%23%23%23%20Issue%201%0Askills%2Frun-rf100vl-benchmark%2FSKILL.md%3A291-295%0A**Fallback%20family%20scope%20is%20wrong**%0A%0AWhen%20an%20operator%20plans%20a%20non-RF-DETR%20run%20for%20one%20of%20these%20dense%20datasets%2C%20this%20paragraph%20says%20the%20dataset%20will%20use%20the%20fallback%20batch%2C%20but%20%60_batch_plan%60%20enables%20that%20fallback%20only%20for%20%60rfdetr%60%2C%20causing%20the%20operator%20to%20expect%20OOM%20protection%20that%20the%20run%20does%20not%20receive.%0A%0A%60%60%60suggestion%0AThe%20same%20asymmetry%20sets%20the%20OOM%20fallback%3A%20%60dense_oom_fallback%60%20triggers%20on%0A%60max_annotations_per_image%60%2C%20so%20at%20the%20recipes'%20threshold%20of%20200%20exactly%20those%0Athree%20datasets%20exceed%20the%20threshold.%20For%20%60rfdetr%60%2C%20they%20drop%20to%20the%20fallback%0Abatch%20whether%20or%20not%20the%20lane%20would%20actually%20have%20OOM'd%2C%20creating%20a%20protocol%0Adeviation%20on%203%20of%20100%20datasets.%20Check%20that%20this%20is%20the%20trade%20you%20want%20before%0Adataset%20one.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=766&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Separate the two kinds of dataset densit..."](https://github.com/libreyolo/libreyolo/commit/9c34fed5570a7306e281351e1e01771a825c13d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53153635)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->