### PR TITLE
Remove the D-FINE-line denoising sync storm and single-drain the DETR criteria (#763 items 4-5)

### DIFF
--- a/libreyolo/models/deim/denoising.py
+++ b/libreyolo/models/deim/denoising.py
@@ -62,11 +62,23 @@ def get_contrastive_denoising_training_group(
     negative_gt_mask = torch.zeros([bs, max_gt_num * 2, 1], device=device)
     negative_gt_mask[:, max_gt_num:] = 1
     negative_gt_mask = negative_gt_mask.tile([1, num_group, 1])
-    positive_gt_mask = 1 - negative_gt_mask
 
-    positive_gt_mask = positive_gt_mask.squeeze(-1) * pad_gt_mask
-    dn_positive_idx = torch.nonzero(positive_gt_mask)[:, 1]
-    dn_positive_idx = torch.split(dn_positive_idx, [n * num_group for n in num_gts])
+    # The positive-query columns are fully determined by the host-side target
+    # counts: image i has positives at column g * 2 * max_gt_num + j for
+    # g in range(num_group), j in range(num_gts[i]), ascending: exactly the
+    # order upstream's ``torch.nonzero(positive_gt_mask)`` produced. Building
+    # them from arange avoids nonzero's data-dependent output shape, which
+    # forces a GPU->CPU sync every training step.
+    group_offsets = torch.arange(
+        num_group, dtype=torch.int64, device=device
+    ).mul_(2 * max_gt_num)
+    dn_positive_idx = tuple(
+        (
+            group_offsets[:, None]
+            + torch.arange(n, dtype=torch.int64, device=device)
+        ).reshape(-1)
+        for n in num_gts
+    )
     num_denoising = int(max_gt_num * 2 * num_group)
 
     if label_noise_ratio > 0:

--- a/libreyolo/models/deim/loss.py
+++ b/libreyolo/models/deim/loss.py
@@ -329,20 +329,45 @@ class DEIMCriterion(nn.Module):
                 for idx1, idx2 in zip(indices.copy(), indices_aux.copy())
             ]
 
-        for ind in [
-            torch.cat([idx[0][:, None], idx[1][:, None]], 1) for idx in indices
-        ]:
-            unique, counts = torch.unique(ind, return_counts=True, dim=0)
-            count_sort_indices = torch.argsort(counts, descending=True)
-            unique_sorted = unique[count_sort_indices]
+        # One unique over the whole batch (image id prepended) instead of one
+        # per image: unique(dim=0) sorts rows lexicographically, so each
+        # image's segment reproduces its per-image unique output exactly,
+        # while paying one data-dependent-shape sync instead of bs.
+        ind_all = torch.cat(
+            [
+                torch.stack([torch.full_like(idx[0], i), idx[0], idx[1]], dim=1)
+                for i, idx in enumerate(indices)
+            ]
+        )
+        device = ind_all.device
+        unique_all, counts_all = torch.unique(ind_all, return_counts=True, dim=0)
+        seg_sizes = torch.bincount(unique_all[:, 0], minlength=len(indices)).tolist()
+
+        # Per-image count-descending sort (same op on the same values as the
+        # per-image form), coalesced into one batched GPU->CPU transfer;
+        # upstream's per-element .item() loop costs two device syncs per
+        # unique pair (~1,200/step).
+        sorted_pairs = []
+        offset = 0
+        for size in seg_sizes:
+            seg_counts = counts_all[offset : offset + size]
+            sorted_pairs.append(
+                unique_all[offset : offset + size, 1:][
+                    torch.argsort(seg_counts, descending=True)
+                ]
+            )
+            offset += size
+        all_pairs = torch.cat(sorted_pairs).tolist()
+
+        offset = 0
+        for size in seg_sizes:
             column_to_row = {}
-            # One batched GPU->CPU transfer; upstream's per-element .item()
-            # loop costs two device syncs per unique pair (~1,200/step).
-            for row_idx, col_idx in unique_sorted.tolist():
+            for row_idx, col_idx in all_pairs[offset : offset + size]:
                 if row_idx not in column_to_row:
                     column_to_row[row_idx] = col_idx
-            final_rows = torch.tensor(list(column_to_row.keys()), device=ind.device)
-            final_cols = torch.tensor(list(column_to_row.values()), device=ind.device)
+            offset += size
+            final_rows = torch.tensor(list(column_to_row.keys()), device=device)
+            final_cols = torch.tensor(list(column_to_row.values()), device=device)
             results.append((final_rows.long(), final_cols.long()))
         return results
 
@@ -365,24 +390,27 @@ class DEIMCriterion(nn.Module):
         assert loss in loss_map, f"do you really want to compute {loss} loss?"
         return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
 
-    def _normalizer(self, count: int, device: torch.device) -> float:
+    def _normalizer(self, count: int, device: torch.device) -> torch.Tensor:
         """Return the box-count divisor for training or rank-local validation.
 
         Training averages the count across ranks so DDP's gradient averaging
         matches single-GPU. Rank-0-only validation selects the local path
         because it cannot enter a collective while the other ranks wait at the
         validation barrier.
+
+        Returned as a 0-dim device tensor rather than ``.item()``: the value
+        is only ever a divisor (or scaled by a host int), and ``.item()`` here
+        cost one full GPU pipeline drain per call, twice per step.
         """
-        value = torch.as_tensor([count], dtype=torch.float, device=device)
+        value = torch.as_tensor(count, dtype=torch.float, device=device)
         if self.distributed_normalize and _is_dist_available_and_initialized():
             torch.distributed.all_reduce(value)
-            return torch.clamp(value / _get_world_size(), min=1).item()
-        return torch.clamp(value, min=1).item()
+            return torch.clamp(value / _get_world_size(), min=1)
+        return torch.clamp(value, min=1)
 
     def forward(self, outputs, targets, **kwargs):
         outputs_without_aux = {k: v for k, v in outputs.items() if "aux" not in k}
 
-        indices = self.matcher(outputs_without_aux, targets)["indices"]
         self._clear_cache()
 
         if "aux_outputs" not in outputs:
@@ -393,15 +421,31 @@ class DEIMCriterion(nn.Module):
                 "training output. Got keys: " + str(list(outputs.keys()))
             )
 
-        indices_aux_list, cached_indices, cached_indices_enc = [], [], []
-        for aux_outputs in outputs["aux_outputs"] + [outputs["pre_outputs"]]:
-            indices_aux = self.matcher(aux_outputs, targets)["indices"]
-            cached_indices.append(indices_aux)
-            indices_aux_list.append(indices_aux)
-        for aux_outputs in outputs["enc_aux_outputs"]:
-            indices_enc = self.matcher(aux_outputs, targets)["indices"]
-            cached_indices_enc.append(indices_enc)
-            indices_aux_list.append(indices_enc)
+        # Match the output levels as a depth-2 pipeline: the next level's
+        # cost matrix is enqueued on the device before the current one's
+        # ``.cpu()`` drains, so the transfer overlaps the next level's compute
+        # instead of stalling once per level with nothing queued behind.
+        # Depth 2 rather than enqueue-everything: a cost matrix is
+        # (bs, num_queries, total_targets) fp32, and holding every level at
+        # once raises peak VRAM on dense batches.
+        aux_levels = outputs["aux_outputs"] + [outputs["pre_outputs"]]
+        levels = [outputs_without_aux, *aux_levels, *outputs["enc_aux_outputs"]]
+        level_indices = []
+        pending_cost = self.matcher.compute_cost_matrix(levels[0], targets)
+        for next_level in levels[1:]:
+            next_cost = self.matcher.compute_cost_matrix(next_level, targets)
+            level_indices.append(
+                self.matcher.solve(pending_cost.cpu(), targets)["indices"]
+            )
+            pending_cost = next_cost
+        level_indices.append(
+            self.matcher.solve(pending_cost.cpu(), targets)["indices"]
+        )
+
+        indices = level_indices[0]
+        cached_indices = level_indices[1 : 1 + len(aux_levels)]
+        cached_indices_enc = level_indices[1 + len(aux_levels) :]
+        indices_aux_list = cached_indices + cached_indices_enc
         indices_go = self._get_go_indices(indices, indices_aux_list)
 
         device = next(iter(outputs.values())).device
@@ -507,8 +551,10 @@ class DEIMCriterion(nn.Module):
         if "dn_outputs" in outputs:
             assert "dn_meta" in outputs, ""
             indices_dn = self.get_cdn_matched_indices(outputs["dn_meta"], targets)
-            dn_num_boxes = num_boxes * outputs["dn_meta"]["dn_num_group"]
-            dn_num_boxes = dn_num_boxes if dn_num_boxes > 0 else 1
+            dn_num_group = outputs["dn_meta"]["dn_num_group"]
+            # num_boxes is clamped to >= 1, so the positivity guard reduces to
+            # a host-side check on the group count (no device sync).
+            dn_num_boxes = num_boxes * dn_num_group if dn_num_group > 0 else 1
 
             for i, aux_outputs in enumerate(outputs["dn_outputs"]):
                 aux_outputs["is_dn"] = True

--- a/libreyolo/models/deim/matcher.py
+++ b/libreyolo/models/deim/matcher.py
@@ -42,7 +42,15 @@ class HungarianMatcher(nn.Module):
         )
 
     @torch.no_grad()
-    def forward(self, outputs: Dict[str, torch.Tensor], targets, return_topk=False):
+    def compute_cost_matrix(self, outputs: Dict[str, torch.Tensor], targets):
+        """Build the pairwise matching cost on the predictions' device.
+
+        Split out from :meth:`forward` so a caller matching several output
+        levels (main + aux + enc) can enqueue the next level's cost on the
+        device before draining the current one's ``.cpu()`` transfer, paying
+        one overlapped drain per level instead of a full pipeline stall (see
+        ``DEIMCriterion.forward``).
+        """
         bs, num_queries = outputs["pred_logits"].shape[:2]
 
         if self.use_focal_loss:
@@ -83,10 +91,17 @@ class HungarianMatcher(nn.Module):
             + self.cost_class * cost_class
             + self.cost_giou * cost_giou
         )
-        C = C.view(bs, num_queries, -1).cpu()
+        return C.view(bs, num_queries, -1)
 
+    @torch.no_grad()
+    def solve(self, cost_matrix, targets, return_topk=False):
+        """Run the Hungarian assignment on a CPU cost matrix.
+
+        ``cost_matrix`` is the [bs, num_queries, total_targets] output of
+        :meth:`compute_cost_matrix` after ``.cpu()``.
+        """
         sizes = [len(v["boxes"]) for v in targets]
-        C = torch.nan_to_num(C, nan=1.0)
+        C = torch.nan_to_num(cost_matrix, nan=1.0)
         indices_pre = [
             linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))
         ]
@@ -106,6 +121,11 @@ class HungarianMatcher(nn.Module):
             }
 
         return {"indices": indices}
+
+    @torch.no_grad()
+    def forward(self, outputs: Dict[str, torch.Tensor], targets, return_topk=False):
+        cost_matrix = self.compute_cost_matrix(outputs, targets)
+        return self.solve(cost_matrix.cpu(), targets, return_topk=return_topk)
 
     def get_top_k_matches(self, C, sizes, k=1, initial_indices=None):
         indices_list = []

--- a/libreyolo/models/deimv2/loss.py
+++ b/libreyolo/models/deimv2/loss.py
@@ -29,7 +29,6 @@ class DEIMv2Criterion(DEIMCriterion):
     def forward(self, outputs, targets, epoch=0, **kwargs):
         outputs_without_aux = {k: v for k, v in outputs.items() if "aux" not in k}
 
-        indices = self.matcher(outputs_without_aux, targets, epoch=epoch)["indices"]
         self._clear_cache()
 
         if "aux_outputs" not in outputs:
@@ -38,18 +37,33 @@ class DEIMv2Criterion(DEIMCriterion):
                 "training output. Got keys: " + str(list(outputs.keys()))
             )
 
-        indices_aux_list, cached_indices, cached_indices_enc = [], [], []
+        # Match the output levels as a depth-2 pipeline: the next level's
+        # cost matrix is enqueued on the device before the current one's
+        # ``.cpu()`` drains, so the transfer overlaps the next level's compute
+        # instead of stalling once per level with nothing queued behind.
+        # Depth 2 rather than enqueue-everything: a cost matrix is
+        # (bs, num_queries, total_targets) fp32, and holding every level at
+        # once raises peak VRAM on dense batches.
         aux_outputs_list = outputs["aux_outputs"]
         if "pre_outputs" in outputs:
             aux_outputs_list = outputs["aux_outputs"] + [outputs["pre_outputs"]]
-        for aux_outputs in aux_outputs_list:
-            indices_aux = self.matcher(aux_outputs, targets, epoch=epoch)["indices"]
-            cached_indices.append(indices_aux)
-            indices_aux_list.append(indices_aux)
-        for aux_outputs in outputs["enc_aux_outputs"]:
-            indices_enc = self.matcher(aux_outputs, targets, epoch=epoch)["indices"]
-            cached_indices_enc.append(indices_enc)
-            indices_aux_list.append(indices_enc)
+        levels = [outputs_without_aux, *aux_outputs_list, *outputs["enc_aux_outputs"]]
+        level_indices = []
+        pending_cost = self.matcher.compute_cost_matrix(levels[0], targets, epoch=epoch)
+        for next_level in levels[1:]:
+            next_cost = self.matcher.compute_cost_matrix(next_level, targets, epoch=epoch)
+            level_indices.append(
+                self.matcher.solve(pending_cost.cpu(), targets)["indices"]
+            )
+            pending_cost = next_cost
+        level_indices.append(
+            self.matcher.solve(pending_cost.cpu(), targets)["indices"]
+        )
+
+        indices = level_indices[0]
+        cached_indices = level_indices[1 : 1 + len(aux_outputs_list)]
+        cached_indices_enc = level_indices[1 + len(aux_outputs_list) :]
+        indices_aux_list = cached_indices + cached_indices_enc
         indices_go = self._get_go_indices(indices, indices_aux_list)
 
         device = next(iter(outputs.values())).device
@@ -151,8 +165,10 @@ class DEIMv2Criterion(DEIMCriterion):
         if "dn_outputs" in outputs:
             assert "dn_meta" in outputs, ""
             indices_dn = self.get_cdn_matched_indices(outputs["dn_meta"], targets)
