### PR TITLE
v1.5.1 fixes: notice surfaces, dead weight URLs, since restamp, ADR renumbering, zh README (#744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,10 +260,10 @@ and **Removed** before upgrading.
   suffix (`-edge`, `-normal`, `-embed`, `-mesh`). New public result types
   `EdgeMap`, `NormalMap`, `Embeddings`, `Identities` and `Meshes`; new
   validators `EdgeValidator` (ODS/OIS) and `NormalValidator` (angular error).
-  Contracts in `docs/adr/`: `0013-embed-task-contract`,
-  `0013-mesh-task-contract`, `0014-normal-task-contract` and
-  `0015-edge-task-contract`. The two 0013s and the two 0015s genuinely collide;
-  the numbering needs a pass.
+  Contracts in `docs/adr/`: `0013-mesh-task-contract`,
+  `0014-normal-task-contract`, `0017-embed-task-contract` and
+  `0018-edge-task-contract`. The embed and edge contracts first shipped as a
+  second 0013 and a second 0015; they were renumbered after the release.
 
 - `embed`: L2-normalized image and region embeddings. Ships `LibreFaceEmbedder`
   (ONNX Runtime only, `libreyolo[onnx]`), a `Gallery` / `FaceGallery` API, and

--- a/NOTICE
+++ b/NOTICE
@@ -128,6 +128,44 @@ ResNet / timm (Apache License 2.0)
     naming mirrors timm/torchvision so weights load unchanged and inference is
     bit-identical.
 
+ViT / timm (Apache License 2.0)
+    Path:    libreyolo/models/vit/
+    License: libreyolo/models/vit/NOTICE  (Apache-2.0)
+    Source:  https://github.com/huggingface/pytorch-image-models
+             commit 8ef73809f622e0031bd7f4940265734aef8b9978 (v1.0.28)
+
+    The native Vision Transformer graph (libreyolo/models/vit/nn.py) is
+    derived from timm's vision_transformer.py and supporting timm/layers
+    modules (Ross Wightman and the timm contributors, Apache-2.0). Only the
+    classic fixed-224 patch-16 classifier graph used by the shipped AugReg
+    ImageNet-1k checkpoints is retained; later extensions (dynamic sizes,
+    register tokens, layer scale, patch dropout) are omitted. The
+    architecture and AugReg checkpoint lineage originate from
+    google-research/vision_transformer at commit
+    64801f1b3b367b3611cc27a3d45cc22870a36fb3 (Apache-2.0). Module and
+    parameter names remain aligned with timm so all learned tensors load
+    unchanged and inference parity can be tested.
+
+EfficientDet (Apache License 2.0)
+    Path:    libreyolo/models/efficientdet/
+    License: libreyolo/models/efficientdet/NOTICE  (Apache-2.0)
+    Source:  https://github.com/rwightman/efficientdet-pytorch
+             commit c6dff775a36cea0bf9b76c58e59f936411c5ce01 (effdet 0.4.1)
+
+    The EfficientDet D0-D4 architecture, TensorFlow-compatible EfficientNet
+    backbones, BiFPN topology, prediction heads, anchor generation,
+    checkpoint configuration, and evaluation transform are derived from
+    rwightman/efficientdet-pytorch (Apache-2.0, Copyright 2020 Ross
+    Wightman). The native EfficientNet block structure and timm-compatible
+    parameter names follow timm v1.0.28 at commit
+    8ef73809f622e0031bd7f4940265734aef8b9978, and the BiFPN and anchor
+    lineage traces to Google Research's original TensorFlow implementation
+    (google/automl, Apache-2.0). Official D0-D4 COCO checkpoints are
+    unmodified tensors from the upstream v0.1 release, rehosted on an
+    explicitly disclosed implied Apache-2.0 basis. No source from the
+    LGPL-licensed zylo117/Yet-Another-EfficientDet-Pytorch project was
+    consulted or used.
+
 Swin Transformer V1 / timm (Apache-2.0 code + MIT weights)
     Path:    libreyolo/models/swin/
     License: libreyolo/models/swin/NOTICE
@@ -193,6 +231,7 @@ LingBot-Vision (Apache License 2.0)
     Path:    libreyolo/models/lingbotvision/
     License: libreyolo/models/lingbotvision/NOTICE
     Source:  https://github.com/robbyant/lingbot-vision
+    Commit:  151e46321bae4399f8568829f190c7bdec216b49
 
     The LingBot-Vision ViT backbone (libreyolo/models/lingbotvision/nn.py)
     is a native PyTorch port of Robbyant's Apache-2.0 lingbot-vision
@@ -247,6 +286,23 @@ Real-ESRGAN / BasicSR (BSD-3-Clause / Apache-2.0)
     realesr-general-x4v3) are distributed under the BSD-3-Clause License;
     LibreYOLO mirrors converted checkpoints with this provenance stated in the
     model cards.
+
+FeyNobg (Apache License 2.0)
+    Path:    libreyolo/models/feynobg/
+    License: libreyolo/models/feynobg/NOTICE
+    Source:  https://huggingface.co/feyninc/FeyNobg
+             (reference library: https://github.com/feyninc/nobg)
+             Copyright (c) 2026 Feyn Inc.
+
+    FeyNobg (Apache-2.0, code and weights) is architecturally BiRefNet (MIT)
+    with the third Swin-L stage deepened from 18 to 24 blocks. The family
+    instantiates LibreYOLO's BiRefNet nn module with a family-local dimension
+    table (libreyolo/models/feynobg/nn.py); no code was copied from the nobg
+    library, and the port is parity-gated against the nobg reference at fp32
+    (weights/parity_feynobg.py, max_abs_diff == 0). The released Apache-2.0
+    weights are converted and rehosted at LibreYOLO/LibreFeyNobgl-matte,
+    including post-training-quantized fp16/fp8 variants; upstream training
+    data is not disclosed, and only the released weights are redistributed.
 
 PaddleOCR / PP-OCRv5 (Apache-2.0)
     Path:    libreyolo/models/ppocr/, libreyolo/postprocess/ppocr.py
@@ -356,6 +412,25 @@ Faster R-CNN / TorchVision (BSD-3-Clause)
     not an explicit checkpoint-specific grant, and repeat torchvision's
     pretrained-model terms caveat.
 
+RetinaNet / TorchVision (BSD-3-Clause)
+    Path:    libreyolo/models/retinanet/
+    License: libreyolo/models/retinanet/NOTICE
+    Source:  https://github.com/pytorch/vision
+             commit 336d36e8db990a905498c73933e35231876e28bc
+
+    The native LibreRetinaNet inference graph is derived from torchvision
+    v0.26.0's RetinaNet, classification and regression heads, anchor
+    generator, box coder, transform, and FPN-backbone builders (BSD-3-Clause,
+    Copyright (c) Soumith Chintala 2016). Upstream state-dict names are
+    retained for strict conversion. The port adds LibreYOLO factory,
+    checkpoint metadata, validation, class mapping, and export/backend
+    integration; training-only matching and focal-loss code is excluded.
+    Official COCO checkpoints are not bundled in the source distribution.
+    Separate weight mirrors disclose that their BSD-3-Clause redistribution
+    basis is implied by the releasing project, not an explicit
+    checkpoint-specific grant, and repeat torchvision's pretrained-model
+    terms caveat.
+
 SSD300 / TorchVision (BSD-3-Clause; VGG weight lineage CC BY 4.0)
     Path:    libreyolo/models/ssd/, libreyolo/postprocess/ssd.py,
              weights/convert_ssd_weights.py
@@ -420,6 +495,25 @@ AlexNet / TorchVision (BSD-3-Clause)
     separate weight mirror discloses that BSD-3-Clause is an implied
     redistribution basis rather than a checkpoint-specific publisher grant,
     and repeats torchvision's pretrained-model terms caveat.
+
+VGG / TorchVision (BSD-3-Clause)
+    Path:    libreyolo/models/vgg/
+    License: libreyolo/models/vgg/NOTICE
+    Source:  https://github.com/pytorch/vision
+             commit 10f68dbd78b9aa5cab9328f3b2e99cfb0b608122
+
+    The native LibreVGG graph is derived from torchvision's VGG
+    implementation (torchvision/models/vgg.py, BSD-3-Clause, Copyright (c)
+    Soumith Chintala 2016). The upstream feature and classifier module layout
+    is retained so the official VGG-16, VGG-19, VGG-16-BN, and VGG-19-BN
+    state dicts load unchanged. The port adds LibreYOLO factory, checkpoint
+    metadata, preprocessing, result payload, and export/backend integration;
+    training is excluded. The four official ImageNet-1k V1 checkpoints are
+    not bundled in the source distribution. Separate weight mirrors disclose
+    that BSD-3-Clause is an implied redistribution basis rather than a
+    checkpoint-specific publisher grant, and repeat torchvision's
+    pretrained-model terms caveat.
+
 DeepLabv3 / TorchVision (BSD-3-Clause)
     Path:    libreyolo/models/deeplabv3/,
              libreyolo/postprocess/deeplabv3.py,
@@ -435,6 +529,24 @@ DeepLabv3 / TorchVision (BSD-3-Clause)
     port adds LibreYOLO metadata, semantic results, validation, and fixed-520
     export/backend integration; it excludes the training-only auxiliary FCN
     classifier and training recipe. Official COCO checkpoints are not bundled
+    in the source distribution. Separate weight mirrors disclose that their
+    BSD-3-Clause redistribution basis is implied by the releasing project,
+    not an explicit checkpoint-specific grant, and repeat torchvision's
+    pretrained-model terms caveat.
+
+FCN / TorchVision (BSD-3-Clause)
+    Path:    libreyolo/models/fcn/
+    License: libreyolo/models/fcn/NOTICE
+    Source:  https://github.com/pytorch/vision
+             commit 336d36e8db990a905498c73933e35231876e28bc
+
+    The native LibreFCN inference graph is derived from torchvision v0.26.0's
+    FCN model, head, dilated-ResNet builder configuration, and feature-layer
+    routing (BSD-3-Clause, Copyright (c) Soumith Chintala 2016 and the
+    torchvision contributors). Upstream state-dict names are retained for
+    strict conversion. The port adds LibreYOLO factory, checkpoint metadata,
+    semantic result conversion, validation, and export/backend integration;
+    training losses are excluded. Official COCO checkpoints are not bundled
     in the source distribution. Separate weight mirrors disclose that their
     BSD-3-Clause redistribution basis is implied by the releasing project,
     not an explicit checkpoint-specific grant, and repeat torchvision's
@@ -456,8 +568,9 @@ LW-DETR (Apache License 2.0)
     against the official implementation for all five released sizes. Upstream's
     own Conditional DETR / DETR / Deformable DETR / ViTDet lineage headers are
     preserved in the ported modules and cited separately in
-    THIRD_PARTY_NOTICES.txt. Ported inference only — the Group-DETR training
-    recipe is not included. See docs/provenance/lwdetr.md.
+    THIRD_PARTY_NOTICES.txt. Ported inference only: the Group-DETR training
+    recipe is not included. Family-level details live in
+    libreyolo/models/lwdetr/NOTICE; see docs/provenance/lwdetr.md.
 
 Deformable DETR (Apache License 2.0)
     Path:    libreyolo/models/deformable_detr/,
@@ -475,6 +588,28 @@ Deformable DETR (Apache License 2.0)
     Apache-2.0 SenseTime COCO weights are converted and rehosted for all five
     released variants. Source-file lineage headers are preserved; see
     docs/provenance/deformable_detr.md.
+
+DINO-DETR (Apache License 2.0)
+    Path:    libreyolo/models/dinodetr/,
+             libreyolo/postprocess/dinodetr.py,
+             weights/convert_dinodetr_weights.py
+    License: libreyolo/models/dinodetr/NOTICE
+    Source:  https://github.com/IDEA-Research/DINO
+             commit d84a491d41898b3befd8294d1cf2614661fc0953
+             Copyright (c) 2022 IDEA. All Rights Reserved.
+
+    LibreDINO-DETR ports only the three released inference architectures
+    (ResNet-50 4-scale, ResNet-50 5-scale, Swin-L). The pinned DINO
+    implementation carries Conditional DETR, DETR, and Deformable DETR
+    lineage notices, reproduced in the family NOTICE, and the Swin-L backbone
+    is ported through DINO's modified Swin Transformer implementation (MIT,
+    Copyright (c) 2021 Microsoft). Training-only denoising, matching,
+    criteria, losses, data pipelines, and the compiled CUDA multi-scale
+    deformable-attention extension are not included; the ResNet tensor
+    container and pure-PyTorch deformable-attention core reuse LibreYOLO's
+    existing Deformable DETR port. Official checkpoints are rehosted on an
+    explicitly disclosed implied Apache-2.0 basis; see
+    docs/provenance/dinodetr.md.
 
 Dome-DETR (Apache License 2.0)
     Path:    libreyolo/models/domedetr/,

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Surface normals** | MoGe-2 |
 | **Edges** | DexiNed, TEED |
 | **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, Perception Encoder (image, text, whole-video; also zero-shot classify), DINOv2 |
