### PR TITLE
Never fuse SGD: fused SGD corrupts momentum on scaler-skipped overflow steps

### DIFF
--- a/libreyolo/training/optim.py
+++ b/libreyolo/training/optim.py
@@ -10,6 +10,17 @@ import torch
 
 ParamsLike = Iterable[Union[torch.Tensor, Dict[str, Any]]]
 
+#: Optimizers that must never take the fused path. torch's fused SGD (2.11
+#: verified) sets ``_step_supports_amp_scaling`` on the instance, so
+#: GradScaler.step delegates overflow handling to the kernel instead of
+#: skipping the step itself; the fused SGD kernel then advances the momentum
+#: buffer on the very overflow steps the scaler meant to skip entirely. The
+#: routine fp16 overflow on the first training steps writes inf into
+#: momentum, and the weights explode one step later (yolo9 AMP fine-tuning
+#: reached nan loss by step 2). Fused Adam and AdamW honor found_inf and
+#: leave their state untouched on skipped steps, so they keep the fused path.
+_FUSED_UNSAFE = (torch.optim.SGD,)
+
 
 def _materialized_groups(params: ParamsLike) -> List[Union[torch.Tensor, Dict[str, Any]]]:
     """Materialize params (and each group's params) so they can be inspected
@@ -63,7 +74,7 @@ def build_optimizer(
     builds where the kwarg or the fused path itself is missing.
     """
     groups = _materialized_groups(params)
-    if _all_params_cuda(groups):
+    if _all_params_cuda(groups) and not issubclass(optim_cls, _FUSED_UNSAFE):
         try:
             return optim_cls(groups, **kwargs, fused=True)
         except (RuntimeError, ValueError, TypeError):

--- a/tests/unit/test_train_speed_quick_wins.py
+++ b/tests/unit/test_train_speed_quick_wins.py
@@ -194,7 +194,7 @@ def test_build_optimizer_bare_tensor_groups_fuse_on_cuda():
 def test_build_optimizer_falls_back_when_fused_unsupported(monkeypatch):
     calls = []
 
-    class _NoFusedSGD(torch.optim.SGD):
+    class _NoFusedAdamW(torch.optim.AdamW):
         def __init__(self, params, **kwargs):
             calls.append(sorted(kwargs))
             if "fused" in kwargs:
@@ -202,9 +202,59 @@ def test_build_optimizer_falls_back_when_fused_unsupported(monkeypatch):
             super().__init__(params, **kwargs)
 
     monkeypatch.setattr(optim_mod, "_all_params_cuda", lambda groups: True)
-    opt = build_optimizer(_NoFusedSGD, _cpu_params(), lr=0.1)
-    assert isinstance(opt, _NoFusedSGD)
+    opt = build_optimizer(_NoFusedAdamW, _cpu_params(), lr=1e-3)
+    assert isinstance(opt, _NoFusedAdamW)
     assert calls == [["fused", "lr"], ["lr"]]
+
+
+def test_build_optimizer_never_requests_fused_sgd(monkeypatch):
+    """Fused SGD corrupts momentum on GradScaler-skipped overflow steps
+    (torch 2.11), so SGD must never be constructed with fused=True even when
+    every parameter is on CUDA."""
+    calls = []
+
+    class _SpySGD(torch.optim.SGD):
+        def __init__(self, params, **kwargs):
+            calls.append(sorted(kwargs))
+            super().__init__(params, **kwargs)
+
+    monkeypatch.setattr(optim_mod, "_all_params_cuda", lambda groups: True)
+    opt = build_optimizer(_SpySGD, _cpu_params(), lr=0.1, momentum=0.9)
+    assert isinstance(opt, _SpySGD)
+    assert calls == [["lr", "momentum"]]
+    assert not any(group.get("fused") for group in opt.param_groups)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_build_optimizer_sgd_stays_stock_on_cuda():
+    params = [torch.nn.Parameter(torch.randn(3, 3, device="cuda"))]
+    opt = build_optimizer(torch.optim.SGD, params, lr=0.1, momentum=0.9)
+    assert not any(group.get("fused") for group in opt.param_groups)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_scaler_overflow_step_leaves_sgd_state_untouched():
+    """Regression for the 2026-08-14 nightly nan: an AMP overflow step must
+    leave the built SGD's momentum state untouched and the weights unchanged,
+    and the next finite step must land exactly where stock SGD lands."""
+    p = torch.nn.Parameter(torch.ones(4, device="cuda"))
+    opt = build_optimizer(torch.optim.SGD, [p], lr=0.1, momentum=0.9)
+    scaler = torch.amp.GradScaler("cuda")
+
+    overflow = (p * 1e30).sum() * 1e30
+    scaler.scale(overflow).backward()
+    scaler.step(opt)
+    scaler.update()
+    opt.zero_grad(set_to_none=True)
+    assert "momentum_buffer" not in opt.state.get(p, {})
+    assert torch.equal(p.detach(), torch.ones(4, device="cuda"))
+
+    finite = p.sum()
+    scaler.scale(finite).backward()
+    scaler.step(opt)
+    scaler.update()
+    assert torch.isfinite(p).all()
+    assert torch.allclose(p.detach(), torch.full((4,), 0.9, device="cuda"))
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")