-            dn_num_boxes = num_boxes * outputs["dn_meta"]["dn_num_group"]
-            dn_num_boxes = dn_num_boxes if dn_num_boxes > 0 else 1
+            dn_num_group = outputs["dn_meta"]["dn_num_group"]
+            # num_boxes is clamped to >= 1, so the positivity guard reduces to
+            # a host-side check on the group count (no device sync).
+            dn_num_boxes = num_boxes * dn_num_group if dn_num_group > 0 else 1
 
             for i, aux_outputs in enumerate(outputs["dn_outputs"]):
                 if "local" in self.losses:

--- a/libreyolo/models/deimv2/matcher.py
+++ b/libreyolo/models/deimv2/matcher.py
@@ -52,13 +52,15 @@ class HungarianMatcher(nn.Module):
         )
 
     @torch.no_grad()
-    def forward(
-        self,
-        outputs: Dict[str, torch.Tensor],
-        targets,
-        return_topk=False,
-        epoch=0,
-    ):
+    def compute_cost_matrix(self, outputs: Dict[str, torch.Tensor], targets, epoch=0):
+        """Build the pairwise matching cost on the predictions' device.
+
+        Split out from :meth:`forward` so a caller matching several output
+        levels (main + aux + enc) can enqueue the next level's cost on the
+        device before draining the current one's ``.cpu()`` transfer, paying
+        one overlapped drain per level instead of a full pipeline stall (see
+        ``DEIMv2Criterion.forward``).
+        """
         bs, num_queries = outputs["pred_logits"].shape[:2]
 
         if self.use_focal_loss:
@@ -106,10 +108,17 @@ class HungarianMatcher(nn.Module):
                 + self.cost_giou * cost_giou
             )
 
-        C = C.view(bs, num_queries, -1).cpu()
+        return C.view(bs, num_queries, -1)
 
+    @torch.no_grad()
+    def solve(self, cost_matrix, targets, return_topk=False):
+        """Run the Hungarian assignment on a CPU cost matrix.
+
+        ``cost_matrix`` is the [bs, num_queries, total_targets] output of
+        :meth:`compute_cost_matrix` after ``.cpu()``.
+        """
         sizes = [len(v["boxes"]) for v in targets]
-        C = torch.nan_to_num(C, nan=1.0)
+        C = torch.nan_to_num(cost_matrix, nan=1.0)
         indices_pre = [
             linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))
         ]
@@ -129,6 +138,17 @@ class HungarianMatcher(nn.Module):
             }
 
         return {"indices": indices}
+
+    @torch.no_grad()
+    def forward(
+        self,
+        outputs: Dict[str, torch.Tensor],
+        targets,
+        return_topk=False,
+        epoch=0,
+    ):
+        cost_matrix = self.compute_cost_matrix(outputs, targets, epoch=epoch)
+        return self.solve(cost_matrix.cpu(), targets, return_topk=return_topk)
 
     def get_top_k_matches(self, C, sizes, k=1, initial_indices=None):
         indices_list = []

--- a/libreyolo/models/dfine/denoising.py
+++ b/libreyolo/models/dfine/denoising.py
@@ -63,11 +63,23 @@ def get_contrastive_denoising_training_group(
     negative_gt_mask = torch.zeros([bs, max_gt_num * 2, 1], device=device)
     negative_gt_mask[:, max_gt_num:] = 1
     negative_gt_mask = negative_gt_mask.tile([1, num_group, 1])
-    positive_gt_mask = 1 - negative_gt_mask
 
-    positive_gt_mask = positive_gt_mask.squeeze(-1) * pad_gt_mask
-    dn_positive_idx = torch.nonzero(positive_gt_mask)[:, 1]
-    dn_positive_idx = torch.split(dn_positive_idx, [n * num_group for n in num_gts])
+    # The positive-query columns are fully determined by the host-side target
+    # counts: image i has positives at column g * 2 * max_gt_num + j for
+    # g in range(num_group), j in range(num_gts[i]), ascending: exactly the
+    # order upstream's ``torch.nonzero(positive_gt_mask)`` produced. Building
+    # them from arange avoids nonzero's data-dependent output shape, which
+    # forces a GPU->CPU sync every training step.
+    group_offsets = torch.arange(
+        num_group, dtype=torch.int64, device=device
+    ).mul_(2 * max_gt_num)
+    dn_positive_idx = tuple(
+        (
+            group_offsets[:, None]
+            + torch.arange(n, dtype=torch.int64, device=device)
+        ).reshape(-1)
+        for n in num_gts
+    )
     num_denoising = int(max_gt_num * 2 * num_group)
 
     if label_noise_ratio > 0:

--- a/libreyolo/models/dfine/loss.py
+++ b/libreyolo/models/dfine/loss.py
@@ -402,20 +402,45 @@ class DFINECriterion(nn.Module):
                 for idx1, idx2 in zip(indices.copy(), indices_aux.copy())
             ]
 
-        for ind in [
-            torch.cat([idx[0][:, None], idx[1][:, None]], 1) for idx in indices
-        ]:
-            unique, counts = torch.unique(ind, return_counts=True, dim=0)
-            count_sort_indices = torch.argsort(counts, descending=True)
-            unique_sorted = unique[count_sort_indices]
+        # One unique over the whole batch (image id prepended) instead of one
+        # per image: unique(dim=0) sorts rows lexicographically, so each
+        # image's segment reproduces its per-image unique output exactly,
+        # while paying one data-dependent-shape sync instead of bs.
+        ind_all = torch.cat(
+            [
+                torch.stack([torch.full_like(idx[0], i), idx[0], idx[1]], dim=1)
+                for i, idx in enumerate(indices)
+            ]
+        )
+        device = ind_all.device
+        unique_all, counts_all = torch.unique(ind_all, return_counts=True, dim=0)
+        seg_sizes = torch.bincount(unique_all[:, 0], minlength=len(indices)).tolist()
+
+        # Per-image count-descending sort (same op on the same values as the
+        # per-image form), coalesced into one batched GPU->CPU transfer;
+        # upstream's per-element .item() loop costs two device syncs per
+        # unique pair (~1,200/step).
+        sorted_pairs = []
+        offset = 0
+        for size in seg_sizes:
+            seg_counts = counts_all[offset : offset + size]
+            sorted_pairs.append(
+                unique_all[offset : offset + size, 1:][
+                    torch.argsort(seg_counts, descending=True)
+                ]
+            )
+            offset += size
+        all_pairs = torch.cat(sorted_pairs).tolist()
+
+        offset = 0
+        for size in seg_sizes:
             column_to_row = {}
-            # One batched GPU->CPU transfer; upstream's per-element .item()
-            # loop costs two device syncs per unique pair (~1,200/step).
-            for row_idx, col_idx in unique_sorted.tolist():
+            for row_idx, col_idx in all_pairs[offset : offset + size]:
                 if row_idx not in column_to_row:
                     column_to_row[row_idx] = col_idx
-            final_rows = torch.tensor(list(column_to_row.keys()), device=ind.device)
-            final_cols = torch.tensor(list(column_to_row.values()), device=ind.device)
+            offset += size
+            final_rows = torch.tensor(list(column_to_row.keys()), device=device)
+            final_cols = torch.tensor(list(column_to_row.values()), device=device)
             results.append((final_rows.long(), final_cols.long()))
         return results
 
@@ -438,24 +463,26 @@ class DFINECriterion(nn.Module):
         assert loss in loss_map, f"do you really want to compute {loss} loss?"
         return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
 
-    def _normalizer(self, count: int, device: torch.device) -> float:
+    def _normalizer(self, count: int, device: torch.device) -> torch.Tensor:
         """Return the box-count divisor for training or rank-local validation.
 
         Training averages the count across ranks so DDP's gradient averaging
         matches single-GPU. Rank-0-only validation selects the local path
         because it cannot enter a collective while the other ranks wait at the
         validation barrier.
+
+        Returned as a 0-dim device tensor rather than ``.item()``: the value
+        is only ever a divisor (or scaled by a host int), and ``.item()`` here
+        cost one full GPU pipeline drain per call, twice per step.
         """
-        value = torch.as_tensor([count], dtype=torch.float, device=device)
+        value = torch.as_tensor(count, dtype=torch.float, device=device)
         if self.distributed_normalize and _is_dist_available_and_initialized():
             torch.distributed.all_reduce(value)
-            return torch.clamp(value / _get_world_size(), min=1).item()
-        return torch.clamp(value, min=1).item()
+            return torch.clamp(value / _get_world_size(), min=1)
+        return torch.clamp(value, min=1)
 
     def forward(self, outputs, targets, **kwargs):
         outputs_without_aux = {k: v for k, v in outputs.items() if "aux" not in k}
-
-        indices = self.matcher(outputs_without_aux, targets)["indices"]
         self._clear_cache()
 
         if "aux_outputs" not in outputs:
@@ -466,15 +493,31 @@ class DFINECriterion(nn.Module):
                 "training output. Got keys: " + str(list(outputs.keys()))
             )
 
-        indices_aux_list, cached_indices, cached_indices_enc = [], [], []
-        for aux_outputs in outputs["aux_outputs"] + [outputs["pre_outputs"]]:
-            indices_aux = self.matcher(aux_outputs, targets)["indices"]
-            cached_indices.append(indices_aux)
-            indices_aux_list.append(indices_aux)
-        for aux_outputs in outputs["enc_aux_outputs"]:
-            indices_enc = self.matcher(aux_outputs, targets)["indices"]
-            cached_indices_enc.append(indices_enc)
-            indices_aux_list.append(indices_enc)
+        # Match the output levels as a depth-2 pipeline: the next level's
+        # cost matrix is enqueued on the device before the current one's
+        # ``.cpu()`` drains, so the transfer overlaps the next level's compute
+        # instead of stalling once per level with nothing queued behind.
+        # Depth 2 rather than enqueue-everything: a cost matrix is
+        # (bs, num_queries, total_targets) fp32, and holding every level at
+        # once raises peak VRAM on dense batches.
+        aux_levels = outputs["aux_outputs"] + [outputs["pre_outputs"]]
+        levels = [outputs_without_aux, *aux_levels, *outputs["enc_aux_outputs"]]
+        level_indices = []
+        pending_cost = self.matcher.compute_cost_matrix(levels[0], targets)
+        for next_level in levels[1:]:
+            next_cost = self.matcher.compute_cost_matrix(next_level, targets)
+            level_indices.append(
+                self.matcher.solve(pending_cost.cpu(), targets)["indices"]
+            )
+            pending_cost = next_cost
+        level_indices.append(
+            self.matcher.solve(pending_cost.cpu(), targets)["indices"]
+        )
+
+        indices = level_indices[0]
+        cached_indices = level_indices[1 : 1 + len(aux_levels)]
+        cached_indices_enc = level_indices[1 + len(aux_levels) :]
+        indices_aux_list = cached_indices + cached_indices_enc
         indices_go = self._get_go_indices(indices, indices_aux_list)
 
         device = next(iter(outputs.values())).device
@@ -580,8 +623,10 @@ class DFINECriterion(nn.Module):
         if "dn_outputs" in outputs:
             assert "dn_meta" in outputs, ""
             indices_dn = self.get_cdn_matched_indices(outputs["dn_meta"], targets)
-            dn_num_boxes = num_boxes * outputs["dn_meta"]["dn_num_group"]
-            dn_num_boxes = dn_num_boxes if dn_num_boxes > 0 else 1
+            dn_num_group = outputs["dn_meta"]["dn_num_group"]
+            # num_boxes is clamped to >= 1, so the positivity guard reduces to
+            # a host-side check on the group count (no device sync).
+            dn_num_boxes = num_boxes * dn_num_group if dn_num_group > 0 else 1
 
             for i, aux_outputs in enumerate(outputs["dn_outputs"]):
                 aux_outputs["is_dn"] = True

--- a/libreyolo/models/dfine/matcher.py
+++ b/libreyolo/models/dfine/matcher.py
@@ -75,7 +75,15 @@ class HungarianMatcher(nn.Module):
         )
 
     @torch.no_grad()
-    def forward(self, outputs: Dict[str, torch.Tensor], targets, return_topk=False):
+    def compute_cost_matrix(self, outputs: Dict[str, torch.Tensor], targets):
+        """Build the pairwise matching cost on the predictions' device.
+
+        Split out from :meth:`forward` so a caller matching several output
+        levels (main + aux + enc) can enqueue the next level's cost on the
+        device before draining the current one's ``.cpu()`` transfer, paying
+        one overlapped drain per level instead of a full pipeline stall (see
+        ``DFINECriterion.forward``).
+        """
         bs, num_queries = outputs["pred_logits"].shape[:2]
 
         if self.use_focal_loss:
@@ -173,10 +181,17 @@ class HungarianMatcher(nn.Module):
                     )
                     offset += n_tgt
 
-        C = C.cpu()
+        return C
 
+    @torch.no_grad()
+    def solve(self, cost_matrix, targets, return_topk=False):
+        """Run the Hungarian assignment on a CPU cost matrix.
+
+        ``cost_matrix`` is the [bs, num_queries, total_targets] output of
+        :meth:`compute_cost_matrix` after ``.cpu()``.
+        """
         sizes = [len(v["boxes"]) for v in targets]
-        C = torch.nan_to_num(C, nan=1.0)
+        C = torch.nan_to_num(cost_matrix, nan=1.0)
         indices_pre = [
             linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))
         ]
@@ -196,6 +211,11 @@ class HungarianMatcher(nn.Module):
             }
 
         return {"indices": indices}
+
+    @torch.no_grad()
+    def forward(self, outputs: Dict[str, torch.Tensor], targets, return_topk=False):
+        cost_matrix = self.compute_cost_matrix(outputs, targets)
+        return self.solve(cost_matrix.cpu(), targets, return_topk=return_topk)
 
     def get_top_k_matches(self, C, sizes, k=1, initial_indices=None):
         indices_list = []

--- a/libreyolo/models/ec/decoder.py
+++ b/libreyolo/models/ec/decoder.py
@@ -40,6 +40,33 @@ from .utils import (
 )
 
 
