### PR TITLE
Add LoRA detection fine-tuning for the LibreVLM tier (Qwen3-VL)

### DIFF
--- a/docs/adr/0002-librevlm-contract.md
+++ b/docs/adr/0002-librevlm-contract.md
@@ -160,7 +160,10 @@ executing mutable upstream model-repository code under the same alias.
 
 ## Out Of Scope (v1)
 
-- Training / fine-tuning (`train()` raises; fine-tune upstream).
+- Training / fine-tuning (`train()` raises; fine-tune upstream). Superseded
+  for Qwen3-VL: LoRA detection fine-tuning shipped later behind the same
+  `train()` surface, with untrainable families keeping documented refusal
+  messages. See `docs/vlm_training.md`.
 - Dataset validation / mAP (`val()` raises; see "Confidence").
 - Export to ONNX/TensorRT/etc. (`export()` raises; generative decode).
 - CLI: the `libreyolo` command does not resolve VLM aliases in v1. The tier is a

--- a/docs/vlm_training.md
+++ b/docs/vlm_training.md
@@ -1,0 +1,106 @@
+# VLM detection fine-tuning
+
+Fine-tune a LibreVLM detector on a standard detect dataset. First trainable
+family: Qwen3-VL. Everything below is the shipped contract; the wider design
+rationale lives in `docs/adr/0002-librevlm-contract.md` (tier contract) and the
+training ADR draft.
+
+## Use
+
+```python
+from libreyolo import LibreVLM
+
+model = LibreVLM("qwen3-vl-2b")
+results = model.train(data="strawberries.yaml", epochs=10)
+
+model = LibreVLM(results["best"])       # load the fine-tune
+model.predict("field.jpg")              # vocabulary comes from the dataset
+```
+
+Needs the optional extra:
+
+```
+pip install "libreyolo[vlm-train]"
+```
+
+- `data` is the standard detect dataset (`docs/dataset_schema.md`): YAML with
+  `train`/`val` image sources and txt label rows. Native COCO JSON datasets
+  are not supported yet and raise with a clear message.
+- The `names` in the YAML become the training vocabulary. Names may be any
+  phrases ("ripe strawberry", "person wearing a helmet"); they are rendered
+  into the model's own grounding prompt and answer format automatically, using
+  the same `BBOX_KEY` / `COORD_DIVISOR` / `BOX_FORMAT` convention the family's
+  `predict()` parser uses. Train and predict cannot drift apart, by
+  construction.
+- `lora=True` is the default and the recommended path. The recipe (rank 16,
+  alpha 32, language-model attention and MLP projections, vision tower frozen)
+  is fixed per family in `libreyolo/models/vlm/training/recipes.py`, not a
+  user-facing knob. `lora=False` full fine-tuning exists behind a VRAM
+  preflight.
+- Defaults reflect VLM reality: `batch=1`, `accumulate=8` (effective batch 8),
+  gradient checkpointing on, cosine schedule with warmup, bf16 autocast on
+  CUDA. There is no `imgsz`; the family's processor owns resolution.
+- Augmentation is geometric-safe only (`hflip=0.5`), because every geometric
+  transform re-renders the target text. Mosaic-style compositing does not
+  apply to generative targets.
+- `resume=` continues from a prior adapter checkpoint (weights only; the
+  optimizer state starts fresh, and the log says so).
+- `callbacks=` and `loggers=` are the standard training layers; TensorBoard,
+  MLflow, and W&B loggers work unchanged.
+
+## Checkpoints
+
+A VLM checkpoint is a directory, not a `.pt`:
+
+```
+runs/vlm/train/weights/best/
+  adapter_model.safetensors    # LoRA adapter (megabytes)
+  adapter_config.json
+  ...processor files...
+  libreyolo_vlm.json           # the contract file
+```
+
+`libreyolo_vlm.json` records family, size, the exact base repo and revision
+the adapter was trained on, the ordered vocabulary, the coordinate convention,
+and the run metrics. `LibreVLM(path)` recognizes the contract, downloads the
+recorded base (never a drifted newer snapshot), merges the adapter for
+inference speed, and pre-applies the saved vocabulary. Base weights are never
+copied into checkpoints, so LibreYOLO never redistributes upstream weights.
+
+Full fine-tunes (`lora=False`) save a self-contained model directory instead;
+the same `LibreVLM(path)` call loads either kind.
+
+## Best/last selection
+
+`best` tracks validation loss when the dataset has a `val` split, else
+training loss. Validation mAP for VLM checkpoints lands together with the
+tier's `val()` support (blocked on real per-box confidence; see the ADR).
+
+## Trainable families
+
+| Family | train() | Why |
+|---|---|---|
+| qwen3-vl | yes | grounding-pretrained, Apache-2.0, official upstream recipe mirrored |
+| lfm2-vl, florence-2, north-micro-vision, internvl3 | not yet | planned; see the training ADR draft |
+| smolvlm2 | no | not grounding-pretrained; cannot reliably learn box emission |
+| kosmos-2 | no | no established recipe; 224px 32x32 grid caps localization |
+| locate-anything | no | research-only non-commercial upstream weights |
+| sensenova-vision | no | multi-node-scale training only, no parameter-efficient path |
+| libremodus | no | upstream ships a pretraining pipeline; gated research-only weights |
+
+The refusal messages on the untrainable families state these reasons.
+
+## Implementation notes
+
+- Trainer: `libreyolo/models/vlm/training/` (dataset rendering, chat-template
+  collation with longest-common-prefix label masking, PEFT LoRA injection with
+  scope assertions, compact loop). Not a `BaseTrainer` subclass: stacked-tensor
+  batching, EMA, and mAP-based epoch logic do not apply to a generative
+  fine-tune.
+- Label masking tolerates boundary retokenization (a template ending in a bare
+  newline can merge that newline into the first answer token) but fails loudly
+  if a chat template rewrites the user turn when an answer is appended.
+- Tests: `tests/unit/test_vlm_training.py` (offline: serialization round-trip
+  through the inference parser, collator masking, contract, gating) and
+  `tests/e2e/test_vlm_train_qwen3vl.py` (CPU end-to-end on a pinned tiny-random
+  Qwen3-VL: train, checkpoint, factory reload, predict).