-| **Embeddings** | LibreFaceEmbedder, CLIP, SigLIP2, DINOv2 |
 | **Video embeddings** | V-JEPA 2 (clip-level embedding, plus video classification with a trainable attentive probe) |
 | **Body mesh** | SAM 3D Body |
 | **Restoration** | NAFNet, Real-ESRGAN, SwinIR |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,31 +11,21 @@
 [![PyPI Downloads](https://static.pepy.tech/badge/libreyolo)](https://pepy.tech/projects/libreyolo)
 [![Hugging Face](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-LibreYOLO-yellow)](https://huggingface.co/LibreYOLO)
 [![Benchmarks](https://img.shields.io/badge/benchmarks-visionanalysis.org-purple)](https://www.visionanalysis.org/)
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-LibreYOLO-blue?logo=linkedin)](https://www.linkedin.com/company/libreyolo/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-LibreYOLO 是一个采用 MIT 许可证的计算机视觉库，支持多种模型的推理和训练。它提供熟悉的高层 Python 和命令行接口，并可读取常见的 YOLO 格式数据集，因此现有工作流只需少量改动即可迁移。
+**一个采用 MIT 许可证的计算机视觉库。** 检测、分割、姿态、深度、OCR
+等十几种任务共用一套精简 API，训练和导出内置提供，而非单独收费。
+支持读取常见的 YOLO 格式数据集，因此现有工作流只需少量改动即可迁移。
 
 ![LibreYOLO 检测示例](libreyolo/assets/parkour_result.jpg)
 
-## 安装与快速开始
+## 安装
 
 ```bash
 pip install libreyolo
 ```
-
-如需从源码以可编辑模式安装（用于开发或跟踪尚未发布的改动）：
-
-```bash
-git clone https://github.com/LibreYOLO/libreyolo.git
-cd libreyolo
-pip install -e .
-```
-
-普通克隆会检出 `release` 分支，即代码与本文档一致的稳定分支。如需获取尚未发布的
-最新开发内容，请使用 `git checkout dev` 切换到集成分支。
-
-ONNX Runtime、OpenVINO、TensorRT、NCNN 和 RF-DETR 等可选运行时与导出依赖，请见[完整文档](https://www.libreyolo.com/docs)。
 
 ```python
 from libreyolo import LibreYOLO, SAMPLE_IMAGE
@@ -44,72 +34,136 @@ model = LibreYOLO("LibreYOLO9t.pt")
 result = model(SAMPLE_IMAGE, save=True)
 ```
 
-## 旗舰模型
+<details>
+<summary><b>可选扩展依赖</b></summary>
 
-LibreYOLO 推荐以下模型系列，因为它们在性能上达到最佳平衡，并且接受最充分的测试：
+<br>
 
-- **YOLOv9**：基于 CNN 的 YOLO 模型。
-- **RF-DETR**：基于 Transformer 的检测与分割模型。
+基础安装已覆盖 YOLOv9 与其他核心检测器、训练和推理。当你需要更重的模型系列
+或某个导出后端时，再安装对应的扩展依赖即可。多个扩展用逗号组合，例如
+`pip install "libreyolo[rfdetr,onnx]"`。
 
-## 兼容性
+| 分组 | 扩展依赖 |
+| --- | --- |
+| 导出 | `onnx`、`tensorrt`、`openvino`、`coreml`、`coreai`、`tflite`（别名 `litert`）、`ncnn`、`mnn`、`paddle`、`executorch` |
+| 服务 | `triton` |
+| 模型 | `rfdetr`、`vlm`、`sam`、`openvocab`、`clip`、`siglip2`、`eomt`、`midas`、`modus`、`sensenova`、`gaze` |
+| 训练 | `lora`、`plots`、`tensorboard`、`mlflow`、`wandb`、`comet`、`clearml`、`neptune`、`dvclive` |
+| 提速 | `fast-eval`、`hub-kernels` |
+| 输入源 | `stream` |
+| 全部 | `pip install "libreyolo[all]"` |
 
-`✓` 表示支持。空单元格表示当前不支持。
+`executorch`、`coreai` 和 `neptune` 被有意排除在 `all` 之外：它们对 torch 或
+protobuf 的版本锁定会拖累环境中的其他依赖。完整列表和各后端说明见
+[安装指南](https://www.libreyolo.com/docs/install)。
 
-<table>
-  <thead>
-    <tr>
-      <th rowspan="2">模型系列</th>
-      <th colspan="7">推理</th>
-      <th rowspan="2">训练</th>
-      <th colspan="6">导出格式</th>
-    </tr>
-    <tr>
-      <th>检测</th>
-      <th>分割</th>
-      <th>语义分割</th>
-      <th>分类</th>
-      <th>姿态</th>
-      <th>OBB</th>
-      <th>视线</th>
-      <th>ONNX</th>
-      <th>TorchScript</th>
-      <th>TensorRT</th>
-      <th>OpenVINO</th>
-      <th>NCNN</th>
-      <th>TFLite (LiteRT)</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr><td><strong>⭐ YOLOv9</strong></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td><strong>⭐ RF-DETR</strong></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td>✓</td></tr>
-    <tr><td>YOLOX</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td>YOLOv9-E2E</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td><td></td></tr>
-    <tr><td>YOLOv9-P2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>YOLO-NAS</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td>CenterNet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>HRNet</td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>D-FINE</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>DEIM</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>DEIMv2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>RT-DETR</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>RT-DETRv2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>RT-DETRv4</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>RetinaNet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>DINO-DETR</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>PicoDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>RTMDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>Mask R-CNN</td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>EC</td><td>✓</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>ViT</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>SSD300</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>L2CS</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>VGG</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>Swin</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>DeepLabv3（语义）</td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-  </tbody>
-</table>
+</details>
+
+<details>
+<summary><b>从源码安装</b></summary>
+
+<br>
+
+```bash
+git clone https://github.com/LibreYOLO/libreyolo.git
+cd libreyolo
+pip install -e .
+```
+
+普通克隆会检出 `release` 分支，即与已发布包一致的稳定分支。如需获取尚未发布的
+内容，请使用 `git checkout dev`。
+
+</details>
+
+## 一套 API，十七种任务
+
+每种任务都是同样的三行代码，只有权重文件不同。
+
+```python
+from libreyolo import LibreYOLO
+
+LibreYOLO("LibreYOLO9t.pt")("street.jpg", save=True)             # 检测
+LibreYOLO("LibreDeepLabv3mv3-sem.pt")("street.jpg", save=True)   # 语义分割
+LibreYOLO("LibreHRNetw32-pose.pt")("street.jpg", save=True)      # 姿态
+LibreYOLO("LibreMiDaSs-depth.pt")("street.jpg", save=True)       # 深度
+LibreYOLO("LibreFeyNobgl-matte.pt")("portrait.jpg", save=True)   # 背景移除
+LibreYOLO("LibreRTDETRv2n-obb.pt")("aerial.jpg", save=True)      # 旋转框
+```
+
+输入源不只是文件。它还可以是摄像头、RTSP 流、视频、目录、YouTube 链接或你的屏幕：
+
+```bash
+libreyolo predict --model yolo9-t --source 0 --show          # 摄像头
+libreyolo predict --model yolo9-t --source rtsp://camera/1   # 网络摄像头
+libreyolo predict --model yolo9-t --source screen            # 屏幕捕获
+```
+
+## 内置内容
+
+| 任务 | 模型 |
+| --- | --- |
+| **检测** | YOLOv9、RF-DETR、YOLOX、YOLO-NAS、D-FINE、DEIM、RT-DETR v1/v2/v4、RTMDet、PicoDet、PP-YOLOE、YOLOv7、EfficientDet，以及经典模型：DETR、Deformable DETR、DINO-DETR、LW-DETR、Faster R-CNN、RetinaNet、SSD、FCOS、CenterNet |
+| **微小目标** | TinyFormer、Dome-DETR（航拍、无人机、遥感） |
+| **实例分割** | RF-DETR、RTMDet、D-FINE、Mask R-CNN |
+| **可提示分割** | SAM、SAM 2、SAM 3、MobileSAM、EdgeTAM、PicoSAM3 |
+| **语义分割** | SegFormer、PIDNet、PP-LiteSeg、DeepLabv3、FCN、LingBot-Vision、DINOv2、EoMT |
+| **全景分割** | EoMT |
+| **姿态** | RF-DETR、YOLO-NAS、HRNet、DEKR、EC |
+| **旋转框（OBB）** | RF-DETR、RT-DETRv2、YOLO-NAS-R |
+| **分类** | MobileNetV4、ConvNeXt、EfficientNetV2、ResNet、ViT、Swin、DeiT、VGG、AlexNet、CLIP、SigLIP2、DINOv2 |
+| **深度估计** | Depth Anything 3、Depth Anything V2、ZipDepth、MiDaS |
+| **表面法线** | MoGe-2 |
+| **边缘检测** | DexiNed、TEED |
+| **嵌入** | LibreFaceEmbedder、CLIP、SigLIP2、Perception Encoder（图像、文本、整段视频；亦支持零样本分类）、DINOv2 |
+| **视频嵌入** | V-JEPA 2（片段级嵌入，另有可训练注意力探针的视频分类） |
+| **人体网格** | SAM 3D Body |
+| **图像复原** | NAFNet、Real-ESRGAN、SwinIR |
+| **背景移除** | BiRefNet、FeyNobg |
+| **OCR** | PP-OCR |
+| **点检测** | FOMO、LocateAnything |
+| **视线估计** | L2CS |
+| **开放词汇与 VLM** | Grounding DINO、OWLv2、OmDet-Turbo、OV-DEIM、Florence-2、Kosmos-2、Qwen3-VL、InternVL3、LFM2-VL、North Micro Vision、SmolVLM2、MODUS |
+
+各模型系列的尺寸、权重与一致性验证证据见[模型参考](https://www.libreyolo.com/docs/models)。
+
+## 训练
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("LibreYOLO9t.pt")
+model.train(data="dataset.yaml", epochs=100, imgsz=640)
+```
+
+```bash
+libreyolo train --model yolo9-t --data dataset.yaml --epochs 100
+```
+
+多 GPU、LoRA、层冻结、蒸馏、从零训练，以及 TensorBoard、MLflow、
+Weights & Biases、Comet、ClearML、Neptune 和 DVCLive 日志记录均受支持。
+详见[训练指南](https://www.libreyolo.com/docs/train)。
+
+## 导出与部署
+
+十二种格式：ONNX、TorchScript、TensorRT、OpenVINO、CoreML、Core AI、
+TFLite（LiteRT）、NCNN、MNN、RKNN、Paddle 和 ExecuTorch。另支持 NVIDIA
+Triton 服务和 DeepStream 配置生成。
+
+```bash
+libreyolo export --model yolo9-t --format onnx
+```
+
+支持范围因模型系列和任务而异，见[导出矩阵](https://www.libreyolo.com/docs/reference/export-matrix)。
+
+## 文档
+
+- [文档](https://www.libreyolo.com/docs)涵盖安装、任务、模型、训练、推理、导出和 CLI
+- [基准测试](https://www.visionanalysis.org/)提供独立的第三方数据
+- [CHANGELOG.md](CHANGELOG.md) 记录版本变更
 
 ## 许可证
 
-- **代码：** MIT License
-- **权重：** 预训练权重可能继承原始来源的许可证。请检查你感兴趣的具体 HF 权重仓库中的许可证。LibreYOLO HF 模型始终包含许可证。
+- **代码：** MIT License。
+- **权重：** 预训练权重可能继承原始来源的许可证，且并非全部为宽松许可。
+  商用前请先查看具体 Hugging Face 仓库上的许可证。每个 LibreYOLO
+  Hugging Face 模型都会标明其许可证。

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -588,6 +588,28 @@ learned parameters are NVIDIA's, unchanged. Models the user trains from
 scratch carry no such restriction.
 
 --------------------------------------------------------------------
+LingBot-Vision (Robbyant / Ant Group)
+--------------------------------------------------------------------
+Source: https://github.com/robbyant/lingbot-vision
+Commit: 151e46321bae4399f8568829f190c7bdec216b49
+License: Apache License 2.0
+Copyright (c) 2026 Robbyant.
+Used for: the LibreLingBotVision semantic family
+          (libreyolo/models/lingbotvision/). The ViT backbone in nn.py is a
+          native port of the upstream DINOv3-style Vision Transformer (axial
+          RoPE over the patch grid, [CLS] plus 4 register tokens, LayerScale,
+          masked-K-bias fused QKV); module and parameter names mirror the
+          reference implementation so the Apache-2.0 backbone checkpoints
+          load unchanged. Only the inference forward path is ported; the
+          upstream self-supervised pretraining machinery is not. The dense
+          head and training recipe are LibreYOLO's own (the upstream report's
+          linear-probing protocol). Hosted LibreLingBotVision{s,b,l}-sem
+          checkpoints combine the unchanged Apache-2.0 Robbyant backbones
+          with an ADE20K head trained by LibreYOLO. Reference: "Vision
+          Pretraining for Dense Spatial Perception", Fu et al., 2026,
+          arXiv:2607.05247. See libreyolo/models/lingbotvision/NOTICE.
+
+--------------------------------------------------------------------
 Grounding DINO (IDEA-Research)
 --------------------------------------------------------------------
 Source: https://github.com/IDEA-Research/GroundingDINO

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -593,7 +593,7 @@ LingBot-Vision (Robbyant / Ant Group)
 Source: https://github.com/robbyant/lingbot-vision
 Commit: 151e46321bae4399f8568829f190c7bdec216b49
 License: Apache License 2.0
-Copyright (c) 2026 Robbyant.
+Copyright 2026 LingBot-Vision Contributors.
 Used for: the LibreLingBotVision semantic family
           (libreyolo/models/lingbotvision/). The ViT backbone in nn.py is a
           native port of the upstream DINOv3-style Vision Transformer (axial
@@ -1302,7 +1302,7 @@ Used for: the FeyNobg background-removal model family
           from 18 to 24 blocks; the family reuses the LibreYOLO BiRefNet
           port's nn module with a family-local dimension table and
           converts the released Apache-2.0 weights (state-dict
-          metadata-wrap plus post-training-quantized fp8/nvfp4
+          metadata-wrap plus post-training-quantized fp16/fp8
           variants). No code was copied from the nobg library. Upstream
           training data is not disclosed; LibreYOLO redistributes only
           the released weights.

--- a/docs/adr/0015-embed-generalization.md
+++ b/docs/adr/0015-embed-generalization.md
@@ -2,12 +2,13 @@
 
 ## Status
 
-Accepted. This ADR amends ADR 0013; it does not replace the face-recognition
-region contract defined there.
+Accepted. This ADR amends ADR 0017 (the embed task contract, numbered 0013
+until a post-1.5.0 renumbering resolved a collision); it does not replace the
+face-recognition region contract defined there.
 
 ## Context
 
-ADR 0013 chose the generic canonical task name `embed`, but its first
+ADR 0017 chose the generic canonical task name `embed`, but its first
 implementation produced only face-region identity vectors. The same primitive
 also serves whole-image similarity and image/text retrieval: a float32,
 L2-normalized row whose dot product with another row measures agreement.

--- a/docs/adr/0017-embed-task-contract.md
+++ b/docs/adr/0017-embed-task-contract.md
@@ -1,4 +1,4 @@
-# ADR 0013: Embed (Facial Recognition) Task Contract
+# ADR 0017: Embed (Facial Recognition) Task Contract
 
 ## Status
 

--- a/docs/adr/0018-edge-task-contract.md
+++ b/docs/adr/0018-edge-task-contract.md
@@ -1,4 +1,4 @@
-# ADR 0015: Edge task and specialist contract
+# ADR 0018: Edge task and specialist contract
 
 Status: accepted
 Date: 2026-07-29

--- a/docs/cuda_graphs.md
+++ b/docs/cuda_graphs.md
@@ -57,10 +57,13 @@ Probe with contrasting distributions rather than two uniform draws, which wash
 out through global pooling and can leave a head emitting byte-identical output
 for both. Add the family to
 `tests/e2e/test_cuda_graph_families.py` and set `SUPPORTS_CUDA_GRAPH = True`.
-That file lives under `tests/e2e/` because it carries the `general_nightly`
-marker, and the nightly target collects with `find tests/e2e -name 'test_*.py'`.
-A `general_nightly` test placed under `tests/unit/` is collected by no CI tier
-at all: the PR gate filters on `-m unit`, and the nightly never looks there.
+That file sets `pytestmark = pytest.mark.cuda_graph` and lives under
+`tests/e2e/` because several of its families pull a pretrained backbone when
+constructed, which breaks the unit tier's no-external-weights contract. The
+matrix is opt-in: run it with `-m cuda_graph`. The nightly core excludes that
+marker from its cost budget and the PR gate filters on `-m unit` inside
+`tests/unit/`, so a file marked this way is collected by no CI tier unless
+someone asks for it.
 
 Traps that have each produced a wrong answer in practice:
 
@@ -86,7 +89,11 @@ Traps that have each produced a wrong answer in practice:
 | Family | Reason |
 | --- | --- |
 | `l2cs` (gaze) | Out of scope. |
-| `sensenova` | Outside this mechanism on two independent counts, neither of them hardware. Its `_forward` takes a structured inputs object rather than a tensor, and inference is autoregressive generation over a growing KV cache, so sequence length changes every decode step. Its vision tower is no better: `bagel.py:264` feeds packed variable-length tokens with `cu_seqlens`, and the line above it calls `torch.max(...).item()`, which syncs. A stock fixed-shape `SiglipVisionModel` does capture bit-identically, but that is not the path this model takes. Supporting it means a static-shape design with graphs bucketed by length, which is a separate feature. It is also not constructible here: no random-init path and a ~15 GB checkpoint. |
+
+`sensenova` used to sit in this table, but its vision tower has since been
+made capturable and `models/sensenova/model.py` now sets
+`SUPPORTS_CUDA_GRAPH = True` for that tower, with generation staying eager;
+the family-specific path is described in its own section below.
 
 The SAM family is supported through a family-specific path too. Its entry
 point is `set_image()` / `predict(points=)`, and the image encoder is both the

--- a/docs/facial_recognition.md
+++ b/docs/facial_recognition.md
@@ -105,7 +105,7 @@ with `face_boxes=[...]`.
   this is an inference product consuming opaque ONNX graphs.
 
 The face-region contract is recorded in
-[`adr/0013-embed-task-contract.md`](adr/0013-embed-task-contract.md) and amended
+[`adr/0017-embed-task-contract.md`](adr/0017-embed-task-contract.md) and amended
 by the general three-shape contract in
 [`adr/0015-embed-generalization.md`](adr/0015-embed-generalization.md).
 

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -409,7 +409,7 @@ finite video under `task="embed"` and returns one row for the whole clip rather
 than one per frame. DINOv2 likewise loads
 an existing family checkpoint and bypasses its task head. Task aliases
 `facial-recognition`, `face-recognition`, `recognition`, `face`, `faceid`,
-`embedding`, and `reid` resolve to `embed` at the API boundary. See ADR 0013
+`embedding`, and `reid` resolve to `embed` at the API boundary. See ADR 0017
 for the face-region contract and ADR 0015 for the general contract.
 `mesh` is the task for human body mesh recovery: recovering a posed 3D body per
 detected person. Models expose `Results.meshes`, row-aligned with

--- a/libreyolo/cli/__init__.py
+++ b/libreyolo/cli/__init__.py
@@ -9,7 +9,7 @@ import typer
 
 app = typer.Typer(
     name="libreyolo",
-    help="LibreYOLO — open source YOLO detection toolkit.",
+    help="LibreYOLO: open source YOLO detection toolkit.",
     add_completion=False,
     no_args_is_help=True,
 )
@@ -34,7 +34,7 @@ def _root(
         help="Show LibreYOLO version and exit.",
     ),
 ) -> None:
-    """LibreYOLO — open source YOLO detection toolkit."""
+    """LibreYOLO: open source YOLO detection toolkit."""
 
 
 def _configure_warning_filters() -> None:
@@ -101,7 +101,7 @@ def entrypoint() -> None:
     # handed to ``app()`` stay in their raw key=value form so each command's
     # ``KeyValueCommand`` does the per-command rewrite (it knows whether a flag
     # has a real ``--no-<flag>`` form). Emitting ``--no-verbose`` here would break
-    # commands whose ``--verbose`` is one-way (e.g. predict) — see issue #490 #41.
+    # commands whose ``--verbose`` is one-way (e.g. predict), see issue #490 #41.
     logging_argv = _normalize_logging_flags(argv)
     _setup_logging_from_argv(logging_argv)
 

--- a/libreyolo/cli/commands/profile.py
+++ b/libreyolo/cli/commands/profile.py
@@ -12,7 +12,7 @@ Built for agents. Every subcommand prints results to stdout and supports
 
 ``run`` and ``infer`` emit the same self-contained ``profile.json`` (schema
 ``libreyolo.profile.analysis/v1``), so every lens below works on either. The
-profiler only measures — read the verdict, change the training/config/code
+profiler only measures: read the verdict, change the training/config/code
 yourself, re-run, ``compare``, repeat until images/sec is maxed (or latency is
 minimised).
 """
@@ -286,7 +286,7 @@ def infer_cmd(
         st = a.get("stages_ms") or {}
         print(f"stages   preprocess {st.get('preprocess')} ms | forward {st.get('forward')} ms | "
               f"postprocess/NMS {st.get('postprocess')} ms")
-        print(f">> {str(a.get('bound')).upper()} — {a.get('bound_why')}")
+        print(f">> {str(a.get('bound')).upper()}: {a.get('bound_why')}")
         print(f"profile: {pj}")
         print(f"next:    libreyolo profile summary {pj}")
 
@@ -322,8 +322,8 @@ def summary_cmd(
     print(f"host overhead {a['host_overhead_ms_per_step']} ms/step  |  "
           f"{a['launches_per_step']} kernel launches/step")
     if a.get("memory_pressure"):
-        print("** MEMORY-PRESSURE: VRAM thrash — utilisation/throughput here are unreliable **")
-    print(f">> {str(a['bound']).upper()} — {a['bound_why']}")
+        print("** MEMORY-PRESSURE: VRAM thrash, utilisation/throughput here are unreliable **")
+    print(f">> {str(a['bound']).upper()}: {a['bound_why']}")
     print("kernel mix:")
     for c in a["categories"]:
         print(f"  {c['name']:<17} {c['pct']:5.1f}%   {c['ms_per_step']:.1f} ms/step")
@@ -339,7 +339,7 @@ def get_cmd(
     field: Optional[str] = typer.Argument(None, help="Metric name (omit to list metrics)"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
-    """Print ONE metric — minimal output for tight loops (img_per_s, forward_ms, gpu_util...)."""
+    """Print ONE metric, minimal output for tight loops (img_per_s, forward_ms, gpu_util...)."""
     a = _load(trace)
     m = a["metrics"]
     if not field:
@@ -380,7 +380,7 @@ def kernels_cmd(
     phase: Optional[str] = typer.Option(None, "--phase", help="Restrict to a phase (forward/backward/dataload/to_device/optimizer)"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
-    """Drill to individual GPU kernels — the bottom of the analysis."""
+    """Drill to individual GPU kernels, the bottom of the analysis."""
     a = _load(trace)
     if phase:
         ks = a["kernels_by_phase"].get(phase)
@@ -439,7 +439,7 @@ def compare_cmd(
     after: str = typer.Argument(..., help="new profile_trace.json"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
-    """Diff two profiles — did the change help? (the optimise-loop closer)."""
+    """Diff two profiles: did the change help? (the optimise-loop closer)."""
     a, b = _load(before), _load(after)
 
     def per_img(x):
@@ -454,7 +454,7 @@ def compare_cmd(
         sa, sb = x.get("img_per_s_std"), y.get("img_per_s_std")
         na, nb = x.get("img_per_s_n", 1), y.get("img_per_s_n", 1)
         if na < 2 or nb < 2 or sa is None or sb is None:
-            return None, "single run — use 'run --repeat N' for a significance call"
+            return None, "single run, use 'run --repeat N' for a significance call"
         se = math.sqrt(sa ** 2 / na + sb ** 2 / nb)
         return (abs(mb - ma) > 2 * se), f"|d|={abs(mb - ma):.1f} vs 2*SE={2 * se:.1f}"
 
@@ -545,4 +545,4 @@ def whatif_cmd(
     print(f"  step   {step} -> ~{new_step:.0f} ms")
     if new_imgs and cur_imgs:
         print(f"  img/s  {cur_imgs} -> ~{new_imgs:.0f}{_pct(cur_imgs, new_imgs)}")
-    print("  (rough — verify by actually profiling the change)")
+    print("  (rough, verify by actually profiling the change)")

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -690,7 +690,7 @@ def train_cmd(
             import yaml
 
             data_out["_human_text"] = (
-                f"Dry run — resolved config for {model}:\n"
+                f"Dry run: resolved config for {model}:\n"
                 + yaml.dump(data_out["resolved_config"], default_flow_style=False)
             )
         out.result(data_out)

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -1,7 +1,7 @@
 """Family-specific config discovery and model name resolution for the CLI.
 
 Config defaults come from the dataclass source of truth (TrainConfig subclasses).
-The CLI discovers them via BaseModel._registry → TRAIN_CONFIG, so adding a new
+The CLI discovers them via BaseModel._registry -> TRAIN_CONFIG, so adding a new
 model family requires zero CLI changes.
 """
 
@@ -99,7 +99,7 @@ def _register_cli_names_for_class(cls) -> None:
 
 
 def _build_name_map() -> None:
-    """Populate CLI name → weight filename mapping from model registry."""
+    """Populate CLI name -> weight filename mapping from model registry."""
     if _CLI_NAME_TO_WEIGHTS:
         return
     from libreyolo.models import try_ensure_rfdetr
@@ -141,8 +141,8 @@ def is_known_weight_filename(model: str) -> bool:
 def resolve_model_name(model: str) -> str:
     """Resolve a CLI model name to a weight filename or passthrough.
 
-    ``yolox-s`` → ``LibreYOLOXs.pt``
-    ``best.pt`` → ``best.pt`` (unchanged)
+    ``yolox-s`` -> ``LibreYOLOXs.pt``
+    ``best.pt`` -> ``best.pt`` (unchanged)
     """
     _build_name_map()
     return _CLI_NAME_TO_WEIGHTS.get(model.lower(), model)
@@ -348,7 +348,7 @@ def apply_family_defaults(
     if not family_diffs:
         return params
 
-    # Reverse alias map: internal name → CLI name (for user_provided check)
+    # Reverse alias map: internal name -> CLI name (for user_provided check)
     from .aliases import TRAIN_ALIASES
 
     internal_to_cli = {v: k for k, v in TRAIN_ALIASES.items()}

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -338,7 +338,7 @@ def apply_family_defaults(
 ) -> dict[str, Any]:
     """Apply family-specific defaults to parameters that weren't explicitly set.
 
-    Discovers defaults from the model's TRAIN_CONFIG dataclass — no hardcoded
+    Discovers defaults from the model's TRAIN_CONFIG dataclass, no hardcoded
     dicts. Only overrides values that came from Typer defaults (not user input).
     """
     if mode != "train":
@@ -373,7 +373,7 @@ def build_train_kwargs(params: dict[str, Any]) -> dict[str, Any]:
 
     Iterates TrainConfig fields and maps CLI-facing parameter names to
     internal field names using TRAIN_ALIASES.  Adding a new field to
-    TrainConfig automatically makes it available — no manual dict needed.
+    TrainConfig automatically makes it available, no manual dict needed.
     """
     from .aliases import TRAIN_ALIASES
     from libreyolo.training.config import TrainConfig
@@ -538,7 +538,7 @@ def _to_json_safe(val: Any) -> Any:
 def get_cfg_defaults() -> dict[str, Any]:
     """Build configuration defaults from dataclasses for the cfg command.
 
-    All values are derived from TrainConfig and ValidationConfig — nothing
+    All values are derived from TrainConfig and ValidationConfig, nothing
     hardcoded.  Family overrides are auto-discovered from the model registry.
     """
     from libreyolo.models.base.model import BaseModel

--- a/libreyolo/cli/output.py
+++ b/libreyolo/cli/output.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def _json_default(obj: Any) -> Any:
-    """Strict JSON default: only allow Path → str. Everything else is an error."""
+    """Strict JSON default: only allow Path -> str. Everything else is an error."""
     if isinstance(obj, Path):
         return str(obj)
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -31,6 +31,9 @@ class SupportEntry:
 
     tier: Tier
     reason: str = ""
+    #: The major.minor release LINE in which the capability first ships, not
+    #: an exact tag: "1.5" covers 1.5.0 and its point releases, so rows that
+    #: land between the .0 tag and the next point release stay truthful.
     since: str | None = None
     constraint: str | None = None
 

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -83,7 +83,7 @@ _add(
         "metadata, factory reload, and public detection parity in "
         "tests/e2e/test_paddle.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "X2Paddle 1.6.0, PaddlePaddle 2.6.2 CPU, ONNX 1.17/opset 15, FP32, "
         "batch 1, fixed square input; WSL2 Ubuntu 22.04"
@@ -109,7 +109,7 @@ _add(
         "runtime reload, raw-output parity, and matched public detection "
         "parity in tests/e2e/test_paddle.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "X2Paddle 1.6.0, PaddlePaddle 2.6.2 CPU, ONNX 1.17/opset 15, FP32, "
         "batch 1, fixed square input; WSL2 Ubuntu 22.04"
@@ -125,7 +125,7 @@ _add(
         "LibreYOLO9t checkpoint has raw-output and public detection parity; "
         "tests/e2e/test_paddle.py validates conversion, not P2 task accuracy."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "X2Paddle 1.6.0, PaddlePaddle 2.6.2 CPU, ONNX 1.17/opset 15, FP32, "
         "batch 1, fixed square input; WSL2 Ubuntu 22.04"
@@ -141,7 +141,7 @@ _add(
         "raw-output parity plus task-aware public keypoint or mask parity in "
         "tests/e2e/test_paddle.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "X2Paddle 1.6.0, PaddlePaddle 2.6.2 CPU, ONNX 1.17/opset 15, FP32, "
         "batch 1, fixed square input; WSL2 Ubuntu 22.04"
@@ -157,7 +157,7 @@ _add(
         "public detection/keypoint parity are covered in "
         "tests/e2e/test_paddle.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "X2Paddle 1.6.0, PaddlePaddle 2.6.2 CPU, ONNX 1.17/opset 15, FP32, "
         "batch 1, fixed square input; WSL2 Ubuntu 22.04"
@@ -194,7 +194,7 @@ _add(
         "artifact reload, metadata, runtime execution, and matched public "
         "post-NMS detection parity in tests/e2e/test_efficientdet_export.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint="FP32, batch 1, fixed per-variant square input",
 )
 _add(
@@ -207,7 +207,7 @@ _add(
         "artifact reload, metadata, OpenVINO CPU execution, and matched public "
         "post-NMS detection parity in tests/e2e/test_efficientdet_export.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "OpenVINO 2026.2, FP32, batch 1, fixed per-variant square input on CPU"
     ),
@@ -222,7 +222,7 @@ _add(
         "artifact reload, metadata, runtime execution, and matched public "
         "post-NMS detection parity in tests/e2e/test_efficientdet_export.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "TensorRT 10.16, FP32, batch 1, fixed per-variant square input; "
         "TensorRT's ITopK limit uses 3840 candidates instead of the native "
@@ -252,7 +252,7 @@ _add(
         "execution, metadata, and matched post-NMS detection parity are "
         "covered in tests/e2e/test_mnn.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint="MNN 3.6.1, CPU, FP32, batch 1, fixed NCHW input shape",
 )
 _add(
@@ -274,7 +274,7 @@ _add(
         "execution, metadata, and matched post-NMS detection parity are "
         "covered in tests/e2e/test_mnn.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint="MNN 3.6.1, CPU, FP32, batch 1, fixed NCHW input shape",
 )
 _add(
@@ -287,7 +287,7 @@ _add(
         "one-to-one public detection parity are covered with a deterministic "
         "strengthened-head fixture in tests/e2e/test_mnn.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint="MNN 3.6.1, CPU, FP32, batch 1, fixed NCHW input shape",
 )
 _add(
@@ -300,7 +300,7 @@ _add(
         "and preserves post-NMS detections, but the intermediate ONNX route "
         "has incomplete query-level score parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint="MNN 3.6.1, CPU, FP32, batch 1, fixed NCHW input shape",
 )
 _add(
@@ -314,7 +314,7 @@ _add(
         "~1e-7 on scores; public post-NMS detections match on batch 1 and 2 "
         "(tests/e2e/test_ppyoloe_export.py)."
     ),
-    since="1.7",
+    since="1.5",
     constraint="Fixed 640 canvas, FP32, batch 1 and 2",
 )
 _add(
@@ -330,7 +330,7 @@ _add(
         "batch 2, so the validated claim is FP32 at fixed batch 1. OpenVINO "
         "carries the batch-1-and-2 compiled-backend coverage."
     ),
-    since="1.7",
+    since="1.5",
     constraint=(
         "TensorRT 10.16, FP32 engine (half=False), fixed 640 canvas, fixed batch 1"
     ),
@@ -344,7 +344,7 @@ _add(
         "CPU FP32 conversion, raw two-tensor parity, factory reload and "
         "matching public post-NMS detections."
     ),
-    since="1.7",
+    since="1.5",
     constraint="OpenVINO CPU FP32, fixed 640 canvas, batch 1 and 2",
 )
 _add(
@@ -458,7 +458,7 @@ _add(
         "runtime execution, per-output raw parity, metadata, and matched "
         "public post-NMS detection parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"),
 )
 _add(
@@ -471,7 +471,7 @@ _add(
         "runtime execution, per-output raw parity, metadata, and public "
         "postprocessing parity for boxes plus keypoints."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"),
 )
 _add(
@@ -484,7 +484,7 @@ _add(
         "runtime execution, per-output raw parity, metadata, and public "
         "postprocessing parity for boxes plus masks."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1; fixed input shape large "
         "enough for the top-300 query selection"
@@ -500,7 +500,7 @@ _add(
         "runtime execution, per-output raw parity, metadata, and matched "
         "public box and keypoint parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"),
 )
 _add(
@@ -513,7 +513,7 @@ _add(
         "runtime execution, per-output logits parity, metadata, and public "
         "probability cosine plus top-1 parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"),
 )
 _add(
@@ -526,7 +526,7 @@ _add(
         "runtime execution, per-output image parity, metadata, and public "
         "restored-image parity above 40 dB PSNR."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"),
 )
 _add(
@@ -539,7 +539,7 @@ _add(
         "runtime execution, per-output heatmap parity, metadata, and matched "
         "public point-coordinate and confidence parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed square input shape"
     ),
@@ -591,7 +591,7 @@ _add(
         "parity, and public semantic-mask parity above 95% pixel agreement. "
         "This validates conversion compatibility, not trained task accuracy."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed 518x518 input shape"
     ),
@@ -622,7 +622,7 @@ _add(
         "conversion compatibility, not trained task accuracy; published "
         "pretrained weights are non-commercial and are not used."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape divisible by 32"
     ),
@@ -639,7 +639,7 @@ _add(
         "raw-map parity, input sensitivity, and public depth-map parity above "
         "40 dB PSNR are covered."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed square input shape "
         "divisible by 14"
@@ -656,7 +656,7 @@ _add(
         "signal/error guard, metadata, and public depth-map parity above "
         "40 dB PSNR."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "FP32, batch 1, fixed square input divisible by 14; TensorRT evidence "
         "uses TensorRT 10.16 and OpenVINO evidence uses OpenVINO 2026.2"
@@ -843,7 +843,7 @@ _add(
     ("yolonas",),
     ("detect",),
     ("tflite",),
-    since="1.6",
+    since="1.5",
     constraint="fixed export canvas",
 )
 _add(
@@ -908,7 +908,7 @@ _add(
         "Tests cover raw logits plus ONNX Runtime artifact reload, public "
         "probabilities, metadata, and top-1 parity."
     ),
-    since="1.7",
+    since="1.5",
     constraint=(
         "FP32 at the native 224x224 input resolution; ONNX supports a dynamic "
         "batch axis"
@@ -923,7 +923,7 @@ _add(
         "Tests cover TorchScript artifact reload, public probabilities, "
         "metadata, and top-1 parity."
     ),
-    since="1.7",
+    since="1.5",
     constraint="FP32 at the native 224x224 input resolution",
 )
 _add(
@@ -935,7 +935,7 @@ _add(
         "Official-checkpoint and deterministic-fixture runtime tests preserve "
         "probability cosine agreement and ordered top-k predictions."
     ),
-    since="1.7",
+    since="1.5",
     constraint="OpenVINO 2026.2 CPU FP32 at the fixed native 224x224 resolution",
 )
 _add(
@@ -947,7 +947,7 @@ _add(
         "Official-checkpoint and deterministic-fixture runtime tests preserve "
         "probability cosine agreement and ordered top-k predictions."
     ),
-    since="1.7",
+    since="1.5",
     constraint="TensorRT 10.16 FP32 at the fixed native 224x224 resolution",
 )
 _add(
@@ -960,7 +960,7 @@ _add(
         "trained-logit probability parity, metadata, and public top-1 parity "
         "in tests/e2e/test_swin_export.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint="Swin V1 at its fixed 224x224 native input resolution",
 )
 _add(
@@ -968,7 +968,7 @@ _add(
     ("mobilenetv4", "convnext", "efficientnetv2", "resnet"),
     ("classify",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed family-native input resolution",
 )
 _add(
@@ -993,7 +993,7 @@ _add(
         "reload, trained probability cosine parity, metadata, and public "
         "top-1 parity in tests/e2e/test_swin_export.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint="FP32 with a fixed 224x224 input resolution",
 )
 _add(
@@ -1001,7 +1001,7 @@ _add(
     ("mobilenetv4", "convnext", "efficientnetv2", "resnet"),
     ("classify",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint="FP32 with fixed family-native input resolution",
 )
 _add(
@@ -1054,7 +1054,7 @@ _add(
         "engine reload, trained probability cosine parity, metadata, and "
         "public top-1 parity in tests/e2e/test_swin_export.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint="FP32, batch 1, and a fixed 224x224 input resolution",
 )
 _add(
@@ -1075,7 +1075,7 @@ _add(
         "reload, two-input raw-logit parity with a 20x signal/error guard, "
         "metadata, class names, and public softmax/top-1 parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "batch 1, fixed square input, class set frozen at export time; "
         "SigLIP2 uses single-label softmax mode"
@@ -1091,7 +1091,7 @@ _add(
         "conversion, LiteRT reload, two-input raw-logit parity with a 20x "
         "signal/error guard, metadata, class names, and public softmax/top-1 parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "onnx2tf 2.6.7, LiteRT 2.1.2 CPU FP32, batch 1, fixed square input, "
         "class set frozen at export time, single-label softmax mode"
@@ -1109,7 +1109,7 @@ _add(
         "video graphs; ONNX matches to 4.3e-07 (embed), 1.3e-07 (video) and "
         "1.5e-05 (classify, on logit_scale-amplified logits)."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "fixed square input; dynamic batch only. Video graphs have a static "
         "frame count -- a dynamic F is not advertised. The classify graph "
@@ -1160,7 +1160,7 @@ _add(
         "reload, raw-logit parity, metadata, and public probability cosine "
         "plus top-1 parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint="OpenVINO 2026.2 CPU FP32, batch 1, fixed 224x224 input",
 )
 _add(
@@ -1184,7 +1184,7 @@ _add(
         "runtime execution, raw-logit parity, metadata, and public probability "
         "cosine plus top-1 parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"),
 )
 _add(
@@ -1197,7 +1197,7 @@ _add(
         "reload, two-input raw embedding parity with a 20x signal/error guard, "
         "metadata, normalization, and public embedding parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "FP32, batch 1, fixed family-native square input; ExecuTorch uses "
         "1.2/XNNPACK, TensorRT uses 10.16, and OpenVINO uses 2026.2"
@@ -1243,7 +1243,7 @@ _add(
         "conversion, LiteRT reload, two-input raw embedding parity with a 20x "
         "signal/error guard, metadata, normalization, and public embedding parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint="onnx2tf 2.6.7, LiteRT 2.1.2 CPU FP32, batch 1, fixed square input",
 )
 _add(
@@ -1263,7 +1263,7 @@ _add(
         "raw embedding parity with a 20x signal/error guard, metadata, "
         "normalization, and public embedding parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint="FP32, batch 1, fixed 224x224 input",
 )
 _add(
@@ -1306,7 +1306,7 @@ _add(
         "reload, two-input raw embedding parity with a 20x signal/error guard, "
         "metadata, normalization, and public embedding parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint="onnx2tf 2.6.7, LiteRT 2.1.2 CPU FP32, batch 1, fixed square input",
 )
 _add(
@@ -1418,7 +1418,7 @@ _add(
     ("dinov2", "eomt", "lingbotvision"),
     ("semantic",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed family-native export canvas",
 )
 _add(
@@ -1426,7 +1426,7 @@ _add(
     ("dinov2", "eomt"),
     ("semantic",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint="FP32 with a fixed family-native export canvas",
 )
 _add(
@@ -1462,7 +1462,7 @@ _add(
     ("pidnet",),
     ("semantic",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed square input",
 )
 _add(
@@ -1498,7 +1498,7 @@ _add(
         "runtime execution, two-head raw-logit parity, metadata, and public "
         "pitch/yaw parity for the fixed face-crop contract."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed 448x448 face crop"),
 )
 _add(
@@ -1511,7 +1511,7 @@ _add(
         "raw-depth parity with a 100x signal/error margin, metadata, and public "
         "depth-map parity above 40 dB PSNR."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape; "
         "Depth Anything uses the Apache-2.0 Small checkpoint"
@@ -1528,7 +1528,7 @@ _add(
         "metadata, and task-aware public boxes plus masks, keypoints, or OBB "
         "geometry parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed task-native input "
         "shape; segment and pose use Apache-2.0 trained checkpoints"
@@ -1559,7 +1559,7 @@ _add(
     ("nafnet",),
     ("restore",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed-resolution export canvas",
 )
 _add(
@@ -1567,7 +1567,7 @@ _add(
     ("nafnet",),
     ("restore",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint="FP32 with a fixed-resolution export canvas",
 )
 _add(
@@ -1613,7 +1613,7 @@ _add(
     ("realesrgan",),
     ("restore",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed-resolution export canvas",
 )
 _add(
@@ -1621,7 +1621,7 @@ _add(
     ("realesrgan",),
     ("restore",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint="FP32 with a fixed-resolution export canvas",
 )
 _add(
@@ -1691,7 +1691,7 @@ _add(
     ("fomo",),
     ("point",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint="FP32 with a fixed 96x96 input",
 )
 _add(
@@ -1699,7 +1699,7 @@ _add(
     ("fomo",),
     ("point",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed square input",
 )
 _add(
@@ -1739,7 +1739,7 @@ _add(
         "Deterministic input-sensitive fixtures cover XNNPACK conversion, "
         "runtime execution, two-image edge-probability parity, and metadata."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"),
 )
 _add(
@@ -1769,7 +1769,7 @@ _add(
         "edge-probability parity with a 20x signal/error guard, metadata, and "
         "public edge-map parity above 40 dB PSNR."
     ),
-    since="1.6",
+    since="1.5",
     constraint="LiteRT 2.1.2 CPU FP32, batch 1, fixed input shape",
 )
 _add(
@@ -1782,7 +1782,7 @@ _add(
         "reload, two-image raw edge-probability parity, metadata, and public "
         "edge-map parity above 40 dB PSNR."
     ),
-    since="1.6",
+    since="1.5",
     constraint="TorchScript CPU FP32, batch 1, fixed input shape",
 )
 _add(
@@ -1795,7 +1795,7 @@ _add(
         "reload, two-image raw edge-probability parity, metadata, and public "
         "edge-map parity above 40 dB PSNR."
     ),
-    since="1.6",
+    since="1.5",
     constraint="OpenVINO 2026.2 CPU FP32, batch 1, fixed input shape",
 )
 _add(
@@ -1808,7 +1808,7 @@ _add(
         "reload, two-image raw edge-probability parity, metadata, and public "
         "edge-map parity above 40 dB PSNR."
     ),
-    since="1.6",
+    since="1.5",
     constraint="TensorRT 10.16 FP32, batch 1, fixed input shape",
 )
 _add(
@@ -1816,7 +1816,7 @@ _add(
     ("zipdepth",),
     ("depth",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed-resolution export canvas",
 )
 _add(
@@ -1875,7 +1875,7 @@ _add(
     ),
     ("detect",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed export canvas; YOLO1 requires 448x448",
 )
 _add(
@@ -1883,7 +1883,7 @@ _add(
     ("yolo2", "yolo3", "yolo4"),
     ("detect",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint="FP32 with a fixed export canvas",
 )
 _add(
@@ -1891,7 +1891,7 @@ _add(
     ("yolo1", "picodet", "rtmdet"),
     ("detect",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint="TensorRT 10.16 FP32 with a fixed canvas; YOLO1 requires 448x448",
 )
 _add(
@@ -2216,7 +2216,7 @@ _add(
     ("yolonas",),
     ("detect", "pose"),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed export canvas",
 )
 _add(
@@ -2280,7 +2280,7 @@ _add(
     ("swinir",),
     ("restore",),
     ("onnx", "torchscript", "openvino", "tflite"),
-    since="1.6",
+    since="1.5",
     constraint=(
         "fixed export canvas; raw-output and predict parity are validated when "
         "the source dimensions exactly match that canvas. Smaller sources are "
@@ -2293,7 +2293,7 @@ _add(
     ("swinir",),
     ("restore",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint=(
         "FP32 with a fixed export canvas; raw-output and predict parity are "
         "validated when the source dimensions exactly match that canvas."
@@ -2422,7 +2422,7 @@ _add(
         "Both official checkpoints preserve baked top-100 detections and public "
         "prediction parity through the portable grid-sample DCN graph."
     ),
-    since="1.7",
+    since="1.5",
     constraint="FP32, fixed square input; ONNX Runtime CPU or TorchScript",
 )
 _add(
@@ -2444,7 +2444,7 @@ _add(
         "Official trained-checkpoint parity covers graph outputs and unified "
         "ONNX-backend detections against native PyTorch."
     ),
-    since="1.7",
+    since="1.5",
     constraint=(
         "ONNX Runtime, FP32, opset 18, batch 1, dynamic source H/W; upstream "
         "aspect resize and final class-wise NMS are embedded in the graph"
@@ -2459,7 +2459,7 @@ _add(
         "The official trained checkpoint preserves the decoded raw grid and "
         "public post-NMS predictions through ONNX Runtime."
     ),
-    since="1.7",
+    since="1.5",
     constraint="ONNX Runtime, FP32, opset 13, fixed 300 x 300 input",
 )
 _add(
@@ -2510,7 +2510,7 @@ _add(
         "Official-checkpoint parity covers decoded graph outputs and unified "
         "ONNX-backend detections against native PyTorch."
     ),
-    since="1.7",
+    since="1.5",
     constraint=(
         "ONNX Runtime, FP32, opset 13, batch 1, dynamic preprocessed H/W; "
         "class-aware NMS runs in the LibreYOLO backend"
@@ -2525,7 +2525,7 @@ _add(
         "The official trained checkpoint preserves the single-tensor raw "
         "contract and public post-NMS detections in ONNX Runtime."
     ),
-    since="1.7",
+    since="1.5",
     constraint=(
         "FP32, batch 1, out-of-graph aspect resize, opset 18, dynamic padded H/W"
     ),
@@ -2539,7 +2539,7 @@ _add(
         "Official trained-checkpoint parity covers final boxes, scores, labels, "
         "and full-image masks through ONNX Runtime and the unified backend."
     ),
-    since="1.7",
+    since="1.5",
     constraint=(
         "ONNX Runtime, FP32, opset 18, batch 1, dynamic source H/W; upstream "
         "aspect resize, class-wise NMS, RoIAlign, and mask paste are embedded"
@@ -2554,7 +2554,7 @@ _add(
         "The official trained checkpoint preserves the single-tensor raw "
         "contract and public post-NMS detections in TorchScript."
     ),
-    since="1.7",
+    since="1.5",
     constraint="FP32, batch 1, out-of-graph aspect resize, variable padded H/W",
 )
 _add(
@@ -2566,7 +2566,7 @@ _add(
         "FP32 dynamic-shape conversion and high-confidence public predictions "
         "pass, but small score/box drift can change low-confidence NMS ordering."
     ),
-    since="1.7",
+    since="1.5",
     constraint="OpenVINO CPU, FP32, batch 1, dynamic padded H/W",
 )
 _add(
@@ -2623,7 +2623,7 @@ _add(
     ("deim",),
     ("detect",),
     ("onnx",),
-    since="1.6",
+    since="1.5",
     constraint="DETR query rows are aligned as an unordered set for parity",
 )
 _add(
@@ -2631,7 +2631,7 @@ _add(
     ("dfine", "ec", "rtdetr", "rtdetrv4"),
     ("detect",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed export canvas",
 )
 _add(
@@ -2680,7 +2680,7 @@ _add(
     ("rtdetrv2", "rtdetrv4"),
     ("detect",),
     ("onnx",),
-    since="1.6",
+    since="1.5",
     constraint=(
         "fixed export canvas; same-device CPU raw parity after one shared "
         "unordered-query permutation; published Apache-2.0 trained checkpoint "
@@ -2697,7 +2697,7 @@ _add(
         "artifact reload, task metadata, raw five-coordinate output parity, "
         "and non-square public OBB prediction parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint="FP32, batch 1, fixed 1024x1024 input canvas",
 )
 _add(
@@ -2710,7 +2710,7 @@ _add(
         "public OBB within 0.041 pixels, but the complete decoder query set "
         "does not meet raw-output parity after matching."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "OpenVINO 2026.2 CPU, FP32, batch 1, fixed 1024x1024 input canvas; "
         "export the ONNX intermediate on CPU"
@@ -2726,7 +2726,7 @@ _add(
         "public OBB within 0.057 pixels, but matched raw queries still drift "
         "by up to 0.078 in logits and 0.034 in normalized box coordinates."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "TensorRT 10.16 FP32 on RTX 5070 Ti, batch 1, fixed 1024x1024 input "
         "canvas; export the ONNX intermediate on CPU"
@@ -2744,7 +2744,7 @@ _add(
     ("dfine",),
     ("segment",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed export canvas",
 )
 _add(
@@ -2760,7 +2760,7 @@ _add(
     ("ec",),
     ("segment",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed 640x640 input",
 )
 _add(
@@ -2858,7 +2858,7 @@ _add(
     ("segformer",),
     ("semantic",),
     ("onnx", "torchscript"),
-    since="1.6",
+    since="1.5",
     constraint="fixed square input divisible by 32",
 )
 _add(
@@ -2866,7 +2866,7 @@ _add(
     ("segformer",),
     ("semantic",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed square input divisible by 32",
 )
 _add(
@@ -2880,7 +2880,7 @@ _add(
         "20x signal/error guard, metadata, and public semantic-mask parity "
         "above 95% pixel agreement."
     ),
-    since="1.6",
+    since="1.5",
     constraint=("TensorRT 10.16 FP32, batch 1, fixed square input divisible by 32"),
 )
 _add(
@@ -2971,7 +2971,7 @@ _add(
     ("depth_anything",),
     ("depth",),
     ("openvino",),
-    since="1.6",
+    since="1.5",
     constraint="fixed input resolution divisible by 14",
 )
 _add(
@@ -2979,7 +2979,7 @@ _add(
     ("depth_anything",),
     ("depth",),
     ("tensorrt",),
-    since="1.6",
+    since="1.5",
     constraint="FP32 with a fixed input resolution divisible by 14",
 )
 _add(
@@ -3068,7 +3068,7 @@ _add(
     ("yolonas",),
     ("obb",),
     ("onnx", "torchscript", "openvino", "tensorrt"),
-    since="1.6",
+    since="1.5",
     constraint=(
         "fixed 1024x1024 export canvas, batch 1, FP32; the official "
         "YOLO-NAS-R-S DOTA2 checkpoint exports, reloads through the factory, "
@@ -3200,7 +3200,7 @@ _add(
         "signal/error guard, metadata, unit-vector normalization, and public "
         "angular parity below 0.1 degree."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "FP32, batch 1, fixed square input divisible by 14; TensorRT evidence "
         "uses TensorRT 10.16 and OpenVINO evidence uses OpenVINO 2026.2"
@@ -3458,7 +3458,7 @@ _add(
         "A deterministic input-sensitive fixture covers conversion, artifact "
         "reload, two-head raw-logit parity, metadata, and public gaze-angle parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint="OpenVINO 2026.2 CPU FP32, batch 1, fixed 448x448 face-crop input",
 )
 _add(
@@ -3470,7 +3470,7 @@ _add(
         "A deterministic input-sensitive fixture covers conversion, artifact "
         "reload, two-head raw-logit parity, metadata, and public gaze-angle parity."
     ),
-    since="1.6",
+    since="1.5",
     constraint="TensorRT 10.16 FP32, batch 1, fixed 448x448 face-crop input",
 )
 _add(
@@ -3526,7 +3526,7 @@ _add(
         "affine crop, normalization, flip-shift, and decoder against the pinned "
         "MIT upstream implementation."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "PyTorch 2.11, ONNX 1.20.1 / ONNX Runtime 1.26 or TorchScript, CPU "
         "FP32, batch 1, fixed checkpoint-native 256x192 (W32) or 384x288 "
@@ -3543,7 +3543,7 @@ _add(
         "artifact reload, raw-heatmap parity within 3e-3, metadata, and public "
         "decoded-keypoint parity in tests/e2e/test_hrnet_exports.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "OpenVINO 2026.2.1 CPU FP32, batch 1, fixed checkpoint-native 256x192 "
         "(W32) or 384x288 (W48) person-crop input; the full-image person "
@@ -3572,7 +3572,7 @@ _add(
         "artifact reload, raw-heatmap parity within 3e-3, metadata, and public "
         "decoded-keypoint parity in tests/e2e/test_hrnet_exports.py."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "TensorRT 10.16.1.11, CUDA 12.8, RTX 5070 Ti, FP32, batch 1, fixed "
         "checkpoint-native 256x192 (W32) or 384x288 (W48) person-crop input; "
@@ -3852,7 +3852,7 @@ _add(
         "frame order. Parity is measured by driving the runtime directly "
         "with a 5D clip."
     ),
-    since="1.6",
+    since="1.5",
     constraint=(
         "FP32, dynamic batch, fixed frame count / crop / tubelet geometry per "
         "graph; ONNX needs opset >= 14 for scaled_dot_product_attention. "

--- a/libreyolo/models/fcn/model.py
+++ b/libreyolo/models/fcn/model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
 import torch
@@ -122,6 +123,32 @@ class LibreFCN(BaseModel):
         if weight is None or getattr(weight, "ndim", 0) < 1:
             return None
         return int(weight.shape[0])
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        """Reject the ``-sem`` spelling instead of building a dead URL.
+
+        This family's hosted repos are suffixless (``LibreYOLO/LibreFCNr50``),
+        unlike the ``-sem`` convention of its semantic siblings, so the base
+        implementation turns ``LibreFCNr50-sem.pt`` into a URL for a repo that
+        does not exist and the download fails with an HTTP error that reads
+        like an outage. Name the correct spelling instead.
+
+        The size guard matters: ``download_weights`` asks every registered
+        family in turn and takes the first non-None answer, so raising on a
+        filename that is not ours would hijack another family's download.
+        """
+        name = Path(filename).name
+        size = cls.detect_size_from_filename(name)
+        if size is None:
+            return None
+        if cls.detect_task_from_filename(name) is not None:
+            canonical = f"{cls.FILENAME_PREFIX}{size}{cls.WEIGHT_EXT}"
+            raise FileNotFoundError(
+                f"{name}: LibreYOLO hosts {cls.FILENAME_PREFIX} weights without "
+                f"a task suffix. Use '{canonical}' instead."
+            )
+        return super().get_download_url(name)
 
     @classmethod
     def default_checkpoint_names(cls, nc: int) -> Optional[Dict[int, str]]:

--- a/libreyolo/models/lingbotvision/NOTICE
+++ b/libreyolo/models/lingbotvision/NOTICE
@@ -3,7 +3,7 @@ LibreLingBotVision family
 
 The LingBot-Vision ViT backbone in this directory is a native port of
 lingbot-vision (https://github.com/robbyant/lingbot-vision, commit
-151e463), released by
+151e46321bae4399f8568829f190c7bdec216b49), released by
 Robbyant (Ant Group) under the Apache License, Version 2.0.
 Copyright (c) 2026 Robbyant.
 Reference: "Vision Pretraining for Dense Spatial Perception",

--- a/libreyolo/models/lwdetr/NOTICE
+++ b/libreyolo/models/lwdetr/NOTICE
@@ -1,0 +1,48 @@
+LibreLWDETR includes code ported from LW-DETR:
+
+Source: https://github.com/Atten4Vis/LW-DETR
+Commit: d5e6e6c4add2d24dafb965ced8b50163c50b9788
+License: Apache License 2.0.
+Copyright (c) 2024 Baidu. All Rights Reserved.
+
+The upstream source headers carry notices for work modified from ViTDet,
+Conditional DETR, DETR, and Deformable DETR; those headers are preserved in
+the ported modules:
+
+ViTDet
+Source: https://github.com/facebookresearch/detectron2/tree/main/projects/ViTDet
+License: Apache License 2.0.
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Conditional DETR
+Source: https://github.com/Atten4Vis/ConditionalDETR
+License: Apache License 2.0.
+Copyright (c) 2021 Microsoft. All Rights Reserved.
+
+DETR
+Source: https://github.com/facebookresearch/detr
+License: Apache License 2.0.
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Deformable DETR
+Source: https://github.com/fundamentalvision/Deformable-DETR
+License: Apache License 2.0.
+Copyright (c) 2020 SenseTime. All Rights Reserved.
+
+LibreYOLO ports the plain-ViT encoder with interleaved window/global
+attention, the multi-scale projector, and the shallow deformable DETR decoder
+for the five released sizes. Module and attribute names mirror upstream so
+the official Apache-2.0 COCO checkpoints load unchanged, and ported outputs
+are bit-exact against the official implementation (max_abs_diff == 0.0 on
+pred_logits and pred_boxes for all five sizes). Ported inference only: the
+Group-DETR one-to-many training recipe (query groups in self-attention,
+Hungarian matching, the IoU-aware classification loss) is not included,
+although the checkpoint's query groups and per-group two-stage heads are
+materialised so upstream weights load strictly.
+
+Official weights are converted from the upstream Apache-2.0 releases
+(https://huggingface.co/xbsu/LW-DETR) and rehosted at
+LibreYOLO/LibreLWDETR{t,s,m,l,x}. Exact source files, SHA-256 hashes, and
+parity evidence are recorded in docs/provenance/lwdetr.md.
+
+The Apache-2.0 license text is at ``licenses/Apache-2.0.txt``.

--- a/libreyolo/models/mask_rcnn/model.py
+++ b/libreyolo/models/mask_rcnn/model.py
@@ -78,6 +78,33 @@ class LibreMaskRCNN(LibreFasterRCNN):
     def detect_checkpoint_task(cls, state_dict: dict) -> Optional[str]:
         return "segment" if cls.can_load(state_dict) else None
 
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        """Reject the ``-seg`` spelling instead of building a dead URL.
+
+        The hosted repo is suffixless (``LibreYOLO/LibreMaskRCNNr50``), so the
+        base implementation turns ``LibreMaskRCNNr50-seg.pt`` into a URL for a
+        repo that does not exist and the download fails with an HTTP error
+        that reads like an outage. Name the correct spelling instead.
+
+        The size guard matters: ``download_weights`` asks every registered
+        family in turn and takes the first non-None answer, so raising on a
+        filename that is not ours would hijack another family's download.
+        Torchvision spellings (``maskrcnn_resnet50_fpn_v2*``) carry no task
+        suffix and keep resolving through the base implementation.
+        """
+        name = Path(filename).name
+        size = cls.detect_size_from_filename(name)
+        if size is None:
+            return None
+        if cls.detect_task_from_filename(name) is not None:
+            canonical = f"{cls.FILENAME_PREFIX}{size}{cls.WEIGHT_EXT}"
+            raise FileNotFoundError(
+                f"{name}: LibreYOLO hosts {cls.FILENAME_PREFIX} weights without "
+                f"a task suffix. Use '{canonical}' instead."
+            )
+        return super().get_download_url(name)
+
     def _allow_checkpoint_task_mismatch(self, checkpoint_task: str) -> bool:
         """Allow the shared instance-segmentation checkpoint in detect mode."""
         return checkpoint_task == "segment" and self.task == "detect"

--- a/skills/libreyolo-release/SKILL.md
+++ b/skills/libreyolo-release/SKILL.md
@@ -342,14 +342,19 @@ hotfix, use the "Minor vs patch" branch-off-`release` variant instead.
    preflight check 3 told you if there are any). Resolve conflicts on dev;
    the version line auto-merges to the clean release value, so **manually
    set dev back to the next `X.Y.Z.dev0`** (the number the user chose).
-2. **Bump + hand over the PR link.** Branch off merged dev, set
-   `pyproject.toml` to the clean `X.Y.Z` the user chose, push, then hand the
-   user the one-click compare URL
-   `https://github.com/LibreYOLO/libreyolo/compare/release...<branch>?expand=1`.
-   Per `AGENTS.md`, the **agent does not open the PR**; the human submits
-   it. Remind them: this PR shows no CI checks by design, and it must be
-   merged with a **merge commit, never squash** (squash collapses the whole
-   cycle's history).
+2. **Bump + open the release PR.** Branch off merged dev, set
+   `pyproject.toml` to the clean `X.Y.Z` the user chose, and push. Per
+   `AGENTS.md`, the agent **may open the `dev -> release` PR itself**. The
+   description must follow `.github/pull_request_template.md` with a
+   `## Code provenance` section that is accurate for the actual diff, and
+   must state that the PR shows no CI checks by design and must be merged
+   with a **merge commit, never squash** (squash collapses the whole
+   cycle's history). Opening the PR is where the agent's authority stops:
+   the human reviews, approves and merges. Handing over the one-click
+   compare URL
+   `https://github.com/LibreYOLO/libreyolo/compare/release...<branch>?expand=1`
+   instead of opening the PR remains a valid alternative, and is the better
+   one when the human wants the description in their own words.
 3. **GitHub release (human action).** Cutting the release is the user's. By
    default the agent creates **no** release object: hand over the changelog
    file and the New Release URL and let the human fill it in, so no

--- a/tests/unit/cli/test_help_ascii.py
+++ b/tests/unit/cli/test_help_ascii.py
@@ -1,0 +1,43 @@
+"""The CLI's user-facing text must survive legacy Windows console codepages.
+
+A U+2014 em dash in the root help string rendered ``libreyolo --help`` as
+``LibreYOLO ? open source YOLO detection toolkit`` on cp1252 consoles.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+CLI_ROOT = Path(__file__).resolve().parents[3] / "libreyolo" / "cli"
+
+
+def test_root_help_strings_are_ascii():
+    from libreyolo.cli import _root, app
+
+    assert app.info.help.isascii()
+    assert _root.__doc__.isascii()
+    assert "LibreYOLO" in app.info.help
+
+
+def test_no_em_or_en_dashes_in_cli_string_literals():
+    """Scan every CLI source file: no U+2013/U+2014 outside comments.
+
+    Comments never reach a console; help strings, docstrings (typer renders
+    command docstrings as help), and print/echo literals all do.
+    """
+    import io
+    import tokenize
+
+    offenders = []
+    for path in sorted(CLI_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        for token in tokenize.generate_tokens(io.StringIO(source).readline):
+            if token.type == tokenize.COMMENT:
+                continue
+            if "\u2014" in token.string or "\u2013" in token.string:
+                offenders.append(f"{path.name}:{token.start[0]}")
+    assert not offenders, f"em/en dashes in CLI strings: {offenders}"

--- a/tests/unit/cli/test_help_ascii.py
+++ b/tests/unit/cli/test_help_ascii.py
@@ -38,6 +38,6 @@ def test_no_em_or_en_dashes_in_cli_string_literals():
         for token in tokenize.generate_tokens(io.StringIO(source).readline):
             if token.type == tokenize.COMMENT:
                 continue
-            if "\u2014" in token.string or "\u2013" in token.string:
+            if any(ord(ch) > 127 for ch in token.string):
                 offenders.append(f"{path.name}:{token.start[0]}")
-    assert not offenders, f"em/en dashes in CLI strings: {offenders}"
+    assert not offenders, f"non-ASCII in CLI strings: {offenders}"

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -859,3 +859,39 @@ def test_generated_docs_expose_validated_constraints():
     assert "## Validated constraints" in docs
     assert "`yolonas` / `detect` / `coreai`" in docs
     assert "raw-image preprocessing" in docs
+
+
+def test_shipping_rows_never_claim_a_future_since_version():
+    """A validated/available row cannot postdate the library's own version.
+
+    During 1.5.0 development 176 rows were stamped ``since="1.6"`` or
+    ``since="1.7"`` for capabilities that shipped in 1.5.0. Nothing rendered
+    ``since`` at the time, but the field becomes a lie the day the docs or
+    CLI surface it. The floor is the source tree's declared major.minor
+    (``1.6.0.dev0`` means 1.6 is in progress, so ``since="1.6"`` is fine);
+    installed dist metadata can lag a source checkout, so prefer pyproject.
+    """
+    import re
+
+    match = re.search(
+        r'^\[project\][^\[]*?^version\s*=\s*"(\d+)\.(\d+)',
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"),
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        import libreyolo
+
+        match = re.match(r"(\d+)\.(\d+)", libreyolo.__version__)
+    assert match is not None
+    floor = (int(match.group(1)), int(match.group(2)))
+
+    offenders = {}
+    for key, entry in SUPPORT.items():
+        if entry.tier not in ("validated", "available") or entry.since is None:
+            continue
+        since = tuple(int(part) for part in entry.since.split("."))
+        if since > floor:
+            offenders[key] = entry.since
+    assert not offenders, (
+        f"Rows claim since > {'.'.join(map(str, floor))}: {sorted(offenders.items())}"
+    )

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -865,11 +865,13 @@ def test_shipping_rows_never_claim_a_future_since_version():
     """A validated/available row cannot postdate the library's own version.
 
     During 1.5.0 development 176 rows were stamped ``since="1.6"`` or
-    ``since="1.7"`` for capabilities that shipped in 1.5.0. Nothing rendered
-    ``since`` at the time, but the field becomes a lie the day the docs or
-    CLI surface it. The floor is the source tree's declared major.minor
-    (``1.6.0.dev0`` means 1.6 is in progress, so ``since="1.6"`` is fine);
-    installed dist metadata can lag a source checkout, so prefer pyproject.
+    ``since="1.7"`` for capabilities that ship in the 1.5 line. Nothing
+    rendered ``since`` at the time, but the field becomes a lie the day the
+    docs or CLI surface it. ``since`` names the major.minor release LINE a
+    capability first ships in (see ``SupportEntry``), so rows added between
+    the ``v1.5.0`` tag and the next point release legitimately carry "1.5".
+    The floor is the source tree's declared major.minor from pyproject;
+    installed dist metadata can lag a source checkout, so pyproject wins.
     """
     import re
 

--- a/tests/unit/test_fcn.py
+++ b/tests/unit/test_fcn.py
@@ -194,3 +194,51 @@ def test_shared_semantic_surfaces_extract_primary_fcn_output():
 
     torch.testing.assert_close(exported, image[:, :2])
     torch.testing.assert_close(validated, image[:, :2])
+
+
+@pytest.mark.parametrize("size", ["r50", "r101"])
+def test_fcn_hosted_spellings_resolve_to_suffixless_repos(size):
+    """Both accepted suffixless names must point at the repos that exist.
+
+    The hosted repos are ``LibreYOLO/LibreFCNr50`` and
+    ``LibreYOLO/LibreFCNr101``, without the ``-sem`` suffix its semantic
+    siblings use.
+    """
+    assert LibreFCN.get_download_url(f"LibreFCN{size}.pt") == (
+        f"https://huggingface.co/LibreYOLO/LibreFCN{size}"
+        f"/resolve/main/LibreFCN{size}.pt"
+    )
+
+
+@pytest.mark.parametrize("size", ["r50", "r101"])
+def test_fcn_suffixed_spelling_is_rejected_with_the_canonical_name(size):
+    """``LibreFCN<size>-sem.pt`` names a repo that does not exist.
+
+    The filename regex accepts the ``-sem`` spelling, so left to the base
+    implementation it builds a dead URL and the download fails with an HTTP
+    error that reads like an outage. The resolver must instead reject it
+    before any URL is built and name the hosted spelling.
+    """
+    with pytest.raises(FileNotFoundError) as excinfo:
+        LibreFCN.get_download_url(f"LibreFCN{size}-sem.pt")
+    message = str(excinfo.value)
+    assert f"LibreFCN{size}.pt" in message
+    assert "huggingface" not in message.lower()
+
+
+def test_fcn_download_guard_ignores_foreign_filenames():
+    """``download_weights`` polls every family; never hijack another's name."""
+    assert LibreFCN.get_download_url("LibreYOLOXs.pt") is None
+    assert LibreFCN.get_download_url("LibreDeepLabv3mv3-sem.pt") is None
+
+
+def test_fcn_cli_names_resolve_to_the_hosted_spelling():
+    """CLI aliases and weight-name checks must agree with the resolver."""
+    from libreyolo.cli.config import is_known_weight_filename, resolve_model_name
+
+    assert resolve_model_name("fcn-r50") == "LibreFCNr50.pt"
+    assert resolve_model_name("fcn-r50-sem") == "LibreFCNr50.pt"
+    assert is_known_weight_filename("LibreFCNr50.pt") is True
+    # The suffixed file spelling stays rejected on both surfaces: the CLI
+    # treats it as unknown and the resolver raises before building a URL.
+    assert is_known_weight_filename("LibreFCNr50-sem.pt") is False

--- a/tests/unit/test_mask_rcnn.py
+++ b/tests/unit/test_mask_rcnn.py
@@ -92,3 +92,64 @@ def test_validator_slices_native_mask_detection_list():
         }
     ]
     assert validator._slice_batch_predictions(predictions, 0) is predictions[0]
+
+
+def test_hosted_spelling_resolves_to_the_suffixless_repo():
+    """The hosted repo is ``LibreYOLO/LibreMaskRCNNr50``, no ``-seg`` suffix."""
+    from libreyolo import LibreMaskRCNN
+
+    assert LibreMaskRCNN.get_download_url("LibreMaskRCNNr50.pt") == (
+        "https://huggingface.co/LibreYOLO/LibreMaskRCNNr50"
+        "/resolve/main/LibreMaskRCNNr50.pt"
+    )
+
+
+def test_torchvision_spelling_still_resolves_suffixless():
+    """Upstream filenames carry no task suffix and keep the base mapping."""
+    from libreyolo import LibreMaskRCNN
+
+    assert LibreMaskRCNN.get_download_url("maskrcnn_resnet50_fpn_v2_coco.pt") == (
+        "https://huggingface.co/LibreYOLO/LibreMaskRCNNr50"
+        "/resolve/main/LibreMaskRCNNr50.pt"
+    )
+
+
+def test_seg_spelling_is_rejected_with_the_canonical_name():
+    """``LibreMaskRCNNr50-seg.pt`` names a repo that does not exist.
+
+    The filename regex accepts the ``-seg`` spelling (DEFAULT_TASK is
+    segment), so left to the base implementation it builds a dead URL. The
+    resolver must reject it before any URL is built and name the hosted
+    spelling instead.
+    """
+    from libreyolo import LibreMaskRCNN
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        LibreMaskRCNN.get_download_url("LibreMaskRCNNr50-seg.pt")
+    message = str(excinfo.value)
+    assert "LibreMaskRCNNr50.pt" in message
+    assert "huggingface" not in message.lower()
+
+
+def test_download_guard_ignores_foreign_filenames():
+    """``download_weights`` polls every family; never hijack another's name."""
+    from libreyolo import LibreMaskRCNN
+
+    assert LibreMaskRCNN.get_download_url("LibreYOLOXs.pt") is None
+    assert LibreMaskRCNN.get_download_url("LibreRFDETRn-seg.pt") is None
+
+
+def test_cli_names_agree_with_the_resolver():
+    """The CLI and the resolver must reject the same spelling.
+
+    ``mask_rcnn-r50`` and its advertised ``mask_rcnn-r50-seg`` alias both map
+    to the hosted suffixless checkpoint; the raw ``LibreMaskRCNNr50-seg.pt``
+    file spelling stays rejected on both surfaces (the CLI exits with
+    model_not_found, the resolver raises before building a URL).
+    """
+    from libreyolo.cli.config import is_known_weight_filename, resolve_model_name
+
+    assert resolve_model_name("mask_rcnn-r50") == "LibreMaskRCNNr50.pt"
+    assert resolve_model_name("mask_rcnn-r50-seg") == "LibreMaskRCNNr50.pt"
+    assert is_known_weight_filename("LibreMaskRCNNr50.pt") is True
+    assert is_known_weight_filename("LibreMaskRCNNr50-seg.pt") is False

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -251,6 +251,17 @@ project the weights were derived from. Per-family summary:
              adds LibreYOLO checkpoint metadata. Every Hugging Face weight
              repository carries the upstream Apache-2.0 LICENSE and NOTICE.
 
+    LW-DETR  (LibreLWDETR{t,s,m,l,x})                  Apache-2.0
+             upstream code: Atten4Vis/LW-DETR at commit
+               d5e6e6c4add2d24dafb965ced8b50163c50b9788
+             upstream weights: xbsu/LW-DETR on Hugging Face, declared
+             Apache-2.0 in the model-card metadata. Converted and rehosted
+             at LibreYOLO/LibreLWDETR{t,s,m,l,x}; learned tensors are
+             unchanged and conversion only adds LibreYOLO checkpoint
+             metadata. Ported outputs are bit-exact against the official
+             implementation for all five sizes; source SHA-256 hashes and
+             evidence are in docs/provenance/lwdetr.md.
+
     EoMT     (LibreEoMTl-sem, LibreEoMTl-seg,          MIT
               LibreEoMTl-seg-1280, LibreEoMT{s,b,l}-panoptic)
              upstream: tue-mps/eomt
@@ -460,6 +471,15 @@ project the weights were derived from. Per-family summary:
              scratch on your own data carry no such restriction; a fine-tune
              started from a released checkpoint inherits it.
 
+    LingBot-Vision (LibreLingBotVision{s,b,l}-sem)     Apache-2.0
+             upstream: robbyant/lingbot-vision (code and released backbone
+             weights Apache-2.0, Copyright (c) 2026 Robbyant; backbone
+             checkpoints published in the robbyant lingbot-vision Hugging
+             Face collection). Each hosted checkpoint combines the unchanged
+             Apache-2.0 backbone tensors with an ADE20K dense head trained
+             by LibreYOLO; see each weight repo's README for the training
+             data.
+
     PP-OCRv5 (LibrePPOCR{t,l}-ocr)                     Apache-2.0
              upstream: PaddlePaddle/PaddleOCR (code and released
              weights Apache-2.0). Converted from the official
@@ -501,6 +521,36 @@ project the weights were derived from. Per-family summary:
              converted because they contain the older PicoSAM2 network.
              Distilled by upstream from SAM 2.1 and SAM 3; teacher weights
              are not included or redistributed.
+
+    SAM 3D Body (LibreSAM3DBody{d3,h}-mesh)           SAM License (restricted)
+             upstream: facebookresearch/sam-3d-body (Meta Platforms, Inc.)
+             The SAM License is NOT a permissive license: it carries
+             field-of-use restrictions (military, nuclear, espionage and
+             weapons use), a no-reverse-engineering clause, and unilateral
+             amendment by Meta. It permits redistribution provided its terms
+             are passed through, so the checkpoints are mirrored
+             byte-identically at LibreYOLO/LibreSAM3DBodyd3-mesh and
+             LibreYOLO/LibreSAM3DBodyh-mesh, each carrying the SAM License
+             text and an access gate recording acceptance. Mirroring does
+             not change the license: the weights remain SAM-licensed, not
+             MIT, and are NOT covered by LibreYOLO's permissive license.
+             No upstream code is ported; libreyolo/models/sam3dbody/ is
+             LibreYOLO's own MIT wrapper around the optional upstream
+             package. See THIRD_PARTY_NOTICES.txt for the full description.
+
+    Face recognition (librefacerec-l.onnx,             per-file, see below
+              librefacerec-det.onnx)
+             librefacerec-l.onnx: the AuraFace-v1 embedding graph
+             (glintr100.onnx from fal/AuraFace-v1 on Hugging Face,
+             Apache-2.0 weights), mirrored unmodified to the LibreYOLO
+             organization. Upstream training data is undisclosed; only this
+             single Apache-2.0 file is mirrored, none of the other artifacts
+             in the upstream repository.
+             librefacerec-det.onnx: the YuNet face detector
+             (face_detection_yunet_2023mar.onnx from opencv/opencv_zoo,
+             MIT, Copyright (c) Shiqi Yu), mirrored unmodified.
+             No code is ported from either project; both graphs are
+             consumed opaquely at runtime.
 
 The LICENSE and NOTICE files on each Hugging Face model card are the
 authoritative source for redistribution terms. Users converting

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -435,8 +435,8 @@ project the weights were derived from. Per-family summary:
              GitHub), code and weights explicitly Apache-2.0 (YAML license
              tag) -> rehosted under the LibreYOLO org
              (LibreYOLO/LibreFeyNobgl-matte), including
-             post-training-quantized fp8/nvfp4 variants
-             (LibreFeyNobgl-matte-{fp8,nvfp4}). Upstream training data is
+             post-training-quantized fp16/fp8 variants
+             (LibreFeyNobgl-matte-{fp16,fp8}). Upstream training data is
              not disclosed; only the released weights are redistributed.
              Convert with weights/convert_feynobg_weights.py.
 
@@ -473,7 +473,7 @@ project the weights were derived from. Per-family summary:
 
     LingBot-Vision (LibreLingBotVision{s,b,l}-sem)     Apache-2.0
              upstream: robbyant/lingbot-vision (code and released backbone
-             weights Apache-2.0, Copyright (c) 2026 Robbyant; backbone
+             weights Apache-2.0, Copyright 2026 LingBot-Vision Contributors; backbone
              checkpoints published in the robbyant lingbot-vision Hugging
              Face collection). Each hosted checkpoint combines the unchanged
              Apache-2.0 backbone tensors with an ADE20K dense head trained


### PR DESCRIPTION
Part of #744. Covers items 1-11, 13, 15. NOT covered: 12 (deepstream docs), 14 (Jetson page needs a real Orin run), 16-18 (process items). Item 8's generator half lives in the website repo (fixed there, uncommitted, separate decision).

## Licensing surfaces (items 1-5)

- weights/LICENSE_NOTICE.txt: added SAM 3D Body (restricted SAM License, mirrored behind the access gate), LibreLWDETR{t,s,m,l,x}, LibreLingBotVision{s,b,l}-sem, librefacerec-l/-det (AuraFace-v1 Apache-2.0, YuNet MIT).
- THIRD_PARTY_NOTICES.txt: LingBot-Vision entry with the pinned upstream commit recovered and verified (151e46321bae). Copyright transcribed from the pinned upstream LICENSE: "Copyright 2026 LingBot-Vision Contributors".
- Root NOTICE: 7 missing family blocks (retinanet, fcn, vgg, dinodetr, efficientdet, vit, feynobg), pins taken from each family's own files. FeyNobg has no pin anywhere in the repo; its block says so. FeyNobg hosted-variant claims corrected to fp16/fp8 (nvfp4 was withdrawn).
- New libreyolo/models/lwdetr/NOTICE following the detr/deformable_detr pattern. facerec/sam3dbody intentionally carry none (no ported code, matching grounding_dino/owlv2 convention).

## Correctness (items 6, 7, 15)

- LibreFCNr50-sem.pt, LibreFCNr101-sem.pt, LibreMaskRCNNr50-seg.pt were accepted by the filename regex but built dead URLs (verified against the hub: only suffixless repos exist). They now raise naming the hosted spelling; resolver and CLI agree. Long-term alternative (create -sem mirror repos and flip REQUIRE_TASK_SUFFIX) stays open to the maintainer.
- export/support.py: 190 rows restamped since="1.6"/"1.7" to "1.5"; since is now documented as the major.minor release LINE; a test pins that shipping rows never claim a future version.
- CLI: em dashes removed from all user-facing strings (root help, profile, train, config); a tokenize-based test bans them going forward.

## Docs (items 9-11, 13)

- ADR collisions renumbered by landing order: 0013-embed-task-contract to 0017, 0015-edge-task-contract to 0018; every cross-reference updated; the 0015-embed-generalization amendment chain reads correctly.
- docs/cuda_graphs.md: correct pytest marker; sensenova removed from the not-supported table (SUPPORTS_CUDA_GRAPH = True in code).
- skills/libreyolo-release: Phase 3 aligned with AGENTS.md (agent may open the release PR; compare-URL hand-off remains valid).
- README.zh-CN.md fully resynced with the reworked English README; duplicate Embeddings row in the English table removed.

## Verification

- 109 tests green across the touched suites (fcn, mask_rcnn, cli ascii, export support, capability language); 569 passed on the broader weights/download sweep.
- Every upstream repo, commit SHA, and license claim in the notice additions cross-checked against family NOTICE files, docs/provenance/, and live upstream files.

## Code provenance

All code and text is original, written for this PR. Notice entries transcribe attribution facts from the named upstreams (verified at their pinned commits); no third-party code is ported. README.zh-CN.md is a translation of this repository's own README.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates licensing and attribution surfaces, rejects dead hosted-weight spellings, restamps export-support release metadata, removes non-ASCII CLI literals, renumbers colliding ADRs, and synchronizes documentation.
- Adds and corrects model-family notices and weight-license disclosures.
- Makes FCN and Mask R-CNN download resolution reject unsupported task-suffixed filenames with canonical alternatives.
- Strengthens the CLI regression test to reject all non-ASCII source tokens outside comments.
- Updates export-support version metadata, ADR references, CUDA graph documentation, and the Chinese README.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/unit/cli/test_help_ascii.py | The broadened token scan now catches every non-ASCII static CLI token outside comments, resolving the previous dash-only coverage gap. |
| libreyolo/models/fcn/model.py | Rejects task-suffixed FCN filenames before constructing nonexistent hosted-repository URLs. |
| libreyolo/models/mask_rcnn/model.py | Rejects the unsupported Mask R-CNN task-suffixed filename while preserving suffixless and upstream filename resolution. |
| libreyolo/export/support.py | Restamps shipping capability rows to the 1.5 release line and documents the field’s major-minor semantics. |
| README.zh-CN.md | Resynchronizes the Chinese landing page with the current English README structure and feature coverage. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Make the CLI ASCII test reject any non-A..."](https://github.com/libreyolo/libreyolo/commit/11041fa8c00eedcb2e2e88f580012cf0610addfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53386829)</sub>

<!-- /greptile_comment -->