+def _cached_weighting_function(module, reg_max, up, reg_scale):
+    """Memoised ``weighting_function`` for frozen ``up`` / ``reg_scale``.
+
+    The project vector is a deterministic function of frozen parameters, but
+    recomputing it launches ~2x ``reg_max`` tiny device ops every forward.
+    ``_version`` bumps on in-place updates only (``load_state_dict``, EMA);
+    rebinding the parameter object itself would not invalidate the key, so
+    callers must mutate ``up`` / ``reg_scale`` in place.
+    """
+    if not (torch.is_tensor(up) and torch.is_tensor(reg_scale)):
+        return weighting_function(reg_max, up, reg_scale)
+    if up.requires_grad or reg_scale.requires_grad:
+        # A cached tensor would either carry a stale autograd graph or
+        # silently cut gradients; unfrozen parameters take the direct path.
+        return weighting_function(reg_max, up, reg_scale)
+    key = (up.device, up.dtype, up._version, reg_scale._version, int(reg_max))
+    cache = getattr(module, "_weighting_cache", None)
+    if cache is None:
+        cache = module._weighting_cache = {}
+    project = cache.get(key)
+    if project is None:
+        cache.clear()
+        project = weighting_function(reg_max, up, reg_scale)
+        cache[key] = project
+    return project
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim, hidden_dim, output_dim, num_layers=3, act="relu"):
         super().__init__()
@@ -376,7 +403,7 @@ class TransformerDecoder(nn.Module):
         project = (
             self.project
             if hasattr(self, "project")
-            else weighting_function(self.reg_max, up, reg_scale)
+            else _cached_weighting_function(self, self.reg_max, up, reg_scale)
         )
 
         ref_points_detach = F.sigmoid(ref_points_unact)
@@ -805,13 +832,34 @@ class ECTransformer(nn.Module):
             anchors, valid_mask = cached
         return anchors, valid_mask
 