--- a/tests/unit/test_validation_loss.py
+++ b/tests/unit/test_validation_loss.py
@@ -291,7 +291,7 @@ def test_yolo9_rank_local_normalizer_skips_collective(monkeypatch):
         raise AssertionError("rank-local validation entered a collective")
 
     monkeypatch.setattr(
-        yolo9_loss_module, "all_reduce_avg_scalar", _unexpected_collective
+        yolo9_loss_module, "all_reduce_avg_scalar_tensor", _unexpected_collective
     )
     loss = YOLO9Loss(
         num_classes=2,


### PR DESCRIPTION
Fixes the two red CI jobs on dev.

## What broke

- E2E nightly (Modal GPU): `test_rf1_training[yolo9-t]` and `test_load_finetuned_checkpoint[yolo9-t]` fail with loss nan from epoch 1 on dev.
- Unit tests (all 3 OSes): `test_yolo9_rank_local_normalizer_skips_collective` fails with AttributeError since #765 merged.

## Root cause (nightly)

- #765 made `build_optimizer` request `fused=True` for SGD on CUDA.
- torch 2.11 fused SGD sets `_step_supports_amp_scaling` on the instance, so `GradScaler.step` delegates overflow handling to the kernel instead of skipping the step itself.
- The fused SGD kernel advances the momentum buffer on overflow steps the scaler must skip entirely. The routine fp16 overflow on the first training steps writes inf into momentum; weights explode one step later.
- Proven with a minimal synthetic case: after one overflow step, stock SGD has no momentum state; fused SGD has an advanced buffer and diverged params. Fused Adam and AdamW honor found_inf (state untouched, next step bitwise equal to stock), so they keep the fused path.

## Fix

- `_FUSED_UNSAFE = (torch.optim.SGD,)` gate in `build_optimizer`; SGD always constructs stock.
- Regression tests: SGD never receives `fused=True`; an AMP overflow step leaves the built SGD's state untouched and weights unchanged, and the next finite step lands exactly where stock SGD lands.
- Unit-test fix: the monkeypatch target renamed in #765 (`all_reduce_avg_scalar` to `all_reduce_avg_scalar_tensor`).

## Verification

- Bisect: identical training config healthy at 2655c4ab, nan at d3869b27; healthy again with this fix.
- With the fix, CUDA training values are bit-identical to pre-#765 stock SGD.
- Both failing nightly tests pass on a CUDA machine (3 min run).
- `test_train_speed_quick_wins.py` + `test_validation_loss.py` + `test_rfdetr_train_speedups.py`: 127 passed (CUDA present, new regression tests executed).

Cost: SGD families lose the fused-optimizer speedup from #765 item 2. The measured wins there were AdamW-side; re-enabling SGD safely (explicit unscale before step) can be a follow-up.

## Code provenance

All code in this PR is original, written for this PR. No third-party code is ported, adapted, or derived. The diagnosis references torch's public GradScaler/fused-optimizer behavior only.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents CUDA SGD optimizers from using PyTorch’s unsafe fused implementation while retaining fused execution for supported optimizer families.
- Adds an optimizer-class exclusion gate for SGD.
- Adds CUDA regression coverage for overflow handling, momentum state, and subsequent finite updates.
- Updates the YOLO9 validation-loss test to patch the renamed tensor collective helper.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed paths.

The SGD class gate covers direct SGD and subclasses, preserves fused optimization for other CUDA optimizers, and the accompanying tests exercise both construction and AMP overflow behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/optim.py | Excludes SGD and its subclasses from automatic fused construction while preserving the existing CUDA gate and fallback behavior. |
| tests/unit/test_train_speed_quick_wins.py | Adds focused coverage proving SGD remains unfused and scaler-skipped overflow steps do not mutate parameters or momentum state. |
| tests/unit/test_validation_loss.py | Updates the YOLO9 collective monkeypatch to the helper’s current tensor-returning name. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build optimizer] --> B{All parameters on CUDA?}
    B -- No --> E[Construct stock optimizer]
    B -- Yes --> C{Optimizer is SGD family?}
    C -- Yes --> E
    C -- No --> D[Attempt fused optimizer]
    D -- Supported --> F[Use fused optimizer]
    D -- Unsupported --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Never fuse SGD: torch fused SGD corrupts..."](https://github.com/libreyolo/libreyolo/commit/229aa3e188b0aff6411f2e3812653bd127033bda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53381279)</sub>

**Context used:**

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)

<!-- /greptile_comment -->