--- a/libreyolo/models/vlm/__init__.py
+++ b/libreyolo/models/vlm/__init__.py
@@ -79,19 +79,44 @@ _MODUS_ALIASES: Dict[str, str] = {
 _DEFAULT_MODEL = "qwen3-vl-4b"
 
 
+def _load_checkpoint(path, **kwargs) -> LibreVLMModel:
+    """Load a fine-tune checkpoint directory produced by ``train()``."""
+    from .training.checkpoint import read_contract
+
+    contract = read_contract(path)
+    family_classes = {cls.FAMILY: cls for cls, _size in _ALIASES.values()}
+    family_cls = family_classes.get(contract["family"])
+    if family_cls is None:
+        raise ValueError(
+            f"VLM checkpoint {path} was trained on unknown family "
+            f"{contract['family']!r}; this libreyolo build knows "
+            f"{sorted(family_classes)}."
+        )
+    kwargs.setdefault("names", list(contract["names"]))
+    return family_cls(size=contract["size"], checkpoint_dir=str(path), **kwargs)
+
+
 def LibreVLM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreVLMModel:
-    """Load a vision-language detector by name.
+    """Load a vision-language detector by name or fine-tune checkpoint path.
 
     Args:
-        model: Model alias (e.g. ``"qwen3-vl-4b"``, ``"lfm2-vl-450m"``).
-            Defaults to Qwen3-VL-4B (Apache-2.0).
+        model: Model alias (e.g. ``"qwen3-vl-4b"``, ``"lfm2-vl-450m"``), or a
+            path to a fine-tune checkpoint directory produced by ``train()``
+            (it carries ``libreyolo_vlm.json``). Defaults to Qwen3-VL-4B
+            (Apache-2.0).
         **kwargs: Forwarded to the family constructor: ``device``, ``names``
             (initial class vocabulary, same as calling ``set_classes`` after
             load), ``prompt`` (override the detection prompt), ``max_new_tokens``.
+            When loading a checkpoint, ``names`` defaults to the vocabulary the
+            fine-tune was trained on.
 
     Returns:
         A ``LibreVLMModel`` instance with the standard predict/track surface.
     """
+    from .training.checkpoint import is_vlm_checkpoint
+
+    if is_vlm_checkpoint(model):
+        return _load_checkpoint(model, **kwargs)
     key = str(model).strip().lower()
     if key in _LAZY_ALIASES:
         from ..sensenova import LibreSenseNovaVision

--- a/libreyolo/models/vlm/base.py
+++ b/libreyolo/models/vlm/base.py
@@ -87,6 +87,12 @@ class LibreVLMModel(BaseModel):
     _LICENSE_NOTICE: ClassVar[str] = ""
     _LICENSE_NOTICE_SHOWN: ClassVar[bool] = False
 
+    # Detection fine-tuning support. A family becomes trainable by setting this
+    # True AND adding a recipe in ``training/recipes.py``; everything else
+    # raises from ``train()`` with the family's documented reason.
+    TRAINABLE: ClassVar[bool] = False
+    TRAIN_UNSUPPORTED_REASON: ClassVar[str] = ""
+
     # Off by default: all shipped families load through native transformers
     # classes, so we never execute third-party repo code. A family that genuinely
     # needs it must opt in explicitly (and pin a revision).
@@ -119,6 +125,7 @@ class LibreVLMModel(BaseModel):
         task: str | None = None,
         prompt: Optional[str] = None,
         max_new_tokens: Optional[int] = None,
+        checkpoint_dir: Optional[str] = None,
         **kwargs,
     ):
         if size not in self.HF_REPOS:
@@ -127,6 +134,21 @@ class LibreVLMModel(BaseModel):
                 f"Must be one of: {', '.join(self.HF_REPOS)}"
             )
         self._custom_prompt = prompt
+        # Set before super().__init__ because _init_model runs inside it.
+        self._checkpoint_dir = Path(checkpoint_dir) if checkpoint_dir else None
+        if self._checkpoint_dir is not None:
+            # A fine-tune is only valid on the exact base it was trained on:
+            # shadow the class repo/revision with the contract's record so the
+            # adapter never lands on a drifted upstream snapshot.
+            from .training.checkpoint import read_contract
+
+            contract = read_contract(self._checkpoint_dir)
+            base_repo = contract.get("base_repo")
+            if base_repo:
+                self.HF_REPOS = {**self.HF_REPOS, size: base_repo}
+            base_revision = contract.get("base_revision")
+            if base_revision:
+                self.HF_REVISIONS = {**self.HF_REVISIONS, size: base_revision}
         if max_new_tokens is not None:
             self.MAX_NEW_TOKENS = max_new_tokens
 
@@ -376,14 +398,60 @@ class LibreVLMModel(BaseModel):
         return model, processor
 
     def _init_model(self) -> nn.Module:
-        snapshot_dir = self._ensure_weights()
-        model, processor = self._load_pretrained(snapshot_dir)
+        checkpoint_dir = getattr(self, "_checkpoint_dir", None)
+        if checkpoint_dir is not None and (checkpoint_dir / "config.json").exists():
+            # Full fine-tune checkpoint: a self-contained model directory.
+            model, processor = self._load_pretrained(str(checkpoint_dir))
+        else:
+            snapshot_dir = self._ensure_weights()
+            model, processor = self._load_pretrained(snapshot_dir)
+            if checkpoint_dir is not None:
+                model = self._apply_adapter(model, checkpoint_dir)
+                processor = self._load_checkpoint_processor(checkpoint_dir, processor)
         self.processor = processor
         # The actual loaded weight dtype (bf16/fp16 on CUDA, fp32 on CPU). Used to
         # cast the processor's float tensors so a half-precision model never gets
         # fp32 pixel_values on a vision tower that does not self-cast.
         self._model_dtype = next(model.parameters()).dtype
         return model
+
+    def _apply_adapter(self, model: nn.Module, checkpoint_dir: Path) -> nn.Module:
+        """Apply a LoRA fine-tune checkpoint to the freshly loaded base model.
+
+        The adapter is merged into dense weights immediately: inference then
+        runs at plain-model speed with no live peft dependency on the object.
+        """
+        if not (checkpoint_dir / "adapter_config.json").exists():
+            raise FileNotFoundError(
+                f"VLM checkpoint {checkpoint_dir} has neither a full model "
+                "(config.json) nor a LoRA adapter (adapter_config.json)."
+            )
+        try:
+            from peft import PeftModel
+        except ImportError as exc:
+            raise ImportError(
+                "Loading a LoRA fine-tune checkpoint requires the 'vlm-train' "
+                "extra. Install with:\n    pip install 'libreyolo[vlm-train]'"
+            ) from exc
+        peft_model = PeftModel.from_pretrained(model, str(checkpoint_dir))
+        merged = peft_model.merge_and_unload()
+        logger.info(
+            "Loaded fine-tune adapter from %s (merged for inference).",
+            checkpoint_dir,
+        )
+        return merged
+
+    def _load_checkpoint_processor(self, checkpoint_dir: Path, fallback):
+        """Prefer the processor snapshot saved inside the checkpoint."""
+        if not (checkpoint_dir / "preprocessor_config.json").exists():
+            return fallback
+        try:
+            from transformers import AutoProcessor
+        except ImportError:
+            return fallback
+        return AutoProcessor.from_pretrained(
+            str(checkpoint_dir), trust_remote_code=self.TRUST_REMOTE_CODE
+        )
 
     def _prepare_generation_inputs(self, inputs: Any) -> Any:
         """Cast inputs and drop processor keys unsupported by ``generate``."""
@@ -528,14 +596,44 @@ class LibreVLMModel(BaseModel):
         )
 
     # =========================================================================
-    # Out of scope for the inference-first VLM tier
+    # Training (LoRA detection fine-tuning; trainable families only)
     # =========================================================================
 
-    def train(self, *args, **kwargs):
-        raise NotImplementedError(
-            f"Training is out of scope for {type(self).__name__} in LibreYOLO. "
-            "Fine-tune the VLM upstream and load the resulting weights."
-        )
+    def train(self, data: Optional[str] = None, **kwargs):
+        """Fine-tune this VLM as a detector on a standard detect dataset.
+
+        Args:
+            data: Path to a standard LibreYOLO detect dataset YAML. The
+                ``names`` in the YAML become the training vocabulary (any
+                phrases work) and the boxes are rendered into this family's
+                own grounding text format automatically.
+            **kwargs: ``epochs``, ``batch``, ``accumulate``, ``lr0``,
+                ``lora`` (default True), ``output_dir``/``project``/``name``,
+                ``resume``, ``callbacks``, ``loggers``, ``device``, ``seed``,
+                ``workers``, ``hflip``, ``gradient_checkpointing``.
+
+        Returns:
+            A results dict with ``save_dir``, ``best``/``last`` checkpoint
+            directories, and final metrics. Load a checkpoint with
+            ``LibreVLM(results["best"])``.
+        """
+        if not self.TRAINABLE:
+            reason = self.TRAIN_UNSUPPORTED_REASON or (
+                f"Training is not supported for {type(self).__name__} in "
+                "LibreYOLO yet. Trainable VLM families: qwen3-vl."
+            )
+            raise NotImplementedError(reason)
+        if not data:
+            raise ValueError(
+                'train() requires data=<dataset yaml>, e.g. train(data="data.yaml").'
+            )
+        from .training.trainer import VLMDetectionTrainer
+
+        return VLMDetectionTrainer(self, data=data, **kwargs).run()
+
+    # =========================================================================
+    # Out of scope for the inference-first VLM tier
+    # =========================================================================
 
     def val(self, *args, **kwargs):
         raise NotImplementedError(

--- a/libreyolo/models/vlm/kosmos2.py
+++ b/libreyolo/models/vlm/kosmos2.py
@@ -25,6 +25,12 @@ class LibreKosmos2(LibreVLMModel):
     FAMILY = "kosmos2"
     FILENAME_PREFIX = "LibreKosmos2"
 
+    TRAIN_UNSUPPORTED_REASON = (
+        "Kosmos-2 has no established fine-tuning recipe, and its 224px input "
+        "with a 32x32 patch-index grid caps localization quality. Use "
+        "qwen3-vl for trainable VLM detection."
+    )
+
     HF_REPOS: ClassVar[Dict[str, str]] = {
         "224": "microsoft/kosmos-2-patch14-224",
     }

--- a/libreyolo/models/vlm/locateanything.py
+++ b/libreyolo/models/vlm/locateanything.py
@@ -175,6 +175,13 @@ class LibreLocateAnything(LibreVLMModel):
     COORD_DIVISOR = 1000.0
     TRUST_REMOTE_CODE = True
 
+    TRAIN_UNSUPPORTED_REASON = (
+        "LocateAnything's upstream weights are research-only non-commercial, "
+        "so fine-tuned derivatives cannot be shipped for commercial use, and "
+        "its training loop is a bespoke upstream pipeline. Use qwen3-vl for "
+        "trainable VLM detection."
+    )
+
     _LICENSE_NOTICE = (
         "\n"
         "----------------------------------------------------------------\n"

--- a/libreyolo/models/vlm/qwen3vl.py
+++ b/libreyolo/models/vlm/qwen3vl.py
@@ -40,6 +40,12 @@ class LibreQwen3VL(LibreVLMModel):
     BBOX_KEY = "bbox_2d"
     COORD_DIVISOR = 1000.0
 
+    # First trainable family: grounding-pretrained, Apache-2.0, native
+    # transformers classes, and an official upstream fine-tuning recipe this
+    # implementation mirrors (LoRA on the LM, frozen vision tower). Recipe in
+    # ``training/recipes.py``.
+    TRAINABLE = True
+
     # Apache-2.0 weights: no restrictive-license notice needed.
     _LICENSE_NOTICE = ""
 

--- a/libreyolo/models/vlm/smolvlm.py
+++ b/libreyolo/models/vlm/smolvlm.py
@@ -23,6 +23,12 @@ class LibreSmolVLM2(LibreVLMModel):
     FAMILY = "smolvlm2"
     FILENAME_PREFIX = "LibreSmolVLM2"
 
+    TRAIN_UNSUPPORTED_REASON = (
+        "SmolVLM2 is not grounding-pretrained, so detection fine-tuning cannot "
+        "reliably teach box emission. Use a grounding-pretrained family such "
+        "as qwen3-vl."
+    )
+
     HF_REPOS: ClassVar[Dict[str, str]] = {
         "2.2b": "HuggingFaceTB/SmolVLM2-2.2B-Instruct",
         "500m": "HuggingFaceTB/SmolVLM2-500M-Video-Instruct",

--- a/libreyolo/models/vlm/training/__init__.py
+++ b/libreyolo/models/vlm/training/__init__.py
@@ -1,0 +1,20 @@
+"""VLM detection fine-tuning: dataset rendering, collation, and the trainer.
+
+The public entry point is ``LibreVLM(...).train(data=...)``; this package is
+its implementation. See ``docs/adr/0002-librevlm-contract.md`` for the tier
+contract and ``docs/vlm_training.md`` for the training design.
+
+Heavy imports (torch, peft) stay inside the modules so importing the ``vlm``
+package without the ``vlm-train`` extra keeps working.
+"""
+
+from .checkpoint import CONTRACT_FILENAME, is_vlm_checkpoint, read_contract
+from .targets import FamilyFormat, serialize_detections
+
+__all__ = [
+    "CONTRACT_FILENAME",
+    "FamilyFormat",
+    "is_vlm_checkpoint",
+    "read_contract",
+    "serialize_detections",
+]

--- a/libreyolo/models/vlm/training/checkpoint.py
+++ b/libreyolo/models/vlm/training/checkpoint.py
@@ -1,0 +1,108 @@
+"""The VLM fine-tune checkpoint contract.
+
+A VLM checkpoint is a directory, not a ``.pt``: the PEFT adapter tensors, the
+processor snapshot, and ``libreyolo_vlm.json``, the contract file that makes
+the directory loadable by ``LibreVLM(path)``. Base weights are never copied
+into a checkpoint; the contract records which base repo (and pinned revision)
+to resolve, so checkpoints stay megabytes and LibreYOLO never redistributes
+upstream weights.
+
+``libreyolo_vlm.json`` fields (schema 1):
+
+- ``schema``: contract version, integer.
+- ``family`` / ``size``: adapter class resolution keys.
+- ``base_repo`` / ``base_revision``: the exact base the adapter was trained on.
+- ``names``: ordered training vocabulary; pre-applied on load.
+- ``bbox_key`` / ``coord_divisor`` / ``box_format`` / ``prompt``: the output
+  convention the fine-tune was trained to emit, recorded for auditability.
+- ``task``: always ``detect`` today.
+- ``metrics``: final metrics of the producing run.
+- ``libreyolo_version``: producer version string.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+CONTRACT_FILENAME = "libreyolo_vlm.json"
+CONTRACT_SCHEMA = 1
+
+__all__ = [
+    "CONTRACT_FILENAME",
+    "is_vlm_checkpoint",
+    "read_contract",
+    "save_vlm_checkpoint",
+]
+
+
+def is_vlm_checkpoint(path) -> bool:
+    """True when ``path`` is a directory carrying the VLM checkpoint contract."""
+    try:
+        p = Path(path)
+    except TypeError:
+        return False
+    return p.is_dir() and (p / CONTRACT_FILENAME).is_file()
+
+
+def read_contract(path) -> Dict[str, Any]:
+    """Read and minimally validate a checkpoint's contract file."""
+    contract_path = Path(path) / CONTRACT_FILENAME
+    try:
+        contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Unreadable VLM checkpoint contract {contract_path}: {exc}") from exc
+    schema = contract.get("schema")
+    if schema != CONTRACT_SCHEMA:
+        raise ValueError(
+            f"VLM checkpoint {path} uses contract schema {schema!r}; this "
+            f"LibreYOLO understands schema {CONTRACT_SCHEMA}. Upgrade libreyolo."
+        )
+    for key in ("family", "size", "names"):
+        if key not in contract:
+            raise ValueError(f"VLM checkpoint contract {contract_path} is missing {key!r}.")
+    return contract
+
+
+def save_vlm_checkpoint(
+    directory,
+    *,
+    peft_model,
+    processor,
+    wrapper,
+    metrics: Optional[Dict[str, Any]] = None,
+) -> Path:
+    """Write one checkpoint directory: adapter + processor + contract."""
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    peft_model.save_pretrained(str(directory))
+    processor.save_pretrained(str(directory))
+
+    try:
+        from libreyolo import __version__ as libreyolo_version
+    except ImportError:  # pragma: no cover
+        libreyolo_version = "unknown"
+
+    contract = {
+        "schema": CONTRACT_SCHEMA,
+        "family": wrapper.FAMILY,
+        "size": wrapper.size,
+        "base_repo": wrapper.HF_REPOS[wrapper.size],
+        "base_revision": wrapper.HF_REVISIONS.get(wrapper.size),
+        "names": [wrapper.names[i] for i in range(len(wrapper.names))],
+        "bbox_key": wrapper.BBOX_KEY,
+        "coord_divisor": float(wrapper.COORD_DIVISOR),
+        "box_format": wrapper.BOX_FORMAT,
+        "prompt": wrapper._detection_prompt(),
+        "task": "detect",
+        "metrics": dict(metrics or {}),
+        "libreyolo_version": libreyolo_version,
+    }
+    (directory / CONTRACT_FILENAME).write_text(
+        json.dumps(contract, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return directory

--- a/libreyolo/models/vlm/training/collate.py
+++ b/libreyolo/models/vlm/training/collate.py
@@ -1,0 +1,127 @@
+"""Batch collation for VLM detection fine-tuning.
+
+Turns dataset samples (PIL image + prompt + target text) into the tensors a
+chat-template VLM trains on. The one delicate step is label masking: only the
+assistant's answer tokens are supervised; the user turn (including every image
+token) and padding are masked to -100.
+
+Masking is done by the prompt-prefix method: the batch is tokenized twice, once
+as the full conversation and once as the user turn plus generation prompt.
+With right padding, the prompt tokens are a prefix of the full sequence, so
+masking up to the common prefix is family-agnostic; no per-family image token
+ids are needed.
+
+One boundary subtlety: the last prompt token may retokenize when the answer is
+appended (e.g. a template ending in ``<think>\n`` merges that newline into a
+``\n\n`` token once text follows), so the mask runs to the LONGEST COMMON
+PREFIX of the two tokenizations, with a small tolerance. A template that
+genuinely rewrites the user turn when an answer is present would produce a
+short common prefix, and that still fails loudly instead of silently training
+on prompt tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar, Dict, List, Sequence
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["VLMChatCollator"]
+
+
+class VLMChatCollator:
+    """Collate ``{"image", "prompt", "target"}`` samples into a training batch."""
+
+    # Processor outputs that generative forward passes do not accept.
+    DROP_KEYS: ClassVar[tuple] = ("token_type_ids",)
+    # How many trailing prompt tokens may retokenize at the prompt/answer
+    # boundary before it is treated as a broken template. Merged-newline
+    # boundaries use 1-2; anything larger means the template rewrote the turn.
+    BOUNDARY_TOLERANCE: ClassVar[int] = 4
+
+    def __init__(self, processor, max_length_warn: int | None = None) -> None:
+        self.processor = processor
+        self.max_length_warn = max_length_warn
+        self._warned_length = False
+
+    def _tokenizer(self):
+        return getattr(self.processor, "tokenizer", self.processor)
+
+    def __call__(self, samples: Sequence[Dict[str, Any]]) -> Dict[str, torch.Tensor]:
+        full: List[list] = []
+        prompt_only: List[list] = []
+        for sample in samples:
+            user = {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": sample["image"]},
+                    {"type": "text", "text": sample["prompt"]},
+                ],
+            }
+            assistant = {
+                "role": "assistant",
+                "content": [{"type": "text", "text": sample["target"]}],
+            }
+            full.append([user, assistant])
+            prompt_only.append([user])
+
+        tokenizer = self._tokenizer()
+        previous_side = getattr(tokenizer, "padding_side", "right")
+        tokenizer.padding_side = "right"
+        try:
+            batch = self.processor.apply_chat_template(
+                full,
+                tokenize=True,
+                return_dict=True,
+                return_tensors="pt",
+                padding=True,
+            )
+            prompts = self.processor.apply_chat_template(
+                prompt_only,
+                tokenize=True,
+                return_dict=True,
+                return_tensors="pt",
+                padding=True,
+                add_generation_prompt=True,
+            )
+        finally:
+            tokenizer.padding_side = previous_side
+
+        labels = batch["input_ids"].clone()
+        if "attention_mask" in batch:
+            labels[batch["attention_mask"] == 0] = -100
+        prompt_lengths = prompts["attention_mask"].sum(dim=1).tolist()
+        for i, prompt_len in enumerate(prompt_lengths):
+            full_row = batch["input_ids"][i, :prompt_len]
+            prompt_row = prompts["input_ids"][i, :prompt_len]
+            diverging = (full_row != prompt_row).nonzero()
+            common = int(diverging[0]) if len(diverging) else prompt_len
+            if prompt_len - common > self.BOUNDARY_TOLERANCE:
+                raise RuntimeError(
+                    "Chat template broke the prompt-prefix property: the user "
+                    "turn tokenizes differently with and without the assistant "
+                    "answer. Label masking would supervise prompt tokens; "
+                    "this family needs a dedicated collator."
+                )
+            labels[i, :common] = -100
+        batch["labels"] = labels
+
+        if (
+            self.max_length_warn
+            and not self._warned_length
+            and batch["input_ids"].shape[1] > self.max_length_warn
+        ):
+            self._warned_length = True
+            logger.warning(
+                "Training sequence length %d exceeds %d tokens; expect high "
+                "VRAM use. Lower max_pixels or simplify the vocabulary.",
+                batch["input_ids"].shape[1],
+                self.max_length_warn,
+            )
+
+        for key in self.DROP_KEYS:
+            batch.pop(key, None)
+        return batch

--- a/libreyolo/models/vlm/training/data.py
+++ b/libreyolo/models/vlm/training/data.py
@@ -1,0 +1,155 @@
+"""Detect-dataset reader for VLM fine-tuning.
+
+Reads the standard LibreYOLO detect dataset (``docs/dataset_schema.md``: YAML
+with ``train``/``val`` image sources and txt label rows ``class cx cy w h``
+normalized to [0, 1]) and yields PIL images with rendered conversation targets.
+The user never writes conversations or coordinate text; that is the library's
+job, via :mod:`.targets`.
+
+Augmentation is geometric-safe only (horizontal flip), because every geometric
+transform must re-render the target text; the flip happens before rendering.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from PIL import Image
+
+from ....data import get_img_files, img2label_paths
+from .targets import FamilyFormat, serialize_detections
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["VLMDetectDataset"]
+
+
+def _parse_label_file(path: Path) -> List[Tuple[int, float, float, float, float]]:
+    """Parse one txt label file into ``(cls, cx, cy, w, h)`` rows.
+
+    Missing file means no objects (dataset-schema rule). Malformed rows are
+    skipped with a warning rather than aborting a long training run.
+    """
+    if not path.exists():
+        return []
+    rows: List[Tuple[int, float, float, float, float]] = []
+    for line_no, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+    ):
+        parts = line.split()
+        if not parts:
+            continue
+        try:
+            cls = int(float(parts[0]))
+            cx, cy, w, h = (float(v) for v in parts[1:5])
+        except (ValueError, IndexError):
+            logger.warning("Skipping malformed label row %s:%d: %r", path, line_no, line)
+            continue
+        if len(parts) != 5:
+            logger.warning(
+                "Skipping label row with %d fields (detect rows have 5) %s:%d",
+                len(parts),
+                path,
+                line_no,
+            )
+            continue
+        rows.append((cls, cx, cy, w, h))
+    return rows
+
+
+class VLMDetectDataset:
+    """Map-style dataset: detect labels in, conversation samples out.
+
+    Each item is a dict with ``image`` (PIL, RGB), ``prompt`` (the family's
+    detection prompt for the training vocabulary), and ``target`` (the JSON
+    answer text rendered by :func:`serialize_detections`).
+    """
+
+    def __init__(
+        self,
+        image_source,
+        names: Dict[int, str],
+        fmt: FamilyFormat,
+        augment: bool = False,
+        hflip_p: float = 0.5,
+        seed: int = 0,
+    ) -> None:
+        self.names = dict(names)
+        self.fmt = fmt
+        self.augment = augment
+        self.hflip_p = float(hflip_p)
+        self._rng = random.Random(seed)
+        self.images: List[Path] = get_img_files(image_source)
+        if not self.images:
+            raise FileNotFoundError(f"No images found under {image_source!r}")
+        self.labels: List[Path] = img2label_paths(self.images)
+        self._warned_unknown_class = False
+
+    def __len__(self) -> int:
+        return len(self.images)
+
+    def _load_boxes(self, index: int) -> Tuple[List[List[float]], List[str]]:
+        boxes: List[List[float]] = []
+        labels: List[str] = []
+        for cls, cx, cy, w, h in _parse_label_file(self.labels[index]):
+            name = self.names.get(cls)
+            if name is None:
+                if not self._warned_unknown_class:
+                    logger.warning(
+                        "Label file %s references class id %d not present in the "
+                        "dataset names; such rows are skipped.",
+                        self.labels[index],
+                        cls,
+                    )
+                    self._warned_unknown_class = True
+                continue
+            x1 = cx - w / 2.0
+            y1 = cy - h / 2.0
+            x2 = cx + w / 2.0
+            y2 = cy + h / 2.0
+            boxes.append(
+                [
+                    min(max(x1, 0.0), 1.0),
+                    min(max(y1, 0.0), 1.0),
+                    min(max(x2, 0.0), 1.0),
+                    min(max(y2, 0.0), 1.0),
+                ]
+            )
+            labels.append(name)
+        return boxes, labels
+
+    def __getitem__(self, index: int) -> Dict[str, object]:
+        image = Image.open(self.images[index]).convert("RGB")
+        boxes, labels = self._load_boxes(index)
+        if self.augment and self._rng.random() < self.hflip_p:
+            image = image.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+            boxes = [[1.0 - x2, y1, 1.0 - x1, y2] for x1, y1, x2, y2 in boxes]
+        target = serialize_detections(boxes, labels, self.fmt)
+        return {
+            "image": image,
+            "prompt": self.fmt.detection_prompt,
+            "target": target,
+        }
+
+
+def resolve_split_source(data_cfg: Dict, split: str) -> Optional[object]:
+    """Return the image source for a split, or None if the split is absent.
+
+    Native COCO JSON datasets (``annotations:`` in the YAML) are not supported
+    by the VLM trainer yet; the caller gets a clear error instead of silently
+    training without boxes.
+    """
+    annotations = data_cfg.get("annotations")
+    has_coco_json = (
+        isinstance(annotations, dict) and annotations.get(split)
+    ) or data_cfg.get(f"{split}_annotation_file")
+    if has_coco_json:
+        raise NotImplementedError(
+            "VLM training reads txt label files (docs/dataset_schema.md); native "
+            "COCO JSON datasets are not supported yet. Convert the annotations "
+            "to txt labels to train a VLM on this dataset."
+        )
+    return data_cfg.get(split)

--- a/libreyolo/models/vlm/training/recipes.py
+++ b/libreyolo/models/vlm/training/recipes.py
@@ -1,0 +1,63 @@
+"""Per-family VLM fine-tuning recipes.
+
+Fixed per family, not user-facing knobs (the docs/lora.md philosophy): rank,
+alpha, targets, what freezes, and the optimizer defaults live here. A family
+becomes trainable by adding a recipe AND setting ``TRAINABLE = True`` on its
+adapter class; the trainer refuses families without both.
+
+Qwen3-VL: LoRA on the language model's attention and MLP projections, vision
+tower and merger frozen. Matches the official qwen-vl-finetune defaults
+(rank 16 scale, frozen ViT) and the ms-swift best-practice recipe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+__all__ = ["VLMTrainRecipe", "get_recipe"]
+
+
+@dataclass(frozen=True)
+class VLMTrainRecipe:
+    """Family-fixed training recipe."""
+
+    # LoRA adapter shape. ``target_modules`` is a regex matched against module
+    # names; it must only match inside the language model so the vision tower
+    # stays untouched (asserted at injection time).
+    lora_r: int = 16
+    lora_alpha: int = 32
+    lora_dropout: float = 0.05
+    target_modules: str = ""
+    # Module-name prefixes that must never receive adapters and are frozen in
+    # full fine-tuning too.
+    frozen_prefixes: tuple = ()
+    # Optimizer defaults (LoRA path). Full fine-tuning uses ``full_ft_lr0``.
+    lr0: float = 1e-4
+    full_ft_lr0: float = 2e-5
+    weight_decay: float = 0.0
+    warmup_ratio: float = 0.03
+    clip_grad_norm: float = 1.0
+    # Soft ceiling for a training sequence before the collator warns.
+    max_length_warn: int = 8192
+
+
+_RECIPES: Dict[str, VLMTrainRecipe] = {
+    "qwen3vl": VLMTrainRecipe(
+        target_modules=(
+            r".*language_model.*\."
+            r"(q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj)$"
+        ),
+        frozen_prefixes=("model.visual",),
+    ),
+}
+
+
+def get_recipe(family: str) -> VLMTrainRecipe:
+    """Return the fixed recipe for a family, or raise for unknown families."""
+    recipe = _RECIPES.get(family)
+    if recipe is None:
+        raise NotImplementedError(
+            f"No VLM training recipe is defined for family {family!r}."
+        )
+    return recipe

--- a/libreyolo/models/vlm/training/targets.py
+++ b/libreyolo/models/vlm/training/targets.py
@@ -1,0 +1,118 @@
+"""Serialize detection labels into the target text a VLM family is trained on.
+
+This is the training-side mirror of ``libreyolo/models/vlm/parsing.py``: the
+parser turns generated text into boxes using a family's declared convention
+(``BBOX_KEY``, ``COORD_DIVISOR``, ``BOX_FORMAT``); this module turns dataset
+boxes into exactly the text that parser expects back. Keeping both sides driven
+by the same three class attributes is what guarantees a fine-tuned model emits
+what ``predict()`` parses.
+
+Pure functions, no torch, unit-tested offline including a parser round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+__all__ = ["FamilyFormat", "serialize_detections"]
+
+
+@dataclass(frozen=True)
+class FamilyFormat:
+    """The output convention of one VLM family, captured for training.
+
+    Built from a live model via :meth:`from_model` so the training pipeline can
+    never drift from the inference adapter's declared convention.
+    """
+
+    family: str
+    bbox_key: str
+    coord_divisor: float
+    box_format: str
+    detection_prompt: str
+
+    @classmethod
+    def from_model(cls, model) -> "FamilyFormat":
+        """Capture the convention (and current-vocabulary prompt) of a model."""
+        return cls(
+            family=model.FAMILY,
+            bbox_key=model.BBOX_KEY,
+            coord_divisor=float(model.COORD_DIVISOR),
+            box_format=model.BOX_FORMAT,
+            detection_prompt=model._detection_prompt(),
+        )
+
+
+def _convert_layout(
+    box: Tuple[float, float, float, float], box_format: str
+) -> Tuple[float, float, float, float]:
+    """Convert a normalized xyxy box into the family's emitted layout."""
+    x1, y1, x2, y2 = box
+    if box_format == "xyxy":
+        return (x1, y1, x2, y2)
+    if box_format == "xywh":
+        return (x1, y1, x2 - x1, y2 - y1)
+    if box_format == "cxcywh":
+        return ((x1 + x2) / 2.0, (y1 + y2) / 2.0, x2 - x1, y2 - y1)
+    raise ValueError(f"Unknown BOX_FORMAT {box_format!r}")
+
+
+def _scale_coord(value: float, divisor: float) -> float | int:
+    """Scale one normalized coordinate to the family's emitted range.
+
+    ``COORD_DIVISOR == 1.0`` families write floats on [0, 1] (3 decimals, the
+    precision the prompts show); larger divisors (e.g. 1000) write integers on
+    [0, divisor], clamped, matching what the grounding-pretrained models emit.
+    """
+    if divisor == 1.0:
+        return round(min(max(value, 0.0), 1.0), 3)
+    scaled = int(round(min(max(value, 0.0), 1.0) * divisor))
+    return min(max(scaled, 0), int(divisor))
+
+
+def serialize_detections(
+    boxes_xyxy: Sequence[Sequence[float]],
+    labels: Sequence[str],
+    fmt: FamilyFormat,
+) -> str:
+    """Render ground-truth boxes as the family's expected JSON answer text.
+
+    Args:
+        boxes_xyxy: Normalized ``[x1, y1, x2, y2]`` boxes on [0, 1], relative
+            to the full image (the dataset-schema convention).
+        labels: Class name per box (the phrase the model is prompted with).
+        fmt: The family convention captured by :class:`FamilyFormat`.
+
+    Returns:
+        A JSON array string, one object per box, in deterministic reading
+        order (top-to-bottom, then left-to-right), formatted the way the
+        family's detection prompt asks for it. No boxes returns ``"[]"``,
+        teaching the model the documented empty-image answer.
+    """
+    if len(boxes_xyxy) != len(labels):
+        raise ValueError(
+            f"boxes/labels length mismatch: {len(boxes_xyxy)} vs {len(labels)}"
+        )
+    order = sorted(
+        range(len(boxes_xyxy)),
+        key=lambda i: (boxes_xyxy[i][1], boxes_xyxy[i][0]),
+    )
+    items: List[dict] = []
+    for i in order:
+        x1, y1, x2, y2 = (float(v) for v in boxes_xyxy[i])
+        if x2 < x1:
+            x1, x2 = x2, x1
+        if y2 < y1:
+            y1, y2 = y2, y1
+        layout = _convert_layout((x1, y1, x2, y2), fmt.box_format)
+        coords = [_scale_coord(v, fmt.coord_divisor) for v in layout]
+        # Key order matches the prompt examples (box first for bbox_2d
+        # families, label first for the [0,1] default) purely for target
+        # naturalness; the parser accepts either order.
+        if fmt.bbox_key == "bbox_2d":
+            items.append({fmt.bbox_key: coords, "label": str(labels[i])})
+        else:
+            items.append({"label": str(labels[i]), fmt.bbox_key: coords})
+    return json.dumps(items, ensure_ascii=False, separators=(", ", ": "))

--- a/libreyolo/models/vlm/training/trainer.py
+++ b/libreyolo/models/vlm/training/trainer.py
@@ -1,0 +1,533 @@
+"""LoRA SFT trainer for the LibreVLM tier.
+
+Deliberately NOT a ``BaseTrainer`` subclass: that chassis assumes stacked image
+tensors, detection losses, EMA, and mAP validation, none of which apply to an
+autoregressive fine-tune. This trainer keeps the repo's user-facing surface
+(run directories, callbacks, loggers, results dict) and owns a compact loop:
+cross-entropy on assistant tokens, gradient accumulation, cosine schedule with
+warmup, best/last adapter checkpoints.
+
+Checkpoints follow the directory contract in :mod:`.checkpoint`; best/last
+selection uses validation loss (validation mAP lands with the tier's ``val()``
+in a later iteration, as documented in the design docs).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+from ....data import load_data_config
+from ....training.callbacks import (
+    TrainCallbackList,
+    TrainCallbacks,
+    TrainEndEvent,
+    TrainEpochEvent,
+    TrainExceptionEvent,
+    TrainStartEvent,
+)
+from ....training.loggers import resolve_loggers
+from .checkpoint import is_vlm_checkpoint, save_vlm_checkpoint
+from .collate import VLMChatCollator
+from .data import VLMDetectDataset, resolve_split_source
+from .recipes import VLMTrainRecipe, get_recipe
+from .targets import FamilyFormat
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_HINT = (
+    "VLM fine-tuning requires the 'vlm-train' extra. Install with:\n"
+    "    pip install 'libreyolo[vlm-train]'"
+)
+
+__all__ = ["VLMDetectionTrainer", "VLMTrainConfig"]
+
+
+@dataclass
+class VLMTrainConfig:
+    """Resolved VLM training configuration (user kwargs over recipe defaults)."""
+
+    data: str = ""
+    epochs: int = 10
+    batch: int = 1
+    accumulate: int = 8
+    lr0: Optional[float] = None
+    lora: bool = True
+    output_dir: str = "runs/vlm/train"
+    project: Optional[str] = None
+    name: Optional[str] = None
+    exist_ok: bool = True
+    workers: int = 0
+    seed: int = 0
+    device: Optional[str] = None
+    gradient_checkpointing: bool = True
+    hflip: float = 0.5
+    vram_check: bool = True
+    resume: Any = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+def _normalize_names(raw) -> Dict[int, str]:
+    if isinstance(raw, dict):
+        return {int(k): str(v) for k, v in raw.items()}
+    if isinstance(raw, (list, tuple)):
+        return {i: str(v) for i, v in enumerate(raw)}
+    raise ValueError("Dataset YAML must define names as a list or an id mapping.")
+
+
+class VLMDetectionTrainer:
+    """Drive one LoRA (or full) detection fine-tune of a LibreVLM wrapper."""
+
+    def __init__(
+        self,
+        wrapper,
+        data: str,
+        callbacks: TrainCallbacks = None,
+        loggers=None,
+        **kwargs,
+    ) -> None:
+        if not data:
+            raise ValueError("train() requires data=<dataset yaml>.")
+        known = set(VLMTrainConfig.__dataclass_fields__) - {"data", "extra"}
+        config_kwargs = {k: v for k, v in kwargs.items() if k in known}
+        extra = {k: v for k, v in kwargs.items() if k not in known}
+        if extra:
+            logger.warning("Ignoring unknown train() kwargs: %s", sorted(extra))
+        self.config = VLMTrainConfig(data=data, extra=extra, **config_kwargs)
+        if self.config.epochs < 1:
+            raise ValueError(f"epochs must be >= 1, got {self.config.epochs}")
+        if self.config.batch < 1 or self.config.accumulate < 1:
+            raise ValueError("batch and accumulate must both be >= 1.")
+        self.wrapper = wrapper
+        self.recipe: VLMTrainRecipe = get_recipe(wrapper.FAMILY)
+        self.callbacks = TrainCallbackList(callbacks)
+        for logger_cb in resolve_loggers(loggers):
+            self.callbacks.append(logger_cb)
+        self.save_dir = self._resolve_save_dir()
+
+    # ------------------------------------------------------------------
+    # Setup helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_save_dir(self) -> Path:
+        cfg = self.config
+        output = Path(cfg.output_dir)
+        project = Path(cfg.project) if cfg.project else output.parent
+        name = cfg.name if cfg.name else output.name
+        run_dir = Path(project) / str(name)
+        if run_dir.exists() and not cfg.exist_ok:
+            base = run_dir
+            counter = 2
+            while run_dir.exists():
+                run_dir = base.with_name(f"{base.name}{counter}")
+                counter += 1
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return run_dir
+
+    def _resolve_device(self) -> torch.device:
+        if self.config.device:
+            return torch.device(self.config.device)
+        return self.wrapper.device
+
+    def _check_vram_for_full_ft(self, device: torch.device) -> None:
+        if self.config.lora:
+            return
+        if device.type != "cuda":
+            logger.warning(
+                "Full fine-tuning on %s will be extremely slow; lora=True is "
+                "the supported path on this hardware.",
+                device.type,
+            )
+            return
+        if not self.config.vram_check:
+            return
+        params = sum(p.numel() for p in self.wrapper.model.parameters())
+        # Full FT with AdamW: weights + grads + two fp32 moments, before
+        # activations. ~16 bytes/param is the optimistic floor in bf16.
+        needed = params * 16
+        total = torch.cuda.get_device_properties(device).total_memory
+        if needed > total:
+            raise RuntimeError(
+                f"Full fine-tuning needs roughly {needed / 1e9:.0f} GB for "
+                f"optimizer state alone; this GPU has {total / 1e9:.0f} GB. "
+                "Use lora=True (the default), or pass vram_check=False to "
+                "proceed anyway."
+            )
+
+    def _resolve_resume_dir(self) -> Optional[Path]:
+        resume = self.config.resume
+        if not resume:
+            return None
+        candidate = (
+            self.save_dir / "weights" / "last" if resume is True else Path(resume)
+        )
+        if not is_vlm_checkpoint(candidate):
+            raise FileNotFoundError(
+                f"resume={resume!r} is not a VLM checkpoint directory "
+                "(missing libreyolo_vlm.json)."
+            )
+        return candidate
+
+    def _build_train_model(self, resume_dir: Optional[Path]):
+        """Return the trainable module: a PeftModel (LoRA) or the base model."""
+        if self.config.lora:
+            try:
+                from peft import LoraConfig, PeftModel, get_peft_model
+            except ImportError as exc:
+                raise ImportError(_INSTALL_HINT) from exc
+            if resume_dir is not None:
+                model = PeftModel.from_pretrained(
+                    self.wrapper.model, str(resume_dir), is_trainable=True
+                )
+                logger.warning(
+                    "Resumed adapter weights from %s (optimizer state starts "
+                    "fresh).",
+                    resume_dir,
+                )
+            else:
+                lora_config = LoraConfig(
+                    r=self.recipe.lora_r,
+                    lora_alpha=self.recipe.lora_alpha,
+                    lora_dropout=self.recipe.lora_dropout,
+                    target_modules=self.recipe.target_modules,
+                    bias="none",
+                )
+                model = get_peft_model(self.wrapper.model, lora_config)
+            injected = [
+                name
+                for name, module in model.named_modules()
+                if getattr(module, "lora_A", None) is not None
+            ]
+            if not injected:
+                raise RuntimeError(
+                    f"LoRA recipe for {self.wrapper.FAMILY!r} matched no "
+                    "modules; the base model layout changed. This is a "
+                    "LibreYOLO bug."
+                )
+            leaks = [
+                name
+                for name in injected
+                if any(prefix in name for prefix in self.recipe.frozen_prefixes)
+            ]
+            if leaks:
+                raise RuntimeError(
+                    f"LoRA recipe for {self.wrapper.FAMILY!r} leaked adapters "
+                    f"into frozen scope: {leaks[:3]}. This is a LibreYOLO bug."
+                )
+            logger.info("Injected LoRA adapters into %d modules.", len(injected))
+            return model
+
+        # Full fine-tune: freeze the recipe's frozen prefixes, train the rest.
+        if resume_dir is not None:
+            raise NotImplementedError(
+                "resume= is only supported for LoRA training (lora=True)."
+            )
+        frozen = 0
+        for name, param in self.wrapper.model.named_parameters():
+            if any(name.startswith(prefix) for prefix in self.recipe.frozen_prefixes):
+                param.requires_grad_(False)
+                frozen += 1
+        logger.info("Full fine-tune: froze %d frozen-scope parameters.", frozen)
+        return self.wrapper.model
+
+    def _build_dataloaders(self, data_cfg: Dict, names: Dict[int, str], fmt: FamilyFormat):
+        cfg = self.config
+        train_source = resolve_split_source(data_cfg, "train")
+        if not train_source:
+            raise ValueError(f"Dataset {cfg.data!r} has no train split.")
+        val_source = resolve_split_source(data_cfg, "val")
+
+        collator = VLMChatCollator(
+            self.wrapper.processor, max_length_warn=self.recipe.max_length_warn
+        )
+        pin = self._resolve_device().type == "cuda"
+        train_set = VLMDetectDataset(
+            train_source,
+            names,
+            fmt,
+            augment=cfg.hflip > 0,
+            hflip_p=cfg.hflip,
+            seed=cfg.seed,
+        )
+        train_loader = DataLoader(
+            train_set,
+            batch_size=cfg.batch,
+            shuffle=True,
+            num_workers=cfg.workers,
+            collate_fn=collator,
+            generator=torch.Generator().manual_seed(cfg.seed),
+            pin_memory=pin,
+            persistent_workers=cfg.workers > 0,
+        )
+        val_loader = None
+        if val_source:
+            val_set = VLMDetectDataset(val_source, names, fmt, augment=False)
+            val_loader = DataLoader(
+                val_set,
+                batch_size=cfg.batch,
+                shuffle=False,
+                num_workers=cfg.workers,
+                collate_fn=collator,
+                pin_memory=pin,
+                persistent_workers=cfg.workers > 0,
+            )
+        return train_loader, val_loader
+
+    # ------------------------------------------------------------------
+    # The loop
+    # ------------------------------------------------------------------
+
+    def run(self) -> Dict[str, Any]:
+        cfg = self.config
+        start_time = time.time()
+        torch.manual_seed(cfg.seed)
+
+        device = self._resolve_device()
+        self._check_vram_for_full_ft(device)
+
+        data_cfg = load_data_config(
+            cfg.data, allow_scripts=bool(cfg.extra.get("allow_download_scripts", False))
+        )
+        names = _normalize_names(data_cfg.get("names"))
+        # Vocabulary comes from the dataset; sticky on the wrapper from here on.
+        self.wrapper.set_classes([names[i] for i in range(len(names))])
+        fmt = FamilyFormat.from_model(self.wrapper)
+        train_loader, val_loader = self._build_dataloaders(data_cfg, names, fmt)
+
+        resume_dir = self._resolve_resume_dir()
+        train_model = self._build_train_model(resume_dir)
+        train_model.to(device)
+        train_model.train()
+        if cfg.gradient_checkpointing and hasattr(
+            train_model, "gradient_checkpointing_enable"
+        ):
+            train_model.gradient_checkpointing_enable()
+            if hasattr(train_model, "enable_input_require_grads"):
+                train_model.enable_input_require_grads()
+
+        lr0 = (
+            cfg.lr0
+            if cfg.lr0 is not None
+            else (self.recipe.lr0 if cfg.lora else self.recipe.full_ft_lr0)
+        )
+        trainable = [p for p in train_model.parameters() if p.requires_grad]
+        optimizer = torch.optim.AdamW(
+            trainable, lr=lr0, weight_decay=self.recipe.weight_decay
+        )
+        steps_per_epoch = max(1, math.ceil(len(train_loader) / cfg.accumulate))
+        total_steps = steps_per_epoch * cfg.epochs
+        warmup_steps = max(1, int(total_steps * self.recipe.warmup_ratio))
+
+        def lr_lambda(step: int) -> float:
+            if step < warmup_steps:
+                return (step + 1) / warmup_steps
+            progress = (step - warmup_steps) / max(1, total_steps - warmup_steps)
+            return 0.5 * (1.0 + math.cos(math.pi * min(progress, 1.0)))
+
+        scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+        autocast_ctx = (
+            torch.autocast(device_type="cuda", dtype=self.wrapper._model_dtype)
+            if device.type == "cuda"
+            else torch.autocast(device_type="cpu", enabled=False)
+        )
+
+        weights_dir = self.save_dir / "weights"
+        best_metric: Optional[float] = None
+        best_epoch: Optional[int] = None
+        final_loss = float("nan")
+        completed_epochs = 0
+        config_dump = {
+            **asdict(cfg),
+            "lr0": lr0,
+            "resume": str(cfg.resume) if cfg.resume else None,
+            "family": self.wrapper.FAMILY,
+        }
+        config_dump.pop("extra", None)
+
+        self.callbacks.on_train_start(
+            TrainStartEvent(
+                start_epoch=1,
+                total_epochs=cfg.epochs,
+                model_family=self.wrapper.FAMILY,
+                model_size=self.wrapper.size,
+                task="detect",
+                save_dir=str(self.save_dir),
+                config=config_dump,
+            )
+        )
+
+        try:
+            for epoch in range(1, cfg.epochs + 1):
+                epoch_start = time.time()
+                running, seen = 0.0, 0
+                optimizer.zero_grad(set_to_none=True)
+                progress = tqdm(
+                    train_loader,
+                    desc=f"vlm train {epoch}/{cfg.epochs}",
+                    unit="batch",
+                    leave=False,
+                )
+                for step, batch in enumerate(progress, 1):
+                    batch = self._to_device(batch, device)
+                    with autocast_ctx:
+                        loss = train_model(**batch).loss
+                    (loss / cfg.accumulate).backward()
+                    running += float(loss.detach())
+                    seen += 1
+                    if step % cfg.accumulate == 0 or step == len(train_loader):
+                        torch.nn.utils.clip_grad_norm_(
+                            trainable, self.recipe.clip_grad_norm
+                        )
+                        optimizer.step()
+                        scheduler.step()
+                        optimizer.zero_grad(set_to_none=True)
+                    progress.set_postfix(loss=f"{running / max(seen, 1):.4f}")
+
+                train_loss = running / max(seen, 1)
+                final_loss = train_loss
+                val_metrics: Dict[str, float] = {}
+                if val_loader is not None:
+                    val_metrics["val/loss"] = self._eval_loss(
+                        train_model, val_loader, device, autocast_ctx
+                    )
+                metric_name = "val/loss" if val_loader is not None else "train/loss"
+                current = val_metrics.get("val/loss", train_loss)
+                is_best = best_metric is None or current < best_metric
+                if is_best:
+                    best_metric = current
+                    best_epoch = epoch
+
+                metrics = {"train/loss": train_loss, "epoch": epoch, **val_metrics}
+                save_vlm_checkpoint(
+                    weights_dir / "last",
+                    peft_model=train_model,
+                    processor=self.wrapper.processor,
+                    wrapper=self.wrapper,
+                    metrics=metrics,
+                )
+                if is_best:
+                    save_vlm_checkpoint(
+                        weights_dir / "best",
+                        peft_model=train_model,
+                        processor=self.wrapper.processor,
+                        wrapper=self.wrapper,
+                        metrics=metrics,
+                    )
+                completed_epochs = epoch
+
+                self.callbacks.on_train_epoch_end(
+                    TrainEpochEvent(
+                        epoch=epoch,
+                        total_epochs=cfg.epochs,
+                        model_family=self.wrapper.FAMILY,
+                        model_size=self.wrapper.size,
+                        task="detect",
+                        save_dir=str(self.save_dir),
+                        train_loss=train_loss,
+                        train_loss_items={"loss": train_loss},
+                        lr={"lr0": optimizer.param_groups[0]["lr"]},
+                        val_metrics=val_metrics,
+                        validated=val_loader is not None,
+                        is_best=is_best,
+                        current_metric=current,
+                        current_metric_name=metric_name,
+                        best_metric=best_metric,
+                        best_metric_name=metric_name,
+                        best_epoch=best_epoch,
+                        epoch_seconds=time.time() - epoch_start,
+                    )
+                )
+        except BaseException as exc:
+            self.callbacks.on_train_exception(
+                TrainExceptionEvent(
+                    epoch=completed_epochs or None,
+                    total_epochs=cfg.epochs,
+                    model_family=self.wrapper.FAMILY,
+                    model_size=self.wrapper.size,
+                    task="detect",
+                    save_dir=str(self.save_dir),
+                    exception=exc,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                    elapsed_seconds=time.time() - start_time,
+                )
+            )
+            raise
+        finally:
+            self._restore_inference_model(train_model)
+
+        results: Dict[str, Any] = {
+            "save_dir": str(self.save_dir),
+            "best": str(weights_dir / "best"),
+            "last": str(weights_dir / "last"),
+            "epochs": completed_epochs,
+            "final_loss": final_loss,
+            "best_metric": best_metric,
+            "best_epoch": best_epoch,
+            "metric_name": "val/loss" if val_loader is not None else "train/loss",
+        }
+        self.callbacks.on_train_end(
+            TrainEndEvent(
+                total_epochs=cfg.epochs,
+                completed_epochs=completed_epochs,
+                model_family=self.wrapper.FAMILY,
+                model_size=self.wrapper.size,
+                task="detect",
+                save_dir=str(self.save_dir),
+                final_loss=final_loss,
+                best_metric=best_metric,
+                best_epoch=best_epoch,
+                total_seconds=time.time() - start_time,
+                results=results,
+            )
+        )
+        return results
+
+    # ------------------------------------------------------------------
+    # Pieces
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_device(batch, device: torch.device):
+        return {
+            k: v.to(device) if isinstance(v, torch.Tensor) else v
+            for k, v in batch.items()
+        }
+
+    def _eval_loss(self, model, loader, device, autocast_ctx) -> float:
+        model.eval()
+        total, count = 0.0, 0
+        with torch.no_grad():
+            for batch in loader:
+                batch = self._to_device(batch, device)
+                with autocast_ctx:
+                    total += float(model(**batch).loss.detach())
+                count += 1
+        model.train()
+        return total / max(count, 1)
+
+    def _restore_inference_model(self, train_model) -> None:
+        """Leave the wrapper usable for predict() after training.
+
+        The LoRA path trained a PeftModel around ``self.wrapper.model``;
+        merging the trained adapter into dense weights hands the wrapper back a
+        plain model whose ``predict()`` reflects the fine-tune. The full-FT
+        path trained the wrapper's model in place, so only eval() is needed.
+        """
+        try:
+            from peft import PeftModel
+        except ImportError:
+            self.wrapper.model.eval()
+            return
+        if isinstance(train_model, PeftModel):
+            self.wrapper.model = train_model.merge_and_unload()
+            logger.info("Merged trained LoRA adapters into the loaded model.")
+        self.wrapper.model.eval()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,13 @@ vlm = [
     "lmdb>=1.7.0",
     "peft>=0.12.0",
 ]
+vlm-train = [
+    # VLM detection fine-tuning: the vlm inference stack plus PEFT for LoRA.
+    # peft>=0.17 is the floor the LoRA-adapter save/load contract was
+    # validated against.
+    "libreyolo[vlm]",
+    "peft>=0.17.0",
+]
 sam = [
     # Promptable-segmentation families load through transformers;
     # EdgeTAM's RepViT backbone uses Transformers' TimmWrapper.

--- a/tests/e2e/test_vlm_train_qwen3vl.py
+++ b/tests/e2e/test_vlm_train_qwen3vl.py
@@ -1,0 +1,166 @@
+"""End-to-end VLM training smoke test on a tiny-random Qwen3-VL.
+
+Exercises the full loop on CPU with a few-MB random-weight checkpoint that
+shares the real Qwen3-VL architecture, processor, and chat template:
+
+    train() -> adapter checkpoint + contract -> LibreVLM(path) reload -> predict
+
+Random weights mean the loss is meaningless; what this validates is every
+contract in the chain: dataset rendering, the real chat template's
+prompt-prefix property (the label-masking assumption), LoRA injection scope,
+checkpoint save/load, base-repo pinning from the contract, and that a reloaded
+fine-tune predicts through the standard Results path.
+
+Needs network on first run (pinned tiny repo download); skips cleanly offline.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.vlm, pytest.mark.network, pytest.mark.e2e]
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+pytest.importorskip("peft")
+
+from PIL import Image  # noqa: E402
+
+from libreyolo.models.vlm import LibreVLM  # noqa: E402
+from libreyolo.models.vlm.qwen3vl import LibreQwen3VL  # noqa: E402
+
+TINY_REPO = "tiny-random/qwen3-vl"
+TINY_REVISION = "be61f02fa193813901f6bc60707eb4ee08f27b02"
+
+
+class TinyQwen3VL(LibreQwen3VL):
+    """Qwen3-VL adapter pointed at a pinned tiny-random checkpoint."""
+
+    FILENAME_PREFIX = "TinyQwen3VLTest"
+    HF_REPOS = {"2b": TINY_REPO}
+    HF_REVISIONS = {"2b": TINY_REVISION}
+
+
+def _make_dataset(root: Path) -> Path:
+    for split in ("train", "val"):
+        images = root / "images" / split
+        labels = root / "labels" / split
+        images.mkdir(parents=True)
+        labels.mkdir(parents=True)
+        for i in range(2):
+            Image.new("RGB", (64, 64), (40 * i + 40, 80, 120)).save(
+                images / f"img{i}.png"
+            )
+            rows = "0 0.5 0.5 0.4 0.4\n" if i == 0 else "1 0.25 0.25 0.3 0.3\n"
+            (labels / f"img{i}.txt").write_text(rows, encoding="utf-8")
+    yaml_path = root / "data.yaml"
+    yaml_path.write_text(
+        "path: {root}\n"
+        "train: images/train\n"
+        "val: images/val\n"
+        "names:\n  0: ripe strawberry\n  1: leaf\n".format(root=root.as_posix()),
+        encoding="utf-8",
+    )
+    return yaml_path
+
+
+@pytest.fixture(scope="module")
+def tiny_model(tmp_path_factory):
+    workdir = tmp_path_factory.mktemp("vlm-train-e2e")
+    import os
+
+    cwd = os.getcwd()
+    os.chdir(workdir)  # weights/ and runs/ land in the temp dir
+    try:
+        try:
+            model = TinyQwen3VL(size="2b", device="cpu")
+        except Exception as exc:  # pragma: no cover - offline environments
+            pytest.skip(f"tiny Qwen3-VL checkpoint unavailable: {exc}")
+        yield workdir, model
+    finally:
+        os.chdir(cwd)
+
+
+def test_train_checkpoint_reload_predict(tiny_model):
+    workdir, model = tiny_model
+    yaml_path = _make_dataset(workdir / "dataset")
+
+    results = model.train(
+        data=str(yaml_path),
+        epochs=1,
+        batch=1,
+        accumulate=2,
+        workers=0,
+        hflip=0.0,
+        gradient_checkpointing=False,
+        seed=0,
+    )
+
+    # Results dict and run layout.
+    best = Path(results["best"])
+    assert best.is_dir()
+    assert Path(results["last"]).is_dir()
+    assert results["epochs"] == 1
+    assert results["metric_name"] == "val/loss"
+    assert results["best_metric"] is not None
+
+    # Checkpoint contract: adapter-only (no base weights), contract file, and
+    # the vocabulary taken from the dataset names in id order.
+    contract = json.loads((best / "libreyolo_vlm.json").read_text(encoding="utf-8"))
+    assert contract["family"] == "qwen3vl"
+    assert contract["base_repo"] == TINY_REPO
+    assert contract["base_revision"] == TINY_REVISION
+    assert contract["names"] == ["ripe strawberry", "leaf"]
+    assert contract["bbox_key"] == "bbox_2d"
+    assert (best / "adapter_config.json").exists()
+    assert not (best / "config.json").exists(), "adapter checkpoint must not embed base weights"
+    adapter_config = json.loads((best / "adapter_config.json").read_text(encoding="utf-8"))
+    assert adapter_config["r"] == 16
+
+    # The wrapper stays usable after training: adapters merged, vocab sticky.
+    assert model.names == {0: "ripe strawberry", 1: "leaf"}
+    assert not any(
+        getattr(module, "lora_A", None) is not None for module in model.model.modules()
+    ), "adapters must be merged out of the inference model"
+
+    # Reload through the factory; contract pins the tiny base repo.
+    reloaded = LibreVLM(str(best), device="cpu")
+    assert isinstance(reloaded, LibreQwen3VL)
+    assert reloaded.names == {0: "ripe strawberry", 1: "leaf"}
+
+    # Predict runs the standard Results path (random weights, so no boxes are
+    # expected; the contract under test is the pipeline, not accuracy).
+    image = workdir / "dataset" / "images" / "val" / "img0.png"
+    result = reloaded.predict(str(image), max_det=10)
+    assert result is not None
+    assert hasattr(result, "boxes")
+
+
+def test_lora_stays_out_of_vision_tower(tiny_model):
+    workdir, model = tiny_model
+    from peft import LoraConfig, get_peft_model
+
+    from libreyolo.models.vlm.training.recipes import get_recipe
+
+    recipe = get_recipe("qwen3vl")
+    peft_model = get_peft_model(
+        model.model,
+        LoraConfig(
+            r=recipe.lora_r,
+            lora_alpha=recipe.lora_alpha,
+            target_modules=recipe.target_modules,
+        ),
+    )
+    try:
+        injected = [
+            name
+            for name, module in peft_model.named_modules()
+            if getattr(module, "lora_A", None) is not None
+        ]
+        assert injected, "recipe matched no modules"
+        assert not [n for n in injected if "visual" in n], "vision tower got adapters"
+        assert all("language_model" in n for n in injected)
+    finally:
+        merged = peft_model.merge_and_unload()
+        model.model = merged

--- a/tests/unit/test_vlm_training.py
+++ b/tests/unit/test_vlm_training.py
@@ -1,0 +1,396 @@
+"""Offline unit tests for VLM detection fine-tuning.
+
+Everything here runs without network, GPU, or model weights: target
+serialization (including a full round-trip through the inference parser),
+dataset reading, collator label masking with a stub processor, the checkpoint
+contract, and the train() gating surface.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.vlm]
+
+torch = pytest.importorskip("torch")
+from PIL import Image  # noqa: E402
+
+from libreyolo.models.vlm.parsing import build_detection_dict, extract_detections  # noqa: E402
+from libreyolo.models.vlm.training.checkpoint import (  # noqa: E402
+    CONTRACT_FILENAME,
+    is_vlm_checkpoint,
+    read_contract,
+    save_vlm_checkpoint,
+)
+from libreyolo.models.vlm.training.collate import VLMChatCollator  # noqa: E402
+from libreyolo.models.vlm.training.data import (  # noqa: E402
+    VLMDetectDataset,
+    resolve_split_source,
+)
+from libreyolo.models.vlm.training.recipes import get_recipe  # noqa: E402
+from libreyolo.models.vlm.training.targets import (  # noqa: E402
+    FamilyFormat,
+    serialize_detections,
+)
+
+QWEN_FMT = FamilyFormat(
+    family="qwen3vl",
+    bbox_key="bbox_2d",
+    coord_divisor=1000.0,
+    box_format="xyxy",
+    detection_prompt="Detect all instances of: cat, dog.",
+)
+UNIT_FMT = FamilyFormat(
+    family="unit",
+    bbox_key="bbox",
+    coord_divisor=1.0,
+    box_format="xyxy",
+    detection_prompt="Detect.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Target serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeDetections:
+    def test_qwen_format_scales_to_thousand_ints(self):
+        text = serialize_detections([[0.1, 0.2, 0.5, 0.9]], ["cat"], QWEN_FMT)
+        assert json.loads(text) == [{"bbox_2d": [100, 200, 500, 900], "label": "cat"}]
+
+    def test_unit_scale_keeps_three_decimal_floats(self):
+        text = serialize_detections([[0.1234, 0.2, 0.5, 0.8768]], ["cat"], UNIT_FMT)
+        assert json.loads(text) == [{"label": "cat", "bbox": [0.123, 0.2, 0.5, 0.877]}]
+
+    def test_empty_is_empty_array(self):
+        assert serialize_detections([], [], QWEN_FMT) == "[]"
+
+    def test_reading_order_is_deterministic(self):
+        boxes = [[0.5, 0.8, 0.6, 0.9], [0.1, 0.1, 0.2, 0.2], [0.7, 0.1, 0.8, 0.2]]
+        text = serialize_detections(boxes, ["low", "topleft", "topright"], QWEN_FMT)
+        labels = [item["label"] for item in json.loads(text)]
+        assert labels == ["topleft", "topright", "low"]
+
+    def test_clamps_and_reorders_corners(self):
+        text = serialize_detections([[0.9, 1.4, 0.1, -0.2]], ["cat"], QWEN_FMT)
+        assert json.loads(text) == [{"bbox_2d": [100, 0, 900, 1000], "label": "cat"}]
+
+    def test_layout_conversion_xywh_and_cxcywh(self):
+        xywh = FamilyFormat("f", "bbox", 1.0, "xywh", "p")
+        cxcywh = FamilyFormat("f", "bbox", 1.0, "cxcywh", "p")
+        box = [[0.2, 0.2, 0.6, 0.8]]
+        assert json.loads(serialize_detections(box, ["x"], xywh))[0]["bbox"] == [
+            0.2, 0.2, 0.4, 0.6,
+        ]
+        assert json.loads(serialize_detections(box, ["x"], cxcywh))[0]["bbox"] == [
+            0.4, 0.5, 0.4, 0.6,
+        ]
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError, match="mismatch"):
+            serialize_detections([[0, 0, 1, 1]], [], QWEN_FMT)
+
+    def test_round_trip_through_inference_parser(self):
+        """The serializer must be the exact inverse of the predict-time parser."""
+        boxes = [[0.10, 0.20, 0.50, 0.90], [0.25, 0.05, 0.75, 0.55]]
+        labels = ["cat", "dog"]
+        text = serialize_detections(boxes, labels, QWEN_FMT)
+        items = extract_detections(text)
+        result = build_detection_dict(
+            items,
+            {"cat": 0, "dog": 1},
+            (1000, 1000),  # W, H chosen so pixel coords equal 1000*normalized
+            bbox_key=QWEN_FMT.bbox_key,
+            coord_divisor=QWEN_FMT.coord_divisor,
+            box_format=QWEN_FMT.box_format,
+        )
+        assert result["num_detections"] == 2
+        recovered = sorted(
+            (int(c), [round(v) for v in b])
+            for c, b in zip(result["classes"], result["boxes"])
+        )
+        expected = sorted(
+            (i, [round(v * 1000) for v in box])
+            for i, box in zip([0, 1], boxes)
+        )
+        assert recovered == expected
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+
+def _write_dataset(root: Path, rows_by_image: dict) -> Path:
+    images = root / "images" / "train"
+    labels = root / "labels" / "train"
+    images.mkdir(parents=True)
+    labels.mkdir(parents=True)
+    for stem, rows in rows_by_image.items():
+        Image.new("RGB", (64, 48), (120, 130, 140)).save(images / f"{stem}.png")
+        if rows is not None:
+            (labels / f"{stem}.txt").write_text(rows, encoding="utf-8")
+    return images
+
+
+class TestVLMDetectDataset:
+    def test_renders_prompt_and_target(self, tmp_path):
+        images = _write_dataset(tmp_path, {"a": "0 0.5 0.5 0.2 0.4\n"})
+        ds = VLMDetectDataset(images, {0: "cat", 1: "dog"}, QWEN_FMT)
+        sample = ds[0]
+        assert sample["prompt"] == QWEN_FMT.detection_prompt
+        parsed = json.loads(sample["target"])
+        assert parsed == [{"bbox_2d": [400, 300, 600, 700], "label": "cat"}]
+        assert sample["image"].size == (64, 48)
+
+    def test_missing_label_file_teaches_empty_answer(self, tmp_path):
+        images = _write_dataset(tmp_path, {"a": None})
+        ds = VLMDetectDataset(images, {0: "cat"}, QWEN_FMT)
+        assert ds[0]["target"] == "[]"
+
+    def test_malformed_and_unknown_rows_are_skipped(self, tmp_path):
+        images = _write_dataset(
+            tmp_path, {"a": "not a row\n7 0.5 0.5 0.2 0.2\n0 0.5 0.5 0.2 0.2\n"}
+        )
+        ds = VLMDetectDataset(images, {0: "cat"}, QWEN_FMT)
+        parsed = json.loads(ds[0]["target"])
+        assert len(parsed) == 1 and parsed[0]["label"] == "cat"
+
+    def test_hflip_mirrors_boxes(self, tmp_path):
+        images = _write_dataset(tmp_path, {"a": "0 0.25 0.5 0.1 0.2\n"})
+        ds = VLMDetectDataset(images, {0: "cat"}, QWEN_FMT, augment=True, hflip_p=1.0)
+        parsed = json.loads(ds[0]["target"])
+        # cx 0.25 -> mirrored cx 0.75; y untouched.
+        assert parsed[0]["bbox_2d"] == [700, 400, 800, 600]
+
+    def test_empty_image_dir_raises(self, tmp_path):
+        empty = tmp_path / "none"
+        empty.mkdir()
+        with pytest.raises(FileNotFoundError):
+            VLMDetectDataset(empty, {0: "cat"}, QWEN_FMT)
+
+    def test_coco_json_dataset_rejected_clearly(self):
+        cfg = {"train": "imgs", "annotations": {"train": "x.json"}}
+        with pytest.raises(NotImplementedError, match="COCO JSON"):
+            resolve_split_source(cfg, "train")
+        cfg2 = {"train": "imgs", "train_annotation_file": "x.json"}
+        with pytest.raises(NotImplementedError, match="COCO JSON"):
+            resolve_split_source(cfg2, "train")
+
+
+# ---------------------------------------------------------------------------
+# Collator (stub processor: ids are deterministic functions of the text)
+# ---------------------------------------------------------------------------
+
+
+class _StubTokenizer:
+    padding_side = "left"  # collator must flip to right and restore
+
+
+class _StubProcessor:
+    """Tokenizes text as its character codes; images add three fixed tokens."""
+
+    PAD = 0
+    IMAGE_TOKENS = [900, 901, 902]
+
+    def __init__(self, break_prefix=False):
+        self.tokenizer = _StubTokenizer()
+        self.break_prefix = break_prefix
+
+    def _encode_conv(self, conversation, add_generation_prompt):
+        ids = []
+        for turn in conversation:
+            for part in turn["content"]:
+                if part["type"] == "image":
+                    ids.extend(self.IMAGE_TOKENS)
+                else:
+                    ids.extend((ord(c) % 500) + 1000 for c in part["text"])
+        if add_generation_prompt:
+            ids.append(3)  # assistant header stub
+        elif len(conversation) > 1:
+            # Full conversation: header sits between prompt and answer.
+            answer = ids[-sum(len(p["text"]) for p in conversation[-1]["content"]):]
+            prompt = ids[: len(ids) - len(answer)]
+            first = [7] if self.break_prefix else []
+            ids = first + prompt + [3] + answer + [4]  # 4 = eos stub
+        return ids
+
+    def apply_chat_template(
+        self,
+        conversations,
+        tokenize,
+        return_dict,
+        return_tensors,
+        padding,
+        add_generation_prompt=False,
+    ):
+        assert tokenize and return_dict and padding
+        assert self.tokenizer.padding_side == "right"
+        encoded = [
+            self._encode_conv(conv, add_generation_prompt) for conv in conversations
+        ]
+        width = max(len(e) for e in encoded)
+        input_ids = torch.full((len(encoded), width), self.PAD, dtype=torch.long)
+        attention = torch.zeros((len(encoded), width), dtype=torch.long)
+        for i, ids in enumerate(encoded):
+            input_ids[i, : len(ids)] = torch.tensor(ids)
+            attention[i, : len(ids)] = 1
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention,
+            "token_type_ids": torch.zeros_like(input_ids),
+        }
+
+
+def _samples():
+    image = Image.new("RGB", (8, 8))
+    return [
+        {"image": image, "prompt": "find cats", "target": "[]"},
+        {"image": image, "prompt": "find cats", "target": '[{"bbox_2d": [1, 2, 3, 4]}]'},
+    ]
+
+
+class TestVLMChatCollator:
+    def test_masks_prompt_and_padding_supervises_answer(self):
+        collator = VLMChatCollator(_StubProcessor())
+        batch = collator(_samples())
+        labels, ids = batch["labels"], batch["input_ids"]
+        for i, sample in enumerate(_samples()):
+            prompt_len = 3 + len(sample["prompt"]) + 1  # image + text + header
+            assert (labels[i, :prompt_len] == -100).all()
+            answer_len = len(sample["target"]) + 1  # + eos stub
+            answer = labels[i, prompt_len : prompt_len + answer_len]
+            assert (answer != -100).all()
+            assert torch.equal(answer, ids[i, prompt_len : prompt_len + answer_len])
+            assert (labels[i, prompt_len + answer_len :] == -100).all()
+
+    def test_supervised_fraction_is_answer_only(self):
+        batch = VLMChatCollator(_StubProcessor())(_samples())
+        supervised = int((batch["labels"] != -100).sum())
+        expected = sum(len(s["target"]) + 1 for s in _samples())
+        assert supervised == expected
+
+    def test_prefix_violation_raises(self):
+        collator = VLMChatCollator(_StubProcessor(break_prefix=True))
+        with pytest.raises(RuntimeError, match="prompt-prefix"):
+            collator(_samples())
+
+    def test_padding_side_restored_and_drop_keys(self):
+        processor = _StubProcessor()
+        batch = VLMChatCollator(processor)(_samples())
+        assert processor.tokenizer.padding_side == "left"
+        assert "token_type_ids" not in batch
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint contract
+# ---------------------------------------------------------------------------
+
+
+class _StubSaveable:
+    def save_pretrained(self, directory):
+        Path(directory).mkdir(parents=True, exist_ok=True)
+        (Path(directory) / "adapter_config.json").write_text("{}", encoding="utf-8")
+
+
+class _StubWrapper:
+    FAMILY = "qwen3vl"
+    size = "2b"
+    HF_REPOS = {"2b": "org/base-repo"}
+    HF_REVISIONS = {}
+    BBOX_KEY = "bbox_2d"
+    COORD_DIVISOR = 1000.0
+    BOX_FORMAT = "xyxy"
+    names = {0: "cat", 1: "dog"}
+    processor = _StubSaveable()
+
+    def _detection_prompt(self):
+        return "Detect all instances of: cat, dog."
+
+
+class TestCheckpointContract:
+    def test_save_then_read_round_trips(self, tmp_path):
+        target = tmp_path / "best"
+        save_vlm_checkpoint(
+            target,
+            peft_model=_StubSaveable(),
+            processor=_StubSaveable(),
+            wrapper=_StubWrapper(),
+            metrics={"train/loss": 0.5},
+        )
+        assert is_vlm_checkpoint(target)
+        contract = read_contract(target)
+        assert contract["family"] == "qwen3vl"
+        assert contract["size"] == "2b"
+        assert contract["base_repo"] == "org/base-repo"
+        assert contract["names"] == ["cat", "dog"]
+        assert contract["coord_divisor"] == 1000.0
+        assert contract["metrics"]["train/loss"] == 0.5
+
+    def test_is_vlm_checkpoint_negative_cases(self, tmp_path):
+        assert not is_vlm_checkpoint(tmp_path)  # dir without contract
+        assert not is_vlm_checkpoint(tmp_path / "missing")
+        assert not is_vlm_checkpoint("qwen3-vl-4b")  # alias string
+
+    def test_wrong_schema_rejected(self, tmp_path):
+        (tmp_path / CONTRACT_FILENAME).write_text(
+            json.dumps({"schema": 99, "family": "x", "size": "s", "names": []}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="schema"):
+            read_contract(tmp_path)
+
+    def test_missing_field_rejected(self, tmp_path):
+        (tmp_path / CONTRACT_FILENAME).write_text(
+            json.dumps({"schema": 1, "family": "x"}), encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match="size"):
+            read_contract(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Gating and recipes
+# ---------------------------------------------------------------------------
+
+
+class TestTrainGating:
+    def _bare(self, cls):
+        return object.__new__(cls)
+
+    def test_qwen3vl_is_trainable_and_requires_data(self):
+        from libreyolo.models.vlm import LibreQwen3VL
+
+        assert LibreQwen3VL.TRAINABLE is True
+        with pytest.raises(ValueError, match="data="):
+            LibreQwen3VL.train(self._bare(LibreQwen3VL))
+
+    @pytest.mark.parametrize(
+        "module_name, class_name, match",
+        [
+            ("smolvlm", "LibreSmolVLM2", "grounding"),
+            ("kosmos2", "LibreKosmos2", "recipe"),
+            ("locateanything", "LibreLocateAnything", "non-commercial"),
+        ],
+    )
+    def test_untrainable_families_explain_why(self, module_name, class_name, match):
+        import importlib
+
+        module = importlib.import_module(f"libreyolo.models.vlm.{module_name}")
+        cls = getattr(module, class_name)
+        assert cls.TRAINABLE is False
+        with pytest.raises(NotImplementedError, match=match):
+            cls.train(self._bare(cls), data="x.yaml")
+
+    def test_recipe_exists_for_every_trainable_family(self):
+        from libreyolo.models.vlm import _ALIASES
+
+        for cls, _size in set(_ALIASES.values()):
+            if cls.TRAINABLE:
+                recipe = get_recipe(cls.FAMILY)
+                assert recipe.target_modules
+
+    def test_unknown_recipe_raises(self):
+        with pytest.raises(NotImplementedError):
+            get_recipe("not-a-family")


### PR DESCRIPTION
Opened by an agent. Verified: offline unit tests and the tiny-model CPU e2e pass locally (Windows, CPU). Not verified: GPU training, real-weight accuracy.

## What
- LoRA detection fine-tuning for the LibreVLM tier. First trainable family: Qwen3-VL.
- `LibreVLM("qwen3-vl-2b").train(data="data.yaml")` -> adapter checkpoint dir -> `LibreVLM(path)` reload -> `predict()`.
- New package `libreyolo/models/vlm/training/`: target serializer, detect-dataset reader, chat-template collator, per-family recipes, checkpoint contract, trainer.
- `TRAINABLE` gate on the base class; untrainable families raise with documented reasons (smolvlm2, kosmos2, locateanything get specific messages).
- `vlm-train` extra (peft), `docs/vlm_training.md`, ADR 0002 out-of-scope note updated.

## Key decisions
- Input is the standard detect dataset YAML. Boxes are rendered into the family's own grounding text with the same `BBOX_KEY`/`COORD_DIVISOR`/`BOX_FORMAT` the predict parser uses; a unit test proves the serializer is the parser's exact inverse.
- `lora=True` default; recipe fixed per family (r16/a32, LM attention+MLP only, vision tower frozen), injection scope asserted.
- Checkpoint = adapter directory + `libreyolo_vlm.json` (family, size, base repo + pinned revision, vocabulary, coordinate convention, metrics). Loader shadows `HF_REPOS` from the contract so an adapter never loads on a drifted base snapshot. Base weights are never copied.
- Label masking: longest-common-prefix of full vs prompt tokenization with a 4-token boundary tolerance (the chat template merges a trailing newline into a `\n\n` token when the answer follows); genuine template rewrites still fail loudly.
- best/last selection by val loss until VLM `val()` mAP lands.

## Tests
- `tests/unit/test_vlm_training.py`: 28 offline tests (no network/weights): serializer round-trip through the inference parser, dataset reading and hflip re-rendering, collator masking with a stub processor, contract schema, train() gating.
- `tests/e2e/test_vlm_train_qwen3vl.py` (vlm+network+e2e marked): CPU end-to-end on a pinned tiny-random Qwen3-VL with the real architecture and chat template: train -> checkpoint -> factory reload -> predict, plus a LoRA-scope assertion.
- Full unit suite: 1065 passed. One failure in `test_darknet_edge_export_matrix[openvino-LibreYOLO4]` (numeric parity, code untouched by this diff, fails identically in isolation on this machine).

## What a real test looks like (proposed, not run)
The tiny-model e2e validates contracts, not learning. The real validation is an RF100-VL few-shot grid, reusing the existing campaign tooling:

1. Pick 5-7 RF100-VL datasets, one per domain bucket (aerial, medical, industrial, document, natural).
2. Zero-shot baseline: existing `predict()` + `set_classes`, mAP50 at fixed confidence (the protocol the campaign already uses for score-less models).
3. 10-shot: `train()` on a 10-image split of each dataset (qwen3-vl-2b, LoRA, ~40 epochs).
4. Full-split LoRA: `train()` on the whole train split.
5. Compare all three regimes against the published conventional-detector baselines from the RF100-VL campaign.

Pass gates:
- 10-shot beats zero-shot clearly on most datasets.
- Generated boxes stay parseable after SFT (format drift is the known failure mode; the e2e asserts parseability, the grid must confirm it at scale).
- Full-split LoRA closes toward the supervised baselines on the non-COCO domains (aerial/medical/document), where zero-shot VLMs are weakest and fine-tuning must prove its value.

Cost: roughly 1-2 GPU-hours per (dataset, regime) cell on a 24GB card, ~40-80 GPU-h total, one unattended campaign run. Until that grid is green, qwen3-vl train() support should be treated as experimental per the training confidence ladder.

## Not verified
- No real-accuracy run on the 2B weights yet (see grid above).
- COCO-JSON datasets and optimizer-state resume are documented v1 limits.

## Code provenance
- All code in this PR was written for LibreYOLO in this change. No third-party code was copied, adapted, or paraphrased.
- LoRA hyperparameters (rank/alpha, LM-only targets, frozen vision tower) follow the publicly documented upstream Qwen3-VL fine-tuning defaults (Apache-2.0 repo), re-expressed through the peft public API.
- Dependencies used through public APIs only: transformers, peft, torch, PIL, tqdm.
- The e2e fixture downloads `tiny-random/qwen3-vl` (random weights, pinned revision) at test time; nothing from it is vendored.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Qwen3-VL detection fine-tuning, dataset-to-chat target generation, LoRA training, and reloadable adapter checkpoint directories.
- Introduces VLM-specific dataset, collation, recipe, training-loop, and checkpoint modules.
- Extends the LibreVLM factory and base wrapper to load fine-tuned checkpoints.
- Adds optional training dependencies, user documentation, and offline plus end-to-end tests.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

This PR is not safe to merge until arbitrary repository redirection during remote-code checkpoint loading and partial-window gradient normalization are fixed.

A crafted checkpoint can reach a Transformers remote-code loader with an attacker-selected repository, and ordinary dataset lengths cause the new trainer to underweight the final accumulation window of each epoch.

**Files Needing Attention:** libreyolo/models/vlm/base.py, libreyolo/models/vlm/training/trainer.py, libreyolo/models/vlm/training/recipes.py
</details>

<details open><summary><h3>Security Review</h3></summary>

Loading an untrusted checkpoint can redirect the LocateAnything remote-code loader to an attacker-controlled Hugging Face repository, allowing arbitrary code execution. The checkpoint's base repository must be constrained before any remote-code family loads it.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/vlm/base.py | Adds checkpoint loading and training dispatch, but allows a checkpoint to redirect a remote-code family to an arbitrary base repository. |
| libreyolo/models/vlm/training/trainer.py | Implements the VLM training lifecycle and checkpointing, but under-normalizes gradients in partial accumulation windows. |
| libreyolo/models/vlm/training/checkpoint.py | Defines the adapter checkpoint contract, though its minimal validation contributes to unsafe repository redirection. |
| libreyolo/models/vlm/training/collate.py | Builds chat-template batches and masks prompt and padding tokens with explicit prefix validation. |
| libreyolo/models/vlm/training/data.py | Reads detection labels, renders family-specific targets, and applies box-aware horizontal flipping. |
| libreyolo/models/vlm/training/recipes.py | Defines the fixed Qwen3-VL LoRA scope, but the claimed upstream recipe lacks the repository's required provenance details. |
| libreyolo/models/vlm/__init__.py | Extends LibreVLM to resolve checkpoint directories and restore their family and vocabulary. |
| tests/unit/test_vlm_training.py | Covers serialization, dataset reading, masking, checkpoint schema, and gating, but not partial accumulation normalization or adversarial checkpoint metadata. |
| tests/e2e/test_vlm_train_qwen3vl.py | Exercises tiny-model train, save, reload, and predict, but uses an exactly divisible accumulation window and trusted checkpoint metadata. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Dataset[Detect dataset YAML and labels] --> Reader[VLMDetectDataset]
    Reader --> Targets[Family-specific JSON targets]
    Targets --> Collator[Chat-template collator and label masking]
    Collator --> Trainer[LoRA training loop]
    Trainer --> Checkpoint[Adapter plus libreyolo_vlm.json]
    Checkpoint --> Factory[LibreVLM checkpoint loader]
    Factory --> Base[Recorded base-model snapshot]
    Base --> Merge[Merge LoRA adapter]
    Merge --> Predict[predict with saved vocabulary]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20libreyolo%2Flibreyolo%20PR%20%23767%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=767&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fvlm%2Fbase.py%3A146-151%0A**Untrusted%20remote-code%20repository%20override**%0A%0AWhen%20a%20crafted%20checkpoint%20declares%20the%20%60locateanything%60%20family%20and%20supplies%20an%20attacker-controlled%20repository%20with%20a%20SHA-shaped%20revision%2C%20these%20assignments%20replace%20the%20trusted%20base%20mapping%20and%20the%20model%20is%20subsequently%20loaded%20with%20%60trust_remote_code%3DTrue%60%2C%20allowing%20attacker-controlled%20Python%20code%20to%20execute.%20**How%20this%20was%20verified%3A**%20The%20contract-controlled%20repository%20reaches%20LibreLocateAnything's%20Transformers%20loaders%20with%20%60trust_remote_code%3DTrue%60%2C%20while%20the%20guard%20only%20checks%20that%20the%20supplied%20revision%20is%2040%20hexadecimal%20characters.%0A%0A%23%23%23%20Issue%202%0Alibreyolo%2Fmodels%2Fvlm%2Ftraining%2Ftrainer.py%3A382-385%0A**Partial%20accumulation%20is%20underweighted**%0A%0AWhen%20the%20number%20of%20batches%20is%20not%20divisible%20by%20%60cfg.accumulate%60%2C%20every%20loss%20in%20the%20final%20partial%20window%20is%20still%20divided%20by%20the%20full%20configured%20count%20before%20an%20optimizer%20step%2C%20causing%20those%20samples%20to%20contribute%20only%20%60remainder%20%2F%20accumulate%60%20of%20their%20intended%20gradient.%0A%0A%23%23%23%20Issue%203%0Alibreyolo%2Fmodels%2Fvlm%2Ftraining%2Frecipes.py%3A10-12%0A**Upstream%20recipe%20provenance%20is%20incomplete**%0A%0AThis%20recipe%20is%20described%20here%20and%20in%20related%20changed%20documentation%20as%20mirroring%20official%20upstream%20guidance%2C%20but%20the%20upstream%20repository%2C%20commit%2C%20and%20license%20are%20not%20recorded%2C%20preventing%20maintainers%20from%20auditing%20the%20precise%20source%20and%20its%20license%20compatibility.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=767&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22feat%2Fvlm-qwen3vl-training%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fvlm-qwen3vl-training%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fvlm%2Fbase.py%3A146-151%0A**Untrusted%20remote-code%20repository%20override**%0A%0AWhen%20a%20crafted%20checkpoint%20declares%20the%20%60locateanything%60%20family%20and%20supplies%20an%20attacker-controlled%20repository%20with%20a%20SHA-shaped%20revision%2C%20these%20assignments%20replace%20the%20trusted%20base%20mapping%20and%20the%20model%20is%20subsequently%20loaded%20with%20%60trust_remote_code%3DTrue%60%2C%20allowing%20attacker-controlled%20Python%20code%20to%20execute.%20**How%20this%20was%20verified%3A**%20The%20contract-controlled%20repository%20reaches%20LibreLocateAnything's%20Transformers%20loaders%20with%20%60trust_remote_code%3DTrue%60%2C%20while%20the%20guard%20only%20checks%20that%20the%20supplied%20revision%20is%2040%20hexadecimal%20characters.%0A%0A%23%23%23%20Issue%202%0Alibreyolo%2Fmodels%2Fvlm%2Ftraining%2Ftrainer.py%3A382-385%0A**Partial%20accumulation%20is%20underweighted**%0A%0AWhen%20the%20number%20of%20batches%20is%20not%20divisible%20by%20%60cfg.accumulate%60%2C%20every%20loss%20in%20the%20final%20partial%20window%20is%20still%20divided%20by%20the%20full%20configured%20count%20before%20an%20optimizer%20step%2C%20causing%20those%20samples%20to%20contribute%20only%20%60remainder%20%2F%20accumulate%60%20of%20their%20intended%20gradient.%0A%0A%23%23%23%20Issue%203%0Alibreyolo%2Fmodels%2Fvlm%2Ftraining%2Frecipes.py%3A10-12%0A**Upstream%20recipe%20provenance%20is%20incomplete**%0A%0AThis%20recipe%20is%20described%20here%20and%20in%20related%20changed%20documentation%20as%20mirroring%20official%20upstream%20guidance%2C%20but%20the%20upstream%20repository%2C%20commit%2C%20and%20license%20are%20not%20recorded%2C%20preventing%20maintainers%20from%20auditing%20the%20precise%20source%20and%20its%20license%20compatibility.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=767&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add LoRA detection fine-tuning for the L..."](https://github.com/libreyolo/libreyolo/commit/14131c20e5c51bf76f705ae27aec53c14319cd3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53158314)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - AGENTS.md ([source](https://github.com/libreyolo/libreyolo/blob/dev/AGENTS.md))
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
- Knowledge Base — [Data Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/data-pipeline.md)
</details>

<!-- /greptile_comment -->