+    def _get_training_anchors(self, spatial_shapes, memory):
+        """Anchor cache for the training branch (and eval without a fixed size).
+
+        ``_generate_anchors`` builds the grids on the host and copies them to
+        the device, which stalls every training step even though the result is
+        a pure function of the spatial shapes. Cache per (shape, device); kept
+        separate from ``_anchor_cache`` so this path stays bitwise identical to
+        the fresh ``_generate_anchors`` call it replaces (the eval cache may
+        hold buffer-derived values instead).
+        """
+        key = (self._spatial_shape_key(spatial_shapes), memory.device)
+        cache = getattr(self, "_train_anchor_cache", None)
+        if cache is None:
+            cache = self._train_anchor_cache = OrderedDict()
+        cached = cache.get(key)
+        if cached is None:
+            cached = self._generate_anchors(spatial_shapes, device=memory.device)
+            cache[key] = cached
+        cache.move_to_end(key)
+        while len(cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            cache.popitem(last=False)
+        return cached
+
     def _get_decoder_input(
         self, memory, spatial_shapes, denoising_logits=None, denoising_bbox_unact=None
     ):
         if self.training or self.eval_spatial_size is None:
-            anchors, valid_mask = self._generate_anchors(
-                spatial_shapes, device=memory.device
-            )
+            anchors, valid_mask = self._get_training_anchors(spatial_shapes, memory)
         else:
             anchors, valid_mask = self._get_anchors_for_spatial_shapes(
                 spatial_shapes, memory
@@ -1908,12 +1956,29 @@ class ECPoseTransformer(nn.Module):
         )
         self.deploy = True
 
+    def _get_training_anchors(self, spatial_shapes, memory):
+        """Training-branch anchor cache; see ``ECTransformer._get_training_anchors``."""
+        key = (self._spatial_shape_key(spatial_shapes), memory.device, memory.dtype)
+        cache = getattr(self, "_train_anchor_cache", None)
+        if cache is None:
+            cache = self._train_anchor_cache = OrderedDict()
+        cached = cache.get(key)
+        if cached is None:
+            cached = self._generate_anchors(
+                spatial_shapes, device=memory.device, dtype=memory.dtype
+            )
+            cache[key] = cached
+        cache.move_to_end(key)
+        while len(cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            cache.popitem(last=False)
+        return cached
+
     def forward(self, feats, targets=None, samples=None):
         memory, spatial_shapes, split_sizes = self._get_encoder_input(feats)
 
         if self.training:
-            output_proposals, valid_mask = self._generate_anchors(
-                spatial_shapes, device=memory.device, dtype=memory.dtype
+            output_proposals, valid_mask = self._get_training_anchors(
+                spatial_shapes, memory
             )
             output_memory = memory.masked_fill(valid_mask, 0.0)
             output_proposals = output_proposals.repeat(memory.size(0), 1, 1)
@@ -2010,7 +2075,7 @@ class ECPoseTransformer(nn.Module):
         project = (
             self.project
             if hasattr(self, "project")
-            else weighting_function(self.reg_max, self.up, self.reg_scale)
+            else _cached_weighting_function(self, self.reg_max, self.up, self.reg_scale)
         )
 
         out_poses, out_logits, _, _, out_pre_poses, out_pre_scores = self.decoder(

--- a/libreyolo/models/ec/seg_loss.py
+++ b/libreyolo/models/ec/seg_loss.py
@@ -34,10 +34,11 @@ from .loss import ECCriterion
 class ECSegHungarianMatcher(nn.Module):
     """EC matcher with EdgeCrafter's mask-aware segmentation costs.
 
-    The return value intentionally matches D-FINE's matcher contract
-    (``{"indices": ...}``) so :class:`ECCriterion` can keep its shared forward
-    path, while the mask cost follows EdgeCrafter/RF-DETR's point-sampled
-    CE+Dice assignment recipe.
+    The interface intentionally matches D-FINE's matcher contract
+    (``compute_cost_matrix`` on device + ``solve`` on a CPU matrix, with
+    ``forward`` as their composition returning ``{"indices": ...}``) so
+    :class:`ECCriterion` can keep its shared forward path, while the mask cost
+    follows EdgeCrafter/RF-DETR's point-sampled CE+Dice assignment recipe.
     """
 
     def __init__(
@@ -71,15 +72,20 @@ class ECSegHungarianMatcher(nn.Module):
             raise ValueError("at least one matching cost must be non-zero")
 
     @torch.no_grad()
-    def forward(self, outputs, targets, return_topk=False):
+    def compute_cost_matrix(self, outputs, targets):
+        """Build the pairwise matching cost on the predictions' device.
+
+        Split out from :meth:`forward` to match the D-FINE matcher contract:
+        the shared criterion enqueues the next level's cost on device before
+        draining the current one's ``.cpu()`` transfer. Empty-target batches
+        yield a zero-width matrix that :meth:`solve` resolves to empty indices.
+        """
         bs, num_queries = outputs["pred_logits"].shape[:2]
         sizes = [len(v["boxes"]) for v in targets]
         if sum(sizes) == 0:
-            empty = [
-                (torch.zeros(0, dtype=torch.int64), torch.zeros(0, dtype=torch.int64))
-                for _ in targets
-            ]
-            return {"indices": empty}
+            return torch.zeros(
+                bs, num_queries, 0, device=outputs["pred_logits"].device
+            )
 
         flat_logits = outputs["pred_logits"].flatten(0, 1)
         if self.use_focal_loss:
@@ -135,8 +141,25 @@ class ECSegHungarianMatcher(nn.Module):
                 + self.cost_mask_dice * cost_mask_dice
             )
 
+        return cost_matrix.view(bs, num_queries, -1).float()
+
+    @torch.no_grad()
+    def solve(self, cost_matrix, targets, return_topk=False):
+        """Run the Hungarian assignment on a CPU cost matrix.
+
+        ``cost_matrix`` is the [bs, num_queries, total_targets] output of
+        :meth:`compute_cost_matrix` after ``.cpu()``.
+        """
+        sizes = [len(v["boxes"]) for v in targets]
+        if sum(sizes) == 0:
+            empty = [
+                (torch.zeros(0, dtype=torch.int64), torch.zeros(0, dtype=torch.int64))
+                for _ in targets
+            ]
+            return {"indices": empty}
+
         cost_matrix = torch.nan_to_num(
-            cost_matrix.view(bs, num_queries, -1).float().cpu(),
+            cost_matrix,
             nan=1.0,
             posinf=1e6,
             neginf=1e6,
@@ -159,6 +182,11 @@ class ECSegHungarianMatcher(nn.Module):
                 )
             }
         return {"indices": indices}
+
+    @torch.no_grad()
+    def forward(self, outputs, targets, return_topk=False):
+        cost_matrix = self.compute_cost_matrix(outputs, targets)
+        return self.solve(cost_matrix.cpu(), targets, return_topk=return_topk)
 
     def _mask_costs(self, pred_masks, targets):
         tgt_masks = torch.cat([v["masks"] for v in targets])

--- a/libreyolo/models/rtdetr/loss.py
+++ b/libreyolo/models/rtdetr/loss.py
@@ -17,7 +17,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
 
-from libreyolo.training.distributed import all_reduce_avg_scalar
+from libreyolo.training.distributed import all_reduce_avg_scalar_tensor
 
 try:
     from scipy.optimize import linear_sum_assignment
@@ -54,14 +54,17 @@ class HungarianMatcher(nn.Module):
         )
 
     @torch.no_grad()
-    def forward(self, outputs, targets):
-        """
-        Args:
-            outputs: dict with 'pred_logits' [B, Q, C] and 'pred_boxes' [B, Q, 4]
-            targets: list of dicts with 'labels' and 'boxes'
+    def compute_cost_matrix(self, outputs, targets):
+        """Build the pairwise matching cost on the predictions' device.
+
+        Split out from :meth:`forward` so a caller matching several output
+        levels (main + aux) can enqueue the next level's cost on the GPU
+        before the current one's host transfer drains the pipeline (see
+        ``SetCriterion.forward``; issue #763).
 
         Returns:
-            List of (pred_indices, target_indices) tuples per batch element.
+            Cost matrix of dim [batch_size, num_queries, total_num_targets]
+            on the predictions' device, or None when there are no targets.
         """
         bs, num_queries = outputs["pred_logits"].shape[:2]
 
@@ -76,13 +79,7 @@ class HungarianMatcher(nn.Module):
         tgt_bbox = torch.cat([v["boxes"] for v in targets])
 
         if len(tgt_ids) == 0:
-            return [
-                (
-                    torch.as_tensor([], dtype=torch.int64),
-                    torch.as_tensor([], dtype=torch.int64),
-                )
-                for _ in range(bs)
-            ]
+            return None
 
         # Classification cost
         if self.use_focal_loss:
@@ -115,11 +112,34 @@ class HungarianMatcher(nn.Module):
             + self.cost_class * cost_class
             + self.cost_giou * cost_giou
         )
-        C = C.view(bs, num_queries, -1).cpu()
+        return C.view(bs, num_queries, -1)
+
+    @torch.no_grad()
+    def solve(self, cost_matrix, targets):
+        """Run the Hungarian assignment on a host-side cost matrix.
+
+        Args:
+            cost_matrix: [batch_size, num_queries, total_num_targets] CPU
+                tensor from :meth:`compute_cost_matrix` (after ``.cpu()``),
+                or None when there are no targets.
+            targets: Same target list the cost matrix was built from.
+
+        Returns:
+            List of (pred_indices, target_indices) tuples per batch element.
+        """
+        if cost_matrix is None:
+            return [
+                (
+                    torch.as_tensor([], dtype=torch.int64),
+                    torch.as_tensor([], dtype=torch.int64),
+                )
+                for _ in targets
+            ]
 
         sizes = [len(v["boxes"]) for v in targets]
         indices = [
-            linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))
+            linear_sum_assignment(c[i])
+            for i, c in enumerate(cost_matrix.split(sizes, -1))
         ]
         return [
             (
@@ -128,6 +148,19 @@ class HungarianMatcher(nn.Module):
             )
             for i, j in indices
         ]
+
+    @torch.no_grad()
+    def forward(self, outputs, targets):
+        """
+        Args:
+            outputs: dict with 'pred_logits' [B, Q, C] and 'pred_boxes' [B, Q, 4]
+            targets: list of dicts with 'labels' and 'boxes'
+
+        Returns:
+            List of (pred_indices, target_indices) tuples per batch element.
+        """
+        C = self.compute_cost_matrix(outputs, targets)
+        return self.solve(C.cpu() if C is not None else None, targets)
 
 
 # =============================================================================
@@ -169,11 +202,18 @@ class SetCriterion(nn.Module):
         self.alpha = alpha
         self.gamma = gamma
 
-    def _normalizer(self, count, *, device) -> float:
-        """Box-count divisor: DDP-averaged for training, local for validation."""
+    def _normalizer(self, count, *, device) -> torch.Tensor:
+        """Box-count divisor: DDP-averaged for training, local for validation.
+
+        Returned as a 0-dim device tensor rather than a Python float: the
+        value is only ever a divisor, and the ``.item()`` inside the float
+        form cost one full pipeline drain per step (issue #763).
+        """
         if self.distributed_normalize:
-            return all_reduce_avg_scalar(count, device=device)
-        return float(max(float(count), 1.0))
+            return all_reduce_avg_scalar_tensor(count, device=device)
+        return torch.as_tensor(
+            float(count), dtype=torch.float32, device=device
+        ).clamp_min(1.0)
 
     def loss_labels_vfl(self, outputs, targets, indices, num_boxes, log=True):
         """Varifocal Loss — IoU-aware classification."""
@@ -322,8 +362,33 @@ class SetCriterion(nn.Module):
             k: v for k, v in outputs.items() if "aux" not in k and k != "dn_meta"
         }
 
-        # Match last layer outputs to targets
-        indices = self.matcher(outputs_without_aux, targets)
+        # Match the output levels (last decoder layer + aux layers) as a
+        # depth-2 pipeline: the next level's cost matrix is enqueued on the
+        # GPU before the current one's ``.cpu()`` drains, so the device never
+        # idles across the per-level transfers (the old flow drained it once
+        # per level with nothing queued behind). Depth 2 rather than
+        # enqueue-everything: a cost matrix is (bs, num_queries,
+        # total_targets) fp32, so holding all levels at once would raise peak
+        # VRAM on dense batches (issue #763; same shape as rfdetr's PR #762).
+        aux_outputs_list = outputs.get("aux_outputs", [])
+        levels = [outputs_without_aux, *aux_outputs_list]
+        level_indices = []
+        pending_cost = self.matcher.compute_cost_matrix(levels[0], targets)
+        for next_level in levels[1:]:
+            next_cost = self.matcher.compute_cost_matrix(next_level, targets)
+            level_indices.append(
+                self.matcher.solve(
+                    pending_cost.cpu() if pending_cost is not None else None,
+                    targets,
+                )
+            )
+            pending_cost = next_cost
+        level_indices.append(
+            self.matcher.solve(
+                pending_cost.cpu() if pending_cost is not None else None, targets
+            )
+        )
+        indices = level_indices[0]
 
         # Compute number of target boxes for normalization.
         # Under DDP, all-reduce and divide by world_size (the average per-rank
@@ -349,9 +414,9 @@ class SetCriterion(nn.Module):
             losses.update(l_dict)
 
         # Auxiliary losses (intermediate decoder layers)
-        if "aux_outputs" in outputs:
-            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
-                indices = self.matcher(aux_outputs, targets)
+        if aux_outputs_list:
+            for i, aux_outputs in enumerate(aux_outputs_list):
+                indices = level_indices[1 + i]
                 for loss in self.losses:
                     kwargs = {}
                     l_dict = self.get_loss(

--- a/tests/unit/test_dfine_sync_reduction.py
+++ b/tests/unit/test_dfine_sync_reduction.py
@@ -10,6 +10,13 @@ and domedetr (the last three route through the dfine/deim files):
 - ``DFINECriterion``/``DEIMCriterion``: tensor ``_normalizer`` (no ``.item()``),
   batched ``_get_go_indices`` (one ``unique`` + one ``tolist`` per step
   instead of one of each per image), and depth-2 pipelined matcher drains.
+
+Parity scope: bitwise on CPU (asserted below). On CUDA the tensor
+``_normalizer`` divides by a 0-dim tensor instead of a Python float, which
+selects a different division kernel; measured difference up to 4.8e-7 (fp16
+step) and 3.1e-5 (fp32 total_loss), the same acknowledged deviation the
+shipped rfdetr/yolo9 tensor normalizers carry (PR #765). Every other change
+in this branch is bitwise on CUDA as well.
   Full-criterion loss parity against the old control flow bound to a second
   criterion instance, tolerance zero (``torch.equal``).
 - ``HungarianMatcher.compute_cost_matrix``/``solve``: the split used by the

--- a/tests/unit/test_dfine_sync_reduction.py
+++ b/tests/unit/test_dfine_sync_reduction.py
@@ -1,0 +1,655 @@
+"""Parity and sync-count tests for the issue #763 D-FINE-line sync removal.
+
+Covers the denoising/loss changes shared by dfine, deim, deimv2, rtdetrv4, ec
+and domedetr (the last three route through the dfine/deim files):
+
+- ``get_contrastive_denoising_training_group``: the ``torch.nonzero`` on
+  ``positive_gt_mask`` is replaced with host-arithmetic index construction
+  (the mask is fully determined by the per-image target counts). Pinned-RNG
+  parity against a verbatim copy of the old control flow.
+- ``DFINECriterion``/``DEIMCriterion``: tensor ``_normalizer`` (no ``.item()``),
+  batched ``_get_go_indices`` (one ``unique`` + one ``tolist`` per step
+  instead of one of each per image), and depth-2 pipelined matcher drains.
+  Full-criterion loss parity against the old control flow bound to a second
+  criterion instance, tolerance zero (``torch.equal``).
+- ``HungarianMatcher.compute_cost_matrix``/``solve``: the split used by the
+  depth-2 pipeline produces assignments identical to sequential ``forward``.
+
+Baseline sync counts, measured per training step on the current code before
+this change (dfine-n, batch 8, 640 px, 10-30 targets per image, CPU counter):
+2x Tensor.item (_normalizer), 8x Tensor.tolist + 8x torch.unique
+(_get_go_indices, one per image), 1x torch.nonzero (denoising), 5x Tensor.cpu
+(one full pipeline drain per matcher level). Historically (libreyolo 1.4.0,
+before the batched _get_go_indices transfer) the same path measured 1,216
+aten::item calls per step on an ec-s campaign box, ~86 ms of a 396 ms step.
+"""
+
+from __future__ import annotations
+
+import collections
+import copy
+import traceback
+
+import pytest
+import torch
+
+from libreyolo.models.deim.loss import DEIMCriterion
+from libreyolo.models.dfine.loss import DFINECriterion
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Reference oracle: the old contrastive-denoising control flow, verbatim
+# ---------------------------------------------------------------------------
+
+
+def _reference_cdn_group(
+    targets,
+    num_classes,
+    num_queries,
+    class_embed,
+    num_denoising=100,
+    label_noise_ratio=0.5,
+    box_noise_scale=1.0,
+):
+    """Verbatim copy of the pre-change function (torch.nonzero index path)."""
+    from libreyolo.models.dfine.box_ops import box_cxcywh_to_xyxy, box_xyxy_to_cxcywh
+    from libreyolo.models.dfine.ms_deform import inverse_sigmoid
+
+    if num_denoising <= 0:
+        return None, None, None, None
+
+    num_gts = [len(t["labels"]) for t in targets]
+    device = targets[0]["labels"].device
+
+    max_gt_num = max(num_gts)
+    if max_gt_num == 0:
+        dn_meta = {
+            "dn_positive_idx": None,
+            "dn_num_group": 0,
+            "dn_num_split": [0, num_queries],
+        }
+        return None, None, None, dn_meta
+
+    num_group = num_denoising // max_gt_num
+    num_group = 1 if num_group == 0 else num_group
+    bs = len(num_gts)
+
+    input_query_class = torch.full(
+        [bs, max_gt_num], num_classes, dtype=torch.int32, device=device
+    )
+    input_query_bbox = torch.zeros([bs, max_gt_num, 4], device=device)
+    pad_gt_mask = torch.zeros([bs, max_gt_num], dtype=torch.bool, device=device)
+
+    for i in range(bs):
+        num_gt = num_gts[i]
+        if num_gt > 0:
+            input_query_class[i, :num_gt] = targets[i]["labels"]
+            input_query_bbox[i, :num_gt] = targets[i]["boxes"]
+            pad_gt_mask[i, :num_gt] = 1
+
+    input_query_class = input_query_class.tile([1, 2 * num_group])
+    input_query_bbox = input_query_bbox.tile([1, 2 * num_group, 1])
+    pad_gt_mask = pad_gt_mask.tile([1, 2 * num_group])
+
+    negative_gt_mask = torch.zeros([bs, max_gt_num * 2, 1], device=device)
+    negative_gt_mask[:, max_gt_num:] = 1
+    negative_gt_mask = negative_gt_mask.tile([1, num_group, 1])
+    positive_gt_mask = 1 - negative_gt_mask
+
+    positive_gt_mask = positive_gt_mask.squeeze(-1) * pad_gt_mask
+    dn_positive_idx = torch.nonzero(positive_gt_mask)[:, 1]
+    dn_positive_idx = torch.split(dn_positive_idx, [n * num_group for n in num_gts])
+    num_denoising = int(max_gt_num * 2 * num_group)
+
+    if label_noise_ratio > 0:
+        mask = torch.rand_like(input_query_class, dtype=torch.float) < (
+            label_noise_ratio * 0.5
+        )
+        new_label = torch.randint_like(
+            mask, 0, num_classes, dtype=input_query_class.dtype
+        )
+        input_query_class = torch.where(
+            mask & pad_gt_mask, new_label, input_query_class
+        )
+
+    if box_noise_scale > 0:
+        known_bbox = box_cxcywh_to_xyxy(input_query_bbox)
+        diff = torch.tile(input_query_bbox[..., 2:] * 0.5, [1, 1, 2]) * box_noise_scale
+        rand_sign = torch.randint_like(input_query_bbox, 0, 2) * 2.0 - 1.0
+        rand_part = torch.rand_like(input_query_bbox)
+        rand_part = (rand_part + 1.0) * negative_gt_mask + rand_part * (
+            1 - negative_gt_mask
+        )
+        known_bbox += rand_sign * rand_part * diff
+        known_bbox = torch.clip(known_bbox, min=0.0, max=1.0)
+        input_query_bbox = box_xyxy_to_cxcywh(known_bbox)
+        input_query_bbox[input_query_bbox < 0] *= -1
+        input_query_bbox_unact = inverse_sigmoid(input_query_bbox)
+
+    input_query_logits = class_embed(input_query_class)
+
+    tgt_size = num_denoising + num_queries
+    attn_mask = torch.full([tgt_size, tgt_size], False, dtype=torch.bool, device=device)
+    attn_mask[num_denoising:, :num_denoising] = True
+
+    for i in range(num_group):
+        if i == 0:
+            attn_mask[
+                max_gt_num * 2 * i : max_gt_num * 2 * (i + 1),
+                max_gt_num * 2 * (i + 1) : num_denoising,
+            ] = True
+        if i == num_group - 1:
+            attn_mask[
+                max_gt_num * 2 * i : max_gt_num * 2 * (i + 1), : max_gt_num * i * 2
+            ] = True
+        else:
+            attn_mask[
+                max_gt_num * 2 * i : max_gt_num * 2 * (i + 1),
+                max_gt_num * 2 * (i + 1) : num_denoising,
+            ] = True
+            attn_mask[
+                max_gt_num * 2 * i : max_gt_num * 2 * (i + 1), : max_gt_num * 2 * i
+            ] = True
+
+    dn_meta = {
+        "dn_positive_idx": dn_positive_idx,
+        "dn_num_group": num_group,
+        "dn_num_split": [num_denoising, num_queries],
+    }
+
+    return input_query_logits, input_query_bbox_unact, attn_mask, dn_meta
+
+
+def _cdn_impl(family):
+    if family == "dfine":
+        from libreyolo.models.dfine.denoising import (
+            get_contrastive_denoising_training_group,
+        )
+    else:
+        from libreyolo.models.deim.denoising import (
+            get_contrastive_denoising_training_group,
+        )
+    return get_contrastive_denoising_training_group
+
+
+def _make_targets(counts, num_classes, generator):
+    return [
+        {
+            "labels": torch.randint(0, num_classes, (n,), generator=generator),
+            "boxes": torch.rand(n, 4, generator=generator).clamp(1e-3, 0.5),
+        }
+        for n in counts
+    ]
+
+
+TARGET_CONFIGS = [
+    (3, 0, 5),  # empty element in the middle
+    (0, 0, 0),  # all-empty batch
+    (1,),  # single target
+    (25, 12, 31, 7),  # many targets, varied counts
+    (0, 4),  # leading empty element
+]
+
+
+@pytest.mark.parametrize("family", ["dfine", "deim"])
+@pytest.mark.parametrize("counts", TARGET_CONFIGS, ids=[str(c) for c in TARGET_CONFIGS])
+def test_cdn_group_matches_old_control_flow(family, counts):
+    """Pinned RNG: old and new produce element-wise identical denoising groups."""
+    fn = _cdn_impl(family)
+    num_classes = 7
+    class_embed = torch.nn.Embedding(num_classes + 1, 16)
+    generator = torch.Generator().manual_seed(int(sum(counts)) + 11)
+    targets = _make_targets(counts, num_classes, generator)
+
+    torch.manual_seed(763)
+    ref = _reference_cdn_group(targets, num_classes, 20, class_embed)
+    torch.manual_seed(763)
+    got = fn(targets, num_classes, 20, class_embed)
+
+    for r, g in zip(ref[:3], got[:3]):
+        if r is None:
+            assert g is None
+        else:
+            assert torch.equal(r, g)
+
+    r_meta, g_meta = ref[3], got[3]
+    assert r_meta["dn_num_group"] == g_meta["dn_num_group"]
+    assert r_meta["dn_num_split"] == g_meta["dn_num_split"]
+    if r_meta["dn_positive_idx"] is None:
+        assert g_meta["dn_positive_idx"] is None
+    else:
+        assert len(r_meta["dn_positive_idx"]) == len(g_meta["dn_positive_idx"])
+        for r_idx, g_idx in zip(r_meta["dn_positive_idx"], g_meta["dn_positive_idx"]):
+            assert torch.equal(r_idx, g_idx)
+            assert g_idx.dtype == torch.int64
+
+
+@pytest.mark.parametrize("family", ["dfine", "deim"])
+def test_cdn_group_is_nonzero_and_item_free(family, monkeypatch):
+    """The construction must not read device memory back to the host."""
+    fn = _cdn_impl(family)
+
+    def _banned(name):
+        def inner(*args, **kwargs):
+            raise AssertionError(f"denoising group construction called {name}")
+
+        return inner
+
+    monkeypatch.setattr(torch, "nonzero", _banned("torch.nonzero"))
+    monkeypatch.setattr(torch.Tensor, "nonzero", _banned("Tensor.nonzero"))
+    monkeypatch.setattr(torch.Tensor, "item", _banned("Tensor.item"))
+    monkeypatch.setattr(torch.Tensor, "tolist", _banned("Tensor.tolist"))
+
+    generator = torch.Generator().manual_seed(5)
+    targets = _make_targets((6, 0, 14), 7, generator)
+    out = fn(targets, 7, 20, torch.nn.Embedding(8, 16))
+    assert out[0] is not None
+
+
+# ---------------------------------------------------------------------------
+# Matcher split: compute_cost_matrix + solve == forward, pipelined == sequential
+# ---------------------------------------------------------------------------
+
+WEIGHTS = {"cost_class": 2, "cost_bbox": 5, "cost_giou": 2}
+
+
+def _matcher(family):
+    if family == "dfine":
+        from libreyolo.models.dfine.matcher import HungarianMatcher
+    elif family == "deim":
+        from libreyolo.models.deim.matcher import HungarianMatcher
+    else:
+        from libreyolo.models.deimv2.matcher import HungarianMatcher
+    return HungarianMatcher(WEIGHTS)
+
+
+def _level(bs, num_queries, num_classes, generator):
+    return {
+        "pred_logits": torch.randn(bs, num_queries, num_classes, generator=generator) * 2,
+        "pred_boxes": torch.rand(bs, num_queries, 4, generator=generator).clamp(
+            1e-3, 0.5
+        ),
+    }
+
+
+def _assert_indices_equal(a, b):
+    assert len(a) == len(b)
+    for (a_i, a_j), (b_i, b_j) in zip(a, b):
+        assert torch.equal(a_i, b_i)
+        assert torch.equal(a_j, b_j)
+
+
+@pytest.mark.parametrize("family", ["dfine", "deim", "deimv2"])
+@pytest.mark.parametrize("counts", [(9, 14), (0, 6), (0, 0)], ids=["dense", "one-empty", "all-empty"])
+def test_matcher_split_and_pipeline_match_sequential(family, counts):
+    """Depth-2 pipelined compute/solve == per-level forward, exactly."""
+    matcher = _matcher(family)
+    generator = torch.Generator().manual_seed(17)
+    bs, num_queries, num_classes = len(counts), 30, 5
+    targets = _make_targets(counts, num_classes, generator)
+    levels = [_level(bs, num_queries, num_classes, generator) for _ in range(4)]
+
+    sequential = [matcher(level, targets)["indices"] for level in levels]
+
+    pipelined = []
+    pending = matcher.compute_cost_matrix(levels[0], targets)
+    for next_level in levels[1:]:
+        next_cost = matcher.compute_cost_matrix(next_level, targets)
+        pipelined.append(matcher.solve(pending.cpu(), targets)["indices"])
+        pending = next_cost
+    pipelined.append(matcher.solve(pending.cpu(), targets)["indices"])
+
+    assert len(sequential) == len(pipelined)
+    for seq, pipe in zip(sequential, pipelined):
+        _assert_indices_equal(seq, pipe)
+
+
+# ---------------------------------------------------------------------------
+# Full-criterion loss parity: old control flow vs new, tolerance zero
+# ---------------------------------------------------------------------------
+
+
+def _old_criterion_forward(self, outputs, targets, **kwargs):
+    """Verbatim copy of the pre-change DFINECriterion.forward matcher head,
+    delegating the loss accumulation to the (unchanged) tail via the same
+    sequence of get_loss calls. To keep the oracle honest, this reimplements
+    the full old forward."""
+    outputs_without_aux = {k: v for k, v in outputs.items() if "aux" not in k}
+
+    indices = self.matcher(outputs_without_aux, targets)["indices"]
+    self._clear_cache()
+
+    if "aux_outputs" not in outputs:
+        raise RuntimeError(
+            "forward requires 'aux_outputs' in the model's training output."
+        )
+
+    indices_aux_list, cached_indices, cached_indices_enc = [], [], []
+    for aux_outputs in outputs["aux_outputs"] + [outputs["pre_outputs"]]:
+        indices_aux = self.matcher(aux_outputs, targets)["indices"]
+        cached_indices.append(indices_aux)
+        indices_aux_list.append(indices_aux)
+    for aux_outputs in outputs["enc_aux_outputs"]:
+        indices_enc = self.matcher(aux_outputs, targets)["indices"]
+        cached_indices_enc.append(indices_enc)
+        indices_aux_list.append(indices_enc)
+    indices_go = _old_get_go_indices(self, indices, indices_aux_list)
+
+    device = next(iter(outputs.values())).device
+    num_boxes_go = _old_normalizer(self, sum(len(x[0]) for x in indices_go), device)
+    num_boxes = _old_normalizer(self, sum(len(t["labels"]) for t in targets), device)
+
+    losses = {}
+    for loss in self.losses:
+        indices_in = indices_go if loss in ["boxes", "local"] else indices
+        num_boxes_in = num_boxes_go if loss in ["boxes", "local"] else num_boxes
+        meta = self.get_loss_meta_info(loss, outputs, targets, indices_in)
+        l_dict = self.get_loss(loss, outputs, targets, indices_in, num_boxes_in, **meta)
+        l_dict = {
+            k: l_dict[k] * self.weight_dict[k] for k in l_dict if k in self.weight_dict
+        }
+        losses.update(l_dict)
+
+    if "aux_outputs" in outputs:
+        for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+            aux_outputs["up"], aux_outputs["reg_scale"] = (
+                outputs["up"],
+                outputs["reg_scale"],
+            )
+            for loss in self.losses:
+                indices_in = (
+                    indices_go if loss in ["boxes", "local"] else cached_indices[i]
+                )
+                num_boxes_in = num_boxes_go if loss in ["boxes", "local"] else num_boxes
+                meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_in)
+                l_dict = self.get_loss(
+                    loss, aux_outputs, targets, indices_in, num_boxes_in, **meta
+                )
+                l_dict = {
+                    k: l_dict[k] * self.weight_dict[k]
+                    for k in l_dict
+                    if k in self.weight_dict
+                }
+                l_dict = {k + f"_aux_{i}": v for k, v in l_dict.items()}
+                losses.update(l_dict)
+
+    if "pre_outputs" in outputs:
+        aux_outputs = outputs["pre_outputs"]
+        for loss in self.losses:
+            indices_in = (
+                indices_go if loss in ["boxes", "local"] else cached_indices[-1]
+            )
+            num_boxes_in = num_boxes_go if loss in ["boxes", "local"] else num_boxes
+            meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_in)
+            l_dict = self.get_loss(
+                loss, aux_outputs, targets, indices_in, num_boxes_in, **meta
+            )
+            l_dict = {
+                k: l_dict[k] * self.weight_dict[k]
+                for k in l_dict
+                if k in self.weight_dict
+            }
+            l_dict = {k + "_pre": v for k, v in l_dict.items()}
+            losses.update(l_dict)
+
+    if "enc_aux_outputs" in outputs:
+        assert "enc_meta" in outputs, ""
+        class_agnostic = outputs["enc_meta"]["class_agnostic"]
+        if class_agnostic:
+            orig_num_classes = self.num_classes
+            self.num_classes = 1
+            enc_targets = copy.deepcopy(targets)
+            for t in enc_targets:
+                t["labels"] = torch.zeros_like(t["labels"])
+        else:
+            enc_targets = targets
+
+        for i, aux_outputs in enumerate(outputs["enc_aux_outputs"]):
+            for loss in self.losses:
+                indices_in = indices_go if loss == "boxes" else cached_indices_enc[i]
+                num_boxes_in = num_boxes_go if loss == "boxes" else num_boxes
+                meta = self.get_loss_meta_info(loss, aux_outputs, enc_targets, indices_in)
+                l_dict = self.get_loss(
+                    loss, aux_outputs, enc_targets, indices_in, num_boxes_in, **meta
+                )
+                l_dict = {
+                    k: l_dict[k] * self.weight_dict[k]
+                    for k in l_dict
+                    if k in self.weight_dict
+                }
+                l_dict = {k + f"_enc_{i}": v for k, v in l_dict.items()}
+                losses.update(l_dict)
+
+        if class_agnostic:
+            self.num_classes = orig_num_classes
+
+    if "dn_outputs" in outputs:
+        assert "dn_meta" in outputs, ""
+        indices_dn = self.get_cdn_matched_indices(outputs["dn_meta"], targets)
+        dn_num_boxes = num_boxes * outputs["dn_meta"]["dn_num_group"]
+        dn_num_boxes = dn_num_boxes if dn_num_boxes > 0 else 1
+
+        for i, aux_outputs in enumerate(outputs["dn_outputs"]):
+            aux_outputs["is_dn"] = True
+            aux_outputs["up"], aux_outputs["reg_scale"] = (
+                outputs["up"],
+                outputs["reg_scale"],
+            )
+            for loss in self.losses:
+                meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_dn)
+                l_dict = self.get_loss(
+                    loss, aux_outputs, targets, indices_dn, dn_num_boxes, **meta
+                )
+                l_dict = {
+                    k: l_dict[k] * self.weight_dict[k]
+                    for k in l_dict
+                    if k in self.weight_dict
+                }
+                l_dict = {k + f"_dn_{i}": v for k, v in l_dict.items()}
+                losses.update(l_dict)
+
+        if "dn_pre_outputs" in outputs:
+            aux_outputs = outputs["dn_pre_outputs"]
+            for loss in self.losses:
+                meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_dn)
+                l_dict = self.get_loss(
+                    loss, aux_outputs, targets, indices_dn, dn_num_boxes, **meta
+                )
+                l_dict = {
+                    k: l_dict[k] * self.weight_dict[k]
+                    for k in l_dict
+                    if k in self.weight_dict
+                }
+                l_dict = {k + "_dn_pre": v for k, v in l_dict.items()}
+                losses.update(l_dict)
+
+    losses = {k: torch.nan_to_num(v, nan=0.0) for k, v in losses.items()}
+    return losses
+
+
+def _old_get_go_indices(self, indices, indices_aux_list):
+    """Verbatim copy of the pre-change per-image unique/tolist loop."""
+    results = []
+    for indices_aux in indices_aux_list:
+        indices = [
+            (torch.cat([idx1[0], idx2[0]]), torch.cat([idx1[1], idx2[1]]))
+            for idx1, idx2 in zip(indices.copy(), indices_aux.copy())
+        ]
+
+    for ind in [torch.cat([idx[0][:, None], idx[1][:, None]], 1) for idx in indices]:
+        unique, counts = torch.unique(ind, return_counts=True, dim=0)
+        count_sort_indices = torch.argsort(counts, descending=True)
+        unique_sorted = unique[count_sort_indices]
+        column_to_row = {}
+        for row_idx, col_idx in unique_sorted.tolist():
+            if row_idx not in column_to_row:
+                column_to_row[row_idx] = col_idx
+        final_rows = torch.tensor(list(column_to_row.keys()), device=ind.device)
+        final_cols = torch.tensor(list(column_to_row.values()), device=ind.device)
+        results.append((final_rows.long(), final_cols.long()))
+    return results
+
+
+def _old_normalizer(self, count, device):
+    """Verbatim copy of the pre-change .item() normalizer (non-DDP path)."""
+    value = torch.as_tensor([count], dtype=torch.float, device=device)
+    return torch.clamp(value, min=1).item()
+
+
+def _detached(obj):
+    if isinstance(obj, torch.Tensor):
+        return obj.detach().clone()
+    if isinstance(obj, dict):
+        return {k: _detached(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        seq = [_detached(v) for v in obj]
+        return seq if isinstance(obj, list) else tuple(seq)
+    return obj
+
+
+def _dfine_trainer():
+    from libreyolo import LibreDFINE
+    from libreyolo.models.dfine.trainer import DFINETrainer
+
+    wrapper = LibreDFINE(None, size="n", device="cpu")
+    wrapper.model.train()
+    trainer = DFINETrainer(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="n",
+        num_classes=80,
+        data=None,
+        epochs=1,
+        batch=3,
+        imgsz=640,
+        device="cpu",
+        amp=False,
+        ema=False,
+        no_aug_epochs=0,
+        warmup_epochs=0,
+        eval_interval=-1,
+    )
+    trainer.on_setup()
+    return wrapper, trainer
+
+
+def _model_outputs_and_targets(wrapper, counts, seed=99):
+    generator = torch.Generator().manual_seed(seed)
+    targets = _make_targets(counts, 80, generator)
+    for t in targets:
+        t["labels"] = t["labels"].long()
+    imgs = torch.randn(len(counts), 3, 640, 640, generator=generator)
+    torch.manual_seed(seed)
+    with torch.no_grad():
+        outputs = wrapper.model(imgs, targets=targets)
+    return outputs, targets
+
+
+@pytest.fixture(scope="module")
+def dfine_setup():
+    torch.manual_seed(0)
+    wrapper, trainer = _dfine_trainer()
+    return wrapper, trainer
+
+
+def _run_loss_parity(trainer, outputs, targets):
+    new_criterion = trainer.build_criterion()
+    old_criterion = trainer.build_criterion()
+    # Same weights in both instances so the losses are comparable exactly.
+    old_criterion.load_state_dict(new_criterion.state_dict())
+
+    new_losses = new_criterion(_detached(outputs), targets)
+    old_losses = _old_criterion_forward(old_criterion, _detached(outputs), targets)
+
+    assert set(new_losses) == set(old_losses)
+    for key in sorted(new_losses):
+        assert torch.equal(new_losses[key], old_losses[key]), (
+            f"loss {key} differs (tolerance 0): "
+            f"{new_losses[key].item()} vs {old_losses[key].item()}"
+        )
+
+
+def test_criterion_loss_parity_with_denoising(dfine_setup):
+    """Every loss entry bitwise-identical to the old control flow, dn on."""
+    wrapper, trainer = dfine_setup
+    outputs, targets = _model_outputs_and_targets(wrapper, (5, 0, 9))
+    assert "dn_outputs" in outputs
+    _run_loss_parity(trainer, outputs, targets)
+
+
+def test_criterion_loss_parity_without_denoising(dfine_setup):
+    """Every loss entry bitwise-identical to the old control flow, dn off."""
+    wrapper, trainer = dfine_setup
+    saved = wrapper.model.decoder.num_denoising
+    try:
+        wrapper.model.decoder.num_denoising = 0
+        outputs, targets = _model_outputs_and_targets(wrapper, (4, 7, 2), seed=123)
+    finally:
+        wrapper.model.decoder.num_denoising = saved
+    assert "dn_outputs" not in outputs
+    _run_loss_parity(trainer, outputs, targets)
+
+
+# ---------------------------------------------------------------------------
+# Sync-count regression
+# ---------------------------------------------------------------------------
+
+
+class _SyncCounter:
+    """Counts host-sync-inducing calls made from the dfine/deim modules."""
+
+    WATCH = ("/models/dfine/", "/models/deim/", "/models/deimv2/")
+
+    def __init__(self):
+        self.counts = collections.Counter()
+
+    def _from_watched(self):
+        for frame in reversed(traceback.extract_stack()):
+            fn = frame.filename.replace("\\", "/")
+            if any(w in fn for w in self.WATCH):
+                return True
+        return False
+
+    def install(self, monkeypatch):
+        for owner, name in [
+            (torch.Tensor, "item"),
+            (torch.Tensor, "tolist"),
+            (torch.Tensor, "cpu"),
+            (torch.Tensor, "nonzero"),
+            (torch, "nonzero"),
+            (torch, "unique"),
+        ]:
+            orig = getattr(owner, name)
+
+            def wrapped(*args, __orig=orig, __name=name, **kwargs):
+                if self._from_watched():
+                    self.counts[__name] += 1
+                return __orig(*args, **kwargs)
+
+            monkeypatch.setattr(owner, name, wrapped)
+
+
+def test_criterion_sync_count_bound(dfine_setup, monkeypatch):
+    """Per-step sync ops in the dfine loss path stay at the reduced level.
+
+    Before this change (same setup): item 2, tolist 8, unique 8, nonzero 1
+    inside the criterion, plus one denoising nonzero in the model forward.
+    After: item 0, nonzero 0, unique 1, tolist 2, cpu equal to the number of
+    matched levels (still one transfer per level, but pipelined at depth 2).
+    """
+    wrapper, trainer = dfine_setup
+    outputs, targets = _model_outputs_and_targets(wrapper, (6, 11, 3), seed=7)
+    criterion = trainer.build_criterion()
+
+    counter = _SyncCounter()
+    counter.install(monkeypatch)
+    criterion(_detached(outputs), targets)
+
+    assert counter.counts["item"] == 0
+    assert counter.counts["nonzero"] == 0
+    assert counter.counts["unique"] == 1
+    assert counter.counts["tolist"] <= 2
+    num_levels = 1 + len(outputs["aux_outputs"]) + 1 + len(outputs["enc_aux_outputs"])
+    assert counter.counts["cpu"] <= num_levels

--- a/tests/unit/test_ec_sync_reduction.py
+++ b/tests/unit/test_ec_sync_reduction.py
@@ -1,0 +1,450 @@
+"""Sync-reduction parity and regression tests for the EC decoder (issue #763 item 4).
+
+Measured attribution before this work (2 training-like forward+loss steps of the
+EC detection path, CPU, Python-level counter over item/tolist/cpu/numpy/nonzero):
+
+    17 sync calls per step, all attributed to libreyolo/models/dfine/
+        (matcher.py cpu+numpy: 12, loss.py tolist+item: 3, denoising.py
+        nonzero: 1, plus box_ops.py bool asserts: 11 not counted above),
+    0 sync calls attributed to libreyolo/models/ec/ files.
+
+The handoff's "~9 candidate sites in ec/decoder.py" were textual grep matches
+(``int(`` on Python scalars, a deploy-only ``.item()`` in weighting_function,
+a pose-only cache-miss memoisation); none fire on the detection training path.
+The changes covered here instead remove ec/decoder.py's per-step host costs:
+training-time anchor regeneration (host grids + H2D copy every step) and the
+per-forward recomputation of the frozen ``weighting_function`` project vector.
+Both are cached; the tests prove bitwise parity against the original control
+flow, kept as private reference copies below.
+"""
+
+from __future__ import annotations
+
+import collections
+import traceback
+
+import pytest
+import torch
+
+import libreyolo.models.ec.decoder as ec_decoder_mod
+from libreyolo.models.dfine.matcher import HungarianMatcher
+from libreyolo.models.ec.decoder import ECPoseTransformer, ECTransformer
+from libreyolo.models.ec.loss import ECCriterion
+from libreyolo.models.ec.utils import weighting_function
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Private reference copies of the ORIGINAL (pre-cache) control flow.
+# ---------------------------------------------------------------------------
+
+
+def _reference_det_training_anchors(self, spatial_shapes, memory):
+    """Original ECTransformer._get_decoder_input training branch."""
+    return self._generate_anchors(spatial_shapes, device=memory.device)
+
+
+def _reference_pose_training_anchors(self, spatial_shapes, memory):
+    """Original ECPoseTransformer.forward training branch."""
+    return self._generate_anchors(
+        spatial_shapes, device=memory.device, dtype=memory.dtype
+    )
+
+
+def _reference_weighting_function(module, reg_max, up, reg_scale):
+    """Original per-forward weighting_function call (no cache)."""
+    return weighting_function(reg_max, up, reg_scale)
+
+
+class _original_control_flow:
+    """Context manager that restores the pre-cache decoder behavior."""
+
+    def __enter__(self):
+        self._det = ECTransformer._get_training_anchors
+        self._pose = ECPoseTransformer._get_training_anchors
+        self._weight = ec_decoder_mod._cached_weighting_function
+        ECTransformer._get_training_anchors = _reference_det_training_anchors
+        ECPoseTransformer._get_training_anchors = _reference_pose_training_anchors
+        ec_decoder_mod._cached_weighting_function = _reference_weighting_function
+        return self
+
+    def __exit__(self, *exc):
+        ECTransformer._get_training_anchors = self._det
+        ECPoseTransformer._get_training_anchors = self._pose
+        ec_decoder_mod._cached_weighting_function = self._weight
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_det_decoder(seed=0):
+    torch.manual_seed(seed)
+    return ECTransformer(
+        num_classes=4,
+        hidden_dim=64,
+        num_queries=30,
+        feat_channels=(64, 64, 64),
+        dim_feedforward=128,
+        num_layers=2,
+        num_points=(3, 6, 3),
+        eval_idx=-1,
+        num_denoising=10,
+        reg_max=32,
+        reg_scale=4.0,
+        eval_spatial_size=[64, 64],
+    )
+
+
+def _make_criterion():
+    matcher = HungarianMatcher(
+        weight_dict={"cost_class": 2.0, "cost_bbox": 5.0, "cost_giou": 2.0},
+        use_focal_loss=True,
+        alpha=0.25,
+        gamma=2.0,
+    )
+    return ECCriterion(
+        matcher=matcher,
+        weight_dict={
+            "loss_mal": 1.0,
+            "loss_bbox": 5.0,
+            "loss_giou": 2.0,
+            "loss_fgl": 0.15,
+            "loss_ddf": 1.5,
+        },
+        losses=["mal", "boxes", "local"],
+        num_classes=4,
+        alpha=0.75,
+        gamma=2.0,
+        reg_max=32,
+    )
+
+
+def _make_feats(bs=2, seed=1):
+    torch.manual_seed(seed)
+    return [
+        torch.randn(bs, 64, 8, 8),
+        torch.randn(bs, 64, 4, 4),
+        torch.randn(bs, 64, 2, 2),
+    ]
+
+
+def _targets_empty():
+    return [
+        {"labels": torch.zeros(0, dtype=torch.long), "boxes": torch.zeros(0, 4)},
+        {"labels": torch.zeros(0, dtype=torch.long), "boxes": torch.zeros(0, 4)},
+    ]
+
+
+def _targets_single():
+    return [
+        {
+            "labels": torch.tensor([1], dtype=torch.long),
+            "boxes": torch.tensor([[0.5, 0.5, 0.2, 0.2]]),
+        },
+        {"labels": torch.zeros(0, dtype=torch.long), "boxes": torch.zeros(0, 4)},
+    ]
+
+
+def _targets_many():
+    g = torch.Generator().manual_seed(3)
+    return [
+        {
+            "labels": torch.tensor([0, 1, 2], dtype=torch.long),
+            "boxes": torch.rand(3, 4, generator=g) * 0.4 + 0.2,
+        },
+        {
+            "labels": torch.tensor([3, 0, 1, 2, 3], dtype=torch.long),
+            "boxes": torch.rand(5, 4, generator=g) * 0.4 + 0.2,
+        },
+    ]
+
+
+def _assert_tree_equal(a, b, path="out"):
+    assert type(a) is type(b), f"{path}: type {type(a)} vs {type(b)}"
+    if isinstance(a, torch.Tensor):
+        assert torch.equal(a, b), f"{path}: tensors differ"
+    elif isinstance(a, dict):
+        assert a.keys() == b.keys(), f"{path}: keys differ"
+        for k in a:
+            _assert_tree_equal(a[k], b[k], f"{path}.{k}")
+    elif isinstance(a, (list, tuple)):
+        assert len(a) == len(b), f"{path}: length differs"
+        for i, (x, y) in enumerate(zip(a, b)):
+            _assert_tree_equal(x, y, f"{path}[{i}]")
+    else:
+        assert a == b, f"{path}: {a} != {b}"
+
+
+# ---------------------------------------------------------------------------
+# Fixed-input forward parity
+# ---------------------------------------------------------------------------
+
+
+def test_det_training_forward_parity_cold_vs_warm_vs_reference():
+    """Decoder outputs must be bitwise identical with a cold cache, a warm
+    cache, and the original regenerate-every-step control flow."""
+    dec = _make_det_decoder()
+    dec.train()
+    ref = _make_det_decoder(seed=99)
+    ref.load_state_dict(dec.state_dict())
+    ref.train()
+
+    feats = _make_feats()
+    targets = _targets_many()
+
+    torch.manual_seed(7)
+    out_cold = dec(feats, targets=targets)
+    torch.manual_seed(7)
+    out_warm = dec(feats, targets=targets)
+    with _original_control_flow():
+        torch.manual_seed(7)
+        out_ref = ref(feats, targets=targets)
+
+    _assert_tree_equal(out_cold, out_warm)
+    _assert_tree_equal(out_cold, out_ref)
+
+
+def test_det_eval_dynamic_size_forward_parity():
+    """eval_spatial_size=None routes eval through the training-anchor cache;
+    outputs must match the original per-forward regeneration exactly."""
+    torch.manual_seed(0)
+    dec = ECTransformer(
+        num_classes=4,
+        hidden_dim=64,
+        num_queries=30,
+        feat_channels=(64, 64, 64),
+        dim_feedforward=128,
+        num_layers=2,
+        num_points=(3, 6, 3),
+        eval_idx=-1,
+        num_denoising=10,
+        reg_max=32,
+        reg_scale=4.0,
+        eval_spatial_size=None,
+    ).eval()
+
+    feats = _make_feats(bs=1)
+    with torch.no_grad():
+        out_cold = dec(feats)
+        out_warm = dec(feats)
+        with _original_control_flow():
+            out_ref = dec(feats)
+    _assert_tree_equal(out_cold, out_warm)
+    _assert_tree_equal(out_cold, out_ref)
+
+
+def test_cached_anchors_equal_fresh_generation():
+    dec = _make_det_decoder()
+    dec.train()
+    memory = torch.zeros(2, 84, 64)
+    shapes = [[8, 8], [4, 4], [2, 2]]
+    a_new, m_new = dec._get_training_anchors(shapes, memory)
+    a_ref, m_ref = _reference_det_training_anchors(dec, shapes, memory)
+    assert torch.equal(a_new, a_ref)
+    assert torch.equal(m_new, m_ref)
+    # warm lookup returns the identical cached tensors
+    a_again, _ = dec._get_training_anchors(shapes, memory)
+    assert a_again is a_new
+
+
+def test_cached_weighting_function_tracks_parameter_updates():
+    dec = _make_det_decoder()
+    inner = dec.decoder
+    p1 = ec_decoder_mod._cached_weighting_function(
+        inner, inner.reg_max, dec.up, dec.reg_scale
+    )
+    assert torch.equal(p1, weighting_function(inner.reg_max, dec.up, dec.reg_scale))
+    p2 = ec_decoder_mod._cached_weighting_function(
+        inner, inner.reg_max, dec.up, dec.reg_scale
+    )
+    assert p2 is p1
+    # in-place parameter update (what load_state_dict does) must invalidate
+    with torch.no_grad():
+        dec.reg_scale.copy_(torch.tensor([8.0]))
+    p3 = ec_decoder_mod._cached_weighting_function(
+        inner, inner.reg_max, dec.up, dec.reg_scale
+    )
+    assert not torch.equal(p3, p1)
+    assert torch.equal(p3, weighting_function(inner.reg_max, dec.up, dec.reg_scale))
+
+
+# ---------------------------------------------------------------------------
+# Training-path loss parity (denoising active)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "targets_fn", [_targets_empty, _targets_single, _targets_many]
+)
+def test_det_training_loss_parity(targets_fn):
+    """EC detection loss values bitwise identical to the original control flow
+    on fixed inputs, across empty / single / many target configurations."""
+    dec = _make_det_decoder()
+    dec.train()
+    ref = _make_det_decoder(seed=99)
+    ref.load_state_dict(dec.state_dict())
+    ref.train()
+    crit = _make_criterion()
+    crit.train()
+
+    feats = _make_feats()
+    targets = targets_fn()
+
+    torch.manual_seed(11)
+    losses_cold = crit(dec(feats, targets=targets), targets)
+    torch.manual_seed(11)
+    losses_warm = crit(dec(feats, targets=targets), targets)
+    with _original_control_flow():
+        torch.manual_seed(11)
+        losses_ref = crit(ref(feats, targets=targets), targets)
+
+    assert losses_cold.keys() == losses_ref.keys()
+    for k in losses_cold:
+        assert torch.equal(losses_cold[k], losses_warm[k]), k
+        assert torch.equal(losses_cold[k], losses_ref[k]), k
+
+
+def test_pose_training_forward_parity():
+    def make():
+        torch.manual_seed(0)
+        return ECPoseTransformer(
+            hidden_dim=64,
+            nhead=4,
+            num_queries=10,
+            num_decoder_layers=2,
+            dim_feedforward=128,
+            num_keypoints=17,
+            eval_spatial_size=None,
+        )
+
+    def make_targets():
+        g = torch.Generator().manual_seed(5)
+        out = []
+        for n in (2, 1):
+            xy = torch.rand(n, 34, generator=g)
+            vis = torch.randint(0, 3, (n, 17), generator=g).float()
+            out.append(
+                {
+                    "labels": torch.zeros(n, dtype=torch.long),
+                    "boxes": torch.rand(n, 4, generator=g) * 0.4 + 0.2,
+                    "keypoints": torch.cat([xy, vis], dim=1),
+                    "area": torch.rand(n, generator=g) * 100,
+                    "orig_size": torch.tensor([64, 64]),
+                }
+            )
+        return out
+
+    dec = make()
+    dec.train()
+    ref = make()
+    ref.load_state_dict(dec.state_dict())
+    ref.train()
+
+    torch.manual_seed(2)
+    feats = [
+        torch.randn(2, 64, 8, 8),
+        torch.randn(2, 64, 4, 4),
+        torch.randn(2, 64, 2, 2),
+    ]
+    samples = torch.randn(2, 3, 64, 64)
+    targets = make_targets()
+
+    torch.manual_seed(21)
+    out_cold = dec(feats, targets=targets, samples=samples)
+    torch.manual_seed(21)
+    out_warm = dec(feats, targets=targets, samples=samples)
+    with _original_control_flow():
+        torch.manual_seed(21)
+        out_ref = ref(feats, targets=targets, samples=samples)
+
+    _assert_tree_equal(out_cold, out_warm)
+    _assert_tree_equal(out_cold, out_ref)
+
+
+# ---------------------------------------------------------------------------
+# Sync-count regression
+# ---------------------------------------------------------------------------
+
+
+class _SyncCounter:
+    """Counts Python-level item/tolist/cpu/numpy/nonzero calls per source file."""
+
+    KINDS = ("item", "tolist", "cpu", "numpy", "nonzero")
+
+    def __init__(self):
+        self.counts = collections.Counter()
+        self._orig = {}
+
+    def _record(self):
+        for fr in reversed(traceback.extract_stack()):
+            f = fr.filename.replace("\\", "/")
+            if "libreyolo/" in f and "test_ec_sync_reduction" not in f:
+                self.counts[f.split("libreyolo/", 1)[-1]] += 1
+                return
+        self.counts["<outside>"] += 1
+
+    def __enter__(self):
+        rec = self._record
+        for name in ("item", "tolist", "cpu", "numpy", "nonzero"):
+            orig = getattr(torch.Tensor, name)
+            self._orig[name] = orig
+
+            def make(orig):
+                def fn(self_, *a, **k):
+                    rec()
+                    return orig(self_, *a, **k)
+
+                return fn
+
+            setattr(torch.Tensor, name, make(orig))
+        self._orig["torch.nonzero"] = torch.nonzero
+        orig_nz = torch.nonzero
+
+        def t_nonzero(*a, **k):
+            rec()
+            return orig_nz(*a, **k)
+
+        torch.nonzero = t_nonzero
+        return self
+
+    def __exit__(self, *exc):
+        for name in ("item", "tolist", "cpu", "numpy", "nonzero"):
+            setattr(torch.Tensor, name, self._orig[name])
+        torch.nonzero = self._orig["torch.nonzero"]
+        return False
+
+    def total(self, prefix):
+        return sum(c for f, c in self.counts.items() if f.startswith(prefix))
+
+
+def test_ec_decoder_sync_count_regression():
+    """The EC decoder path must issue no Python-level syncs from ec/ files.
+
+    Before this work: 17 sync calls per detection training step, all in
+    libreyolo/models/dfine/ (matcher/loss/denoising); 0 in libreyolo/models/ec/.
+    This test pins the ec/ contribution at 0 for the full forward and bounds
+    the whole decoder forward (which still crosses dfine denoising) at 2 to
+    leave headroom for the dfine-side work landing separately.
+    """
+    dec = _make_det_decoder()
+    dec.train()
+    feats = _make_feats()
+    targets = _targets_many()
+
+    torch.manual_seed(7)
+    dec(feats, targets=targets)  # warm caches; not counted
+
+    with _SyncCounter() as counter:
+        torch.manual_seed(7)
+        dec(feats, targets=targets)
+
+    ec_count = counter.total("models/ec/")
+    forward_count = sum(
+        c for f, c in counter.counts.items() if f != "<outside>"
+    )
+    assert ec_count == 0, f"ec/ sync sites regressed: {counter.counts}"
+    assert forward_count <= 2, f"decoder forward sync budget: {counter.counts}"

--- a/tests/unit/test_rtdetr_sync_reduction.py
+++ b/tests/unit/test_rtdetr_sync_reduction.py
@@ -10,6 +10,12 @@ step below:
     rtdetr v1:  7 x ``.cpu()`` (matcher) + 1 x ``.item()`` (normalizer)
     rtdetrv2:   8 x ``.cpu()``           + 2 x ``.item()``
 
+Parity scope: bitwise on CPU (asserted below). On CUDA the tensor
+``_normalizer`` division selects a different kernel than the old
+divide-by-Python-float and differs by up to ~3e-5 in ``total_loss``; this is
+the same acknowledged deviation the shipped rfdetr/yolo9 tensor normalizers
+carry (PR #765). The matcher pipeline itself is bitwise on CUDA.
+
 The restructure splits the matcher into ``compute_cost_matrix`` (device work)
 and ``solve`` (host LSAP) and pipelines the levels at depth 2, so each
 transfer has the next level's cost enqueued behind it, and the normalizer

--- a/tests/unit/test_rtdetr_sync_reduction.py
+++ b/tests/unit/test_rtdetr_sync_reduction.py
@@ -1,0 +1,542 @@
+"""Parity and sync-count tests for the RT-DETR single-drain criterion (issue #763).
+
+The RT-DETR ``SetCriterion`` used to call its monolithic matcher once per
+output level (main + 5 decoder aux + 1 encoder level appended to
+``aux_outputs``), each call ending in an isolated ``.cpu()`` pipeline drain,
+plus one ``.item()`` drain from the float ``num_boxes`` normalizer. Measured
+per training step at the pre-change base (dev @ d3869b27) on the synthetic
+step below:
+
+    rtdetr v1:  7 x ``.cpu()`` (matcher) + 1 x ``.item()`` (normalizer)
+    rtdetrv2:   8 x ``.cpu()``           + 2 x ``.item()``
+
+The restructure splits the matcher into ``compute_cost_matrix`` (device work)
+and ``solve`` (host LSAP) and pipelines the levels at depth 2, so each
+transfer has the next level's cost enqueued behind it, and the normalizer
+stays a 0-dim tensor. The depth-2 theoretical floor is one ``.cpu()``
+transfer per matched level and zero ``.item()``; the tests below pin the
+criterion to that floor and prove the losses bitwise-identical against a
+reference implementation of the old per-level control flow.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import torch
+
+from libreyolo.models.rtdetr.loss import (
+    HungarianMatcher,
+    RTDETRLoss,
+    SetCriterion,
+)
+from libreyolo.models.rtdetrv2.loss import RTDETRv2Loss
+from libreyolo.training.distributed import all_reduce_avg_scalar
+
+try:
+    from scipy.optimize import linear_sum_assignment
+except ImportError:  # pragma: no cover - scipy is an rtdetr training dep
+    linear_sum_assignment = None
+
+pytestmark = pytest.mark.unit
+
+BS = 2
+NUM_QUERIES = 30
+NUM_CLASSES = 5
+NUM_AUX = 6  # rtdetr v1: 5 decoder aux levels + 1 encoder level
+NUM_DN_AUX = 6
+DN_NUM_GROUP = 4
+
+TARGET_COUNTS = [
+    (4, 7),
+    (0, 0),
+    (0, 5),
+    (1, 0),
+    (1, 1),
+    (40, 25),
+]
+COUNT_IDS = ["normal", "all-empty", "half-empty", "single-and-empty", "single", "many"]
+
+
+# ---------------------------------------------------------------------------
+# Synthetic inputs mirroring a training step
+# ---------------------------------------------------------------------------
+
+
+def _outputs(generator, num_queries=NUM_QUERIES):
+    return {
+        "pred_logits": torch.randn(BS, num_queries, NUM_CLASSES, generator=generator) * 3,
+        "pred_boxes": torch.rand(BS, num_queries, 4, generator=generator).clamp(1e-3, 1.0),
+    }
+
+
+def _targets(generator, counts):
+    return [
+        {
+            "labels": torch.randint(0, NUM_CLASSES, (n,), generator=generator),
+            "boxes": torch.rand(n, 4, generator=generator).clamp(1e-3, 1.0),
+        }
+        for n in counts
+    ]
+
+
+def _step_outputs(generator, counts, v2=False):
+    """Full training-step output dict: main + aux + denoising (+ v2 enc)."""
+    out = _outputs(generator)
+    out["aux_outputs"] = [_outputs(generator) for _ in range(NUM_AUX)]
+    dn_queries = max(max(counts), 1) * 2 * DN_NUM_GROUP
+    out["dn_aux_outputs"] = [
+        _outputs(generator, dn_queries) for _ in range(NUM_DN_AUX)
+    ]
+    out["dn_meta"] = {
+        "dn_positive_idx": [
+            torch.arange(n * DN_NUM_GROUP, dtype=torch.int64) for n in counts
+        ],
+        "dn_num_group": DN_NUM_GROUP,
+        "dn_num_split": [dn_queries, NUM_QUERIES],
+    }
+    if v2:
+        out["enc_aux_outputs"] = [_outputs(generator)]
+        out["enc_meta"] = {"class_agnostic": False}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Reference implementations of the old (pre-#763) control flow
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def _reference_matcher_indices(matcher, outputs, targets):
+    """The old monolithic ``HungarianMatcher.forward``: full cost build,
+    one ``.cpu()``, then per-image LSAP, all in a single call."""
+    bs, num_queries = outputs["pred_logits"].shape[:2]
+
+    if matcher.use_focal_loss:
+        out_prob = torch.nn.functional.sigmoid(outputs["pred_logits"].flatten(0, 1))
+    else:
+        out_prob = outputs["pred_logits"].flatten(0, 1).softmax(-1)
+
+    out_bbox = outputs["pred_boxes"].flatten(0, 1)
+
+    tgt_ids = torch.cat([v["labels"] for v in targets])
+    tgt_bbox = torch.cat([v["boxes"] for v in targets])
+
+    if len(tgt_ids) == 0:
+        return [
+            (
+                torch.as_tensor([], dtype=torch.int64),
+                torch.as_tensor([], dtype=torch.int64),
+            )
+            for _ in range(bs)
+        ]
+
+    if matcher.use_focal_loss:
+        out_prob = out_prob[:, tgt_ids]
+        neg_cost_class = (
+            (1 - matcher.alpha)
+            * (out_prob**matcher.gamma)
+            * (-(1 - out_prob + 1e-8).log())
+        )
+        pos_cost_class = (
+            matcher.alpha
+            * ((1 - out_prob) ** matcher.gamma)
+            * (-(out_prob + 1e-8).log())
+        )
+        cost_class = pos_cost_class - neg_cost_class
+    else:
+        cost_class = -out_prob[:, tgt_ids]
+
+    cost_bbox = (out_bbox[:, None, :] - tgt_bbox[None, :, :]).abs().sum(-1)
+
+    from libreyolo.models.rtdetr.box_ops import (
+        box_cxcywh_to_xyxy,
+        generalized_box_iou,
+    )
+
+    cost_giou = -generalized_box_iou(
+        box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox)
+    )
+
+    C = (
+        matcher.cost_bbox * cost_bbox
+        + matcher.cost_class * cost_class
+        + matcher.cost_giou * cost_giou
+    )
+    C = C.view(bs, num_queries, -1).cpu()
+
+    sizes = [len(v["boxes"]) for v in targets]
+    indices = [linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))]
+    return [
+        (
+            torch.as_tensor(i, dtype=torch.int64),
+            torch.as_tensor(j, dtype=torch.int64),
+        )
+        for i, j in indices
+    ]
+
+
+class _ReferenceSetCriterion(SetCriterion):
+    """Old ``SetCriterion.forward``: sequential per-level matcher calls
+    (one full drain each) and the float ``num_boxes`` normalizer."""
+
+    def _normalizer(self, count, *, device):
+        if self.distributed_normalize:
+            return all_reduce_avg_scalar(count, device=device)
+        return float(max(float(count), 1.0))
+
+    def forward(self, outputs, targets):
+        outputs = self._cast_to_float32(outputs)
+
+        outputs_without_aux = {
+            k: v for k, v in outputs.items() if "aux" not in k and k != "dn_meta"
+        }
+
+        indices = _reference_matcher_indices(self.matcher, outputs_without_aux, targets)
+
+        num_boxes = self._normalizer(
+            sum(len(t["labels"]) for t in targets),
+            device=next(iter(outputs.values())).device,
+        )
+
+        losses = {}
+        for loss in self.losses:
+            l_dict = self.get_loss(loss, outputs, targets, indices, num_boxes)
+            l_dict = {
+                k: l_dict[k] * self.weight_dict.get(k, 1.0)
+                for k in l_dict
+                if k in self.weight_dict
+            }
+            losses.update(l_dict)
+
+        if "aux_outputs" in outputs:
+            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+                indices = _reference_matcher_indices(self.matcher, aux_outputs, targets)
+                for loss in self.losses:
+                    l_dict = self.get_loss(loss, aux_outputs, targets, indices, num_boxes)
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict.get(k, 1.0)
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_aux_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        if "dn_aux_outputs" in outputs:
+            assert "dn_meta" in outputs
+            indices = self.get_cdn_matched_indices(outputs["dn_meta"], targets)
+            num_boxes_dn = num_boxes * outputs["dn_meta"]["dn_num_group"]
+
+            for i, aux_outputs in enumerate(outputs["dn_aux_outputs"]):
+                for loss in self.losses:
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices, num_boxes_dn
+                    )
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict.get(k, 1.0)
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_dn_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        total_loss = sum(v for v in losses.values() if isinstance(v, torch.Tensor))
+        losses["total_loss"] = total_loss
+
+        return losses
+
+
+class _ReferenceRTDETRCriterionv2(_ReferenceSetCriterion):
+    """Old v2 flow: reference parent forward plus the per-level
+    ``enc_aux_outputs`` matcher calls, all through the reference matcher."""
+
+    def forward(self, outputs, targets):
+        losses = _ReferenceSetCriterion.forward(self, outputs, targets)
+
+        if "enc_aux_outputs" in outputs:
+            enc_losses = self._compute_enc_aux_losses(outputs, targets)
+            if enc_losses:
+                losses.update(enc_losses)
+                losses["total_loss"] = sum(
+                    v
+                    for k, v in losses.items()
+                    if k != "total_loss" and isinstance(v, torch.Tensor)
+                )
+        return losses
+
+    def _compute_enc_aux_losses(self, outputs, targets):
+        assert "enc_meta" in outputs, "enc_aux_outputs requires enc_meta"
+
+        device = outputs["pred_logits"].device
+        num_boxes = self._normalizer(
+            sum(len(t["labels"]) for t in targets), device=device
+        )
+
+        class_agnostic = bool(outputs["enc_meta"].get("class_agnostic", False))
+        if class_agnostic:
+            orig_num_classes = self.num_classes
+            self.num_classes = 1
+            enc_targets = copy.deepcopy(targets)
+            for t in enc_targets:
+                t["labels"] = torch.zeros_like(t["labels"])
+        else:
+            enc_targets = targets
+
+        losses = {}
+        try:
+            for i, aux_outputs in enumerate(outputs["enc_aux_outputs"]):
+                aux_outputs = {
+                    k: v.float() if isinstance(v, torch.Tensor) else v
+                    for k, v in aux_outputs.items()
+                }
+                indices = _reference_matcher_indices(
+                    self.matcher, aux_outputs, enc_targets
+                )
+                for loss in self.losses:
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, enc_targets, indices, num_boxes
+                    )
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict.get(k, 1.0)
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_enc_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+        finally:
+            if class_agnostic:
+                self.num_classes = orig_num_classes
+
+        return losses
+
+
+def _reference_criterion(criterion, cls=_ReferenceSetCriterion):
+    """Reference twin sharing the (stateless) matcher and config."""
+    return cls(
+        matcher=criterion.matcher,
+        weight_dict=criterion.weight_dict,
+        losses=criterion.losses,
+        alpha=criterion.alpha,
+        gamma=criterion.gamma,
+        num_classes=criterion.num_classes,
+        distributed_normalize=criterion.distributed_normalize,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assignment parity: split matcher == old monolithic matcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_focal_loss", [True, False], ids=["focal", "softmax"])
+@pytest.mark.parametrize("counts", TARGET_COUNTS, ids=COUNT_IDS)
+@pytest.mark.parametrize("seed", [0, 1, 763])
+def test_split_matcher_assignments_match_reference(seed, counts, use_focal_loss):
+    matcher = HungarianMatcher(
+        {"cost_class": 2, "cost_bbox": 5, "cost_giou": 2},
+        use_focal_loss=use_focal_loss,
+    )
+    generator = torch.Generator().manual_seed(seed)
+    outputs = _outputs(generator)
+    targets = _targets(generator, counts)
+
+    new = matcher(outputs, targets)
+    ref = _reference_matcher_indices(matcher, outputs, targets)
+
+    assert len(new) == len(ref) == BS
+    for (pn, tn), (pr, tr), n in zip(new, ref, counts):
+        assert torch.equal(pn, pr)
+        assert torch.equal(tn, tr)
+        assert len(pn) == len(tn) == min(n, NUM_QUERIES)
+
+
+def test_compute_cost_matrix_returns_none_without_targets():
+    matcher = HungarianMatcher(
+        {"cost_class": 2, "cost_bbox": 5, "cost_giou": 2}, use_focal_loss=True
+    )
+    generator = torch.Generator().manual_seed(0)
+    outputs = _outputs(generator)
+    targets = _targets(generator, (0, 0))
+
+    assert matcher.compute_cost_matrix(outputs, targets) is None
+    indices = matcher.solve(None, targets)
+    assert len(indices) == BS
+    for pi, ti in indices:
+        assert pi.dtype == ti.dtype == torch.int64
+        assert len(pi) == len(ti) == 0
+
+
+# ---------------------------------------------------------------------------
+# Loss parity: pipelined criterion == old sequential control flow, bitwise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_vfl", [True, False], ids=["vfl", "focal"])
+@pytest.mark.parametrize("counts", TARGET_COUNTS, ids=COUNT_IDS)
+@pytest.mark.parametrize("seed", [0, 763])
+def test_criterion_losses_bitwise_match_reference(seed, counts, use_vfl):
+    criterion = RTDETRLoss(num_classes=NUM_CLASSES, use_vfl=use_vfl)
+    reference = _reference_criterion(criterion)
+    criterion.train()
+    reference.train()
+
+    generator = torch.Generator().manual_seed(seed)
+    outputs = _step_outputs(generator, counts)
+    targets = _targets(generator, counts)
+
+    new_losses = criterion(outputs, targets)
+    ref_losses = reference(outputs, targets)
+
+    assert new_losses.keys() == ref_losses.keys()
+    for key in ref_losses:
+        assert torch.equal(new_losses[key], torch.as_tensor(ref_losses[key])), key
+    assert new_losses["total_loss"].ndim == 0
+
+
+@pytest.mark.parametrize("class_agnostic", [False, True], ids=["classed", "agnostic"])
+@pytest.mark.parametrize("counts", TARGET_COUNTS, ids=COUNT_IDS)
+@pytest.mark.parametrize("seed", [0, 763])
+def test_rtdetrv2_criterion_losses_bitwise_match_reference(seed, counts, class_agnostic):
+    criterion = RTDETRv2Loss(num_classes=NUM_CLASSES)
+    reference = _reference_criterion(criterion, cls=_ReferenceRTDETRCriterionv2)
+    criterion.train()
+    reference.train()
+
+    generator = torch.Generator().manual_seed(seed)
+    outputs = _step_outputs(generator, counts, v2=True)
+    outputs["enc_meta"]["class_agnostic"] = class_agnostic
+    if class_agnostic:
+        # The agnostic enc_score_head emits a single foreground logit.
+        for enc_out in outputs["enc_aux_outputs"]:
+            enc_out["pred_logits"] = enc_out["pred_logits"][..., :1]
+    targets = _targets(generator, counts)
+
+    new_losses = criterion(outputs, targets)
+    ref_losses = reference(outputs, targets)
+
+    assert new_losses.keys() == ref_losses.keys()
+    assert any(k.endswith("_enc_0") for k in new_losses)
+    for key in ref_losses:
+        assert torch.equal(new_losses[key], torch.as_tensor(ref_losses[key])), key
+
+
+# ---------------------------------------------------------------------------
+# Sync-count regression: at the depth-2 floor
+# ---------------------------------------------------------------------------
+
+
+class _TransferCounter:
+    def __init__(self, monkeypatch):
+        self.cpu = 0
+        self.item = 0
+        self.tolist = 0
+        orig_cpu = torch.Tensor.cpu
+        orig_item = torch.Tensor.item
+        orig_tolist = torch.Tensor.tolist
+
+        def counting_cpu(t, *a, **k):
+            self.cpu += 1
+            return orig_cpu(t, *a, **k)
+
+        def counting_item(t):
+            self.item += 1
+            return orig_item(t)
+
+        def counting_tolist(t):
+            self.tolist += 1
+            return orig_tolist(t)
+
+        monkeypatch.setattr(torch.Tensor, "cpu", counting_cpu)
+        monkeypatch.setattr(torch.Tensor, "item", counting_item)
+        monkeypatch.setattr(torch.Tensor, "tolist", counting_tolist)
+
+
+def test_v1_criterion_step_transfers_at_depth2_floor(monkeypatch):
+    """Depth-2 floor: one ``.cpu()`` per matched level (1 main + NUM_AUX aux),
+    zero ``.item()``/``.tolist()``. Before the restructure the same step did
+    7 ``.cpu()`` drains with nothing queued behind them plus 1 ``.item()``."""
+    criterion = RTDETRLoss(num_classes=NUM_CLASSES)
+    criterion.train()
+    generator = torch.Generator().manual_seed(763)
+    outputs = _step_outputs(generator, (4, 7))
+    targets = _targets(generator, (4, 7))
+
+    counter = _TransferCounter(monkeypatch)
+    criterion(outputs, targets)
+
+    assert counter.cpu <= 1 + NUM_AUX
+    assert counter.item == 0
+    assert counter.tolist == 0
+
+
+def test_rtdetrv2_criterion_step_transfers_at_depth2_floor(monkeypatch):
+    """v2 floor: parent levels (1 + NUM_AUX) plus one transfer per
+    ``enc_aux_outputs`` level. Before: 8 ``.cpu()`` + 2 ``.item()``."""
+    criterion = RTDETRv2Loss(num_classes=NUM_CLASSES)
+    criterion.train()
+    generator = torch.Generator().manual_seed(763)
+    outputs = _step_outputs(generator, (4, 7), v2=True)
+    targets = _targets(generator, (4, 7))
+
+    counter = _TransferCounter(monkeypatch)
+    criterion(outputs, targets)
+
+    assert counter.cpu <= 1 + NUM_AUX + len(outputs["enc_aux_outputs"])
+    assert counter.item == 0
+    assert counter.tolist == 0
+
+
+def test_empty_targets_do_no_transfers(monkeypatch):
+    criterion = RTDETRLoss(num_classes=NUM_CLASSES)
+    criterion.train()
+    generator = torch.Generator().manual_seed(763)
+    outputs = _step_outputs(generator, (0, 0))
+    targets = _targets(generator, (0, 0))
+
+    counter = _TransferCounter(monkeypatch)
+    criterion(outputs, targets)
+
+    assert counter.cpu == 0
+    assert counter.item == 0
+
+
+# ---------------------------------------------------------------------------
+# Pipeline shape: depth 2, never more than two cost matrices in flight
+# ---------------------------------------------------------------------------
+
+
+def test_criterion_pipelines_levels_at_depth_two(monkeypatch):
+    """The per-level loop must enqueue level i+1's cost before solving level
+    i, and never run more than one compute ahead of the solves."""
+    criterion = RTDETRLoss(num_classes=NUM_CLASSES)
+    criterion.train()
+    generator = torch.Generator().manual_seed(763)
+    outputs = _step_outputs(generator, (4, 7))
+    targets = _targets(generator, (4, 7))
+
+    events = []
+    matcher = criterion.matcher
+    orig_compute = type(matcher).compute_cost_matrix
+    orig_solve = type(matcher).solve
+
+    def compute(self, *a, **k):
+        events.append("compute")
+        return orig_compute(self, *a, **k)
+
+    def solve(self, *a, **k):
+        events.append("solve")
+        return orig_solve(self, *a, **k)
+
+    monkeypatch.setattr(type(matcher), "compute_cost_matrix", compute)
+    monkeypatch.setattr(type(matcher), "solve", solve)
+
+    criterion(outputs, targets)
+
+    num_levels = 1 + NUM_AUX
+    assert events.count("compute") == num_levels
+    assert events.count("solve") == num_levels
+    in_flight = 0
+    for event in events:
+        in_flight += 1 if event == "compute" else -1
+        assert 0 <= in_flight <= 2

--- a/tests/unit/test_validation_loss.py
+++ b/tests/unit/test_validation_loss.py
@@ -291,7 +291,7 @@ def test_yolo9_rank_local_normalizer_skips_collective(monkeypatch):
         raise AssertionError("rank-local validation entered a collective")
 
     monkeypatch.setattr(
-        yolo9_loss_module, "all_reduce_avg_scalar", _unexpected_collective
+        yolo9_loss_module, "all_reduce_avg_scalar_tensor", _unexpected_collective
     )
     loss = YOLO9Loss(
         num_classes=2,


### PR DESCRIPTION
Part of #763 (items 4 and 5; items 1-3 shipped in #765).

## What

- dfine/deim denoising: `torch.nonzero(positive_gt_mask)` replaced with arange index construction (the mask is fully determined by per-image target counts). RNG call order untouched.
- dfine/deim loss: `_get_go_indices` batched (one `unique` + two `tolist` per step instead of one of each per image), tensor `_normalizer` (no `.item()`), host-side dn guard.
- Matchers (dfine/deim/deimv2/rtdetr): split into `compute_cost_matrix` (device) / `solve` (host LSAP); criteria drain per-level cost matrices through a depth-2 pipeline (at most two matrices alive), same shape as rfdetr #762.
- ec decoder: training anchor grids and the weighting-function project vector are cached (invalidated via parameter `_version`; unfrozen params bypass the cache); ec seg matcher implements the split contract.
- Hard data-dependent syncs on the dfine line: 19 to 3 per step. rtdetr criterion: `.item()` drains to 0, `.cpu()` transfers pipelined at the per-level floor.
- Inheritance covered: ec and domedetr inherit DFINECriterion; rtdetrv4 routes through deim; rtdetrv2 inherits the pipelined forward with zero changes.

## Parity

- 246 new tests across tests/unit/test_{dfine,ec,rtdetr}_sync_reduction.py: pinned-RNG denoising group parity, full-criterion loss parity, matcher assignment parity, sync-count regression bounds. All `torch.equal` against verbatim copies of the base control flow.
- Bitwise on CPU. On CUDA the tensor `_normalizer` division differs by up to ~3e-5 in total_loss (different division kernel); this is the same acknowledged deviation the shipped rfdetr/yolo9 tensor normalizers carry from #765, documented in the test docstrings. Everything else is bitwise on CUDA as well.
- Desktop GPU A/B (5070 Ti, fp32): mechanical claims verified (syncs gone, EC saves ~93 launches/step, VRAM flat, step-1 losses digit-identical); end-to-end step time -1 to -1.7% on ec, sub-noise elsewhere on this fast host. The motivating regime is the slow-host campaign boxes (35% of the ec-s step measured blocked on sync); a campaign-box measurement remains a follow-up.

## Follow-ups (not in this PR)

- dfine/box_ops.py asserts: 28 `Tensor.__bool__` syncs/step, now the largest remaining source.
- domedetr/denoising.py and rtdetr/denoising.py forks still carry the `nonzero`.
- ec/pose_denoising.py and ec/pose_loss.py have small residual syncs.
- Campaign-box GPU measurement and the CUDA-graph re-test (#716 ceiling).

Also fixes in passing: `test_yolo9_rank_local_normalizer_skips_collective` (stale monkeypatch target, also shipped via #771; merges clean).

## Code provenance

All code is original, written for this PR. Upstream D-FINE/DEIM (Apache-2.0) were consulted read-only to confirm they carry the same sync patterns (they do; no vectorized form exists upstream to port). The depth-2 drain mirrors our own rfdetr implementation from #762.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces device-to-host synchronization in the D-FINE, DEIM, EC, and RT-DETR training paths while preserving matcher and loss behavior.
- Reconstructs denoising positive indices without data-dependent `nonzero`.
- Splits Hungarian matching into device-side cost computation and host-side solving, then pipelines output levels with bounded matrix residency.
- Uses device-tensor loss normalizers and batches D-FINE-line go-index processing.
- Caches EC anchor grids and frozen weighting-function projections.
- Adds parity and synchronization-regression coverage for the affected model families.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The reachable matcher implementations preserve their family-specific contracts, the tensor normalizers remain arithmetic-only values, and the EC caches account for the device, dtype, shape, and standard parameter-update transitions used by the repository.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/dfine/loss.py | Batches go-index processing, returns tensor normalizers, and pipelines matcher cost transfers without an identified contract regression. |
| libreyolo/models/deim/loss.py | Applies the D-FINE synchronization reductions while retaining DEIM matcher and denoising-loss contracts. |
| libreyolo/models/deimv2/loss.py | Preserves the epoch-dependent matcher cost computation while adopting the pipelined host solve. |
| libreyolo/models/rtdetr/loss.py | Splits and pipelines matching, retains explicit empty-target handling, and replaces scalar normalization with a device tensor. |
| libreyolo/models/ec/decoder.py | Adds bounded anchor caches and version-aware weighting projection caching, with standard device, dtype, and in-place parameter updates represented in cache invalidation. |
| libreyolo/models/ec/seg_loss.py | Implements the split matcher contract and preserves zero-target behavior for the inherited EC criterion. |
| libreyolo/models/dfine/denoising.py | Reconstructs positive denoising indices from target counts in the same group-major order as the removed mask scan. |
| tests/unit/test_dfine_sync_reduction.py | Adds parity and synchronization-count coverage for D-FINE and related inherited criterion paths. |
| tests/unit/test_ec_sync_reduction.py | Covers EC cache behavior, matcher parity, and synchronization reductions. |
| tests/unit/test_rtdetr_sync_reduction.py | Covers RT-DETR assignment, loss, normalization, and synchronization parity. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Criterion
    participant G as GPU cost computation
    participant H as CPU Hungarian solver
    C->>G: compute cost for level 0
    loop Remaining output levels
        C->>G: enqueue cost for next level
        G-->>C: transfer pending cost matrix
        C->>H: solve pending level
        H-->>C: assignment indices
    end
    G-->>C: transfer final cost matrix
    C->>H: solve final level
    H-->>C: final assignment indices
    C->>C: compute main and auxiliary losses
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;upstream/d..."](https://github.com/libreyolo/libreyolo/commit/8af960616845bad60618db18e518867df62c449d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53386714)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->