### PR TITLE
Add mse and entropy calibration algorithms to the quant API (#768 item 1.1)

### DIFF
--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -98,7 +98,10 @@ Two histogram-based algorithms complement those. `mse` sweeps candidate
 clipping thresholds over a 2048-bin histogram of absolute activation values
 and picks the threshold minimizing the quantization reconstruction error, so
 it only clips as far as squared error actually improves; on clean
-distributions it lands next to minmax. `entropy` picks the threshold
+distributions it lands next to minmax. The sweep simulates the affine
+codebook the calibrated layer actually deploys: activations that never
+cross zero (post-ReLU layers) keep all 256 int8 codes on one side, so they
+are judged at that doubled resolution rather than a symmetric stand-in. `entropy` picks the threshold
 minimizing the KL divergence between the original and quantized activation
 distributions, which clips more aggressively because it optimizes
 information preservation rather than squared error. Both help on layers

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -94,6 +94,23 @@ batches (hence the coco128 default: with it, YOLO9-t lands within about one
 mAP point of fp32). The chosen algorithm is recorded in the checkpoint
 manifest.
 
+Two histogram-based algorithms complement those. `mse` sweeps candidate
+clipping thresholds over a 2048-bin histogram of absolute activation values
+and picks the threshold minimizing the quantization reconstruction error, so
+it only clips as far as squared error actually improves; on clean
+distributions it lands next to minmax. `entropy` picks the threshold
+minimizing the KL divergence between the original and quantized activation
+distributions, which clips more aggressively because it optimizes
+information preservation rather than squared error. Both help on layers
+whose activations carry rare large outliers that would otherwise stretch the
+int8 range and crush resolution for the bulk of values. Their cost is
+histogram collection during the calibration pass plus a threshold sweep per
+layer at the end; calibration takes somewhat longer, inference is unchanged.
+Both set the per-tensor activation range only; weight scales stay
+per-channel absolute-max under every algorithm. The same caution as
+percentile applies to transformer families, where clipping activation
+outliers can cost accuracy: validate with `val()` before deploying.
+
 ## Execution tiers
 
 v1 executes quantized arithmetic in **simulation** (fake-quantization with

--- a/libreyolo/cli/commands/quantize.py
+++ b/libreyolo/cli/commands/quantize.py
@@ -32,7 +32,8 @@ def quantize_cmd(
     algorithm: str = typer.Option(
         "auto",
         help="Activation range estimation: auto (minmax), minmax, "
-        "percentile (can reduce transformer accuracy)",
+        "percentile (can reduce transformer accuracy), mse, entropy "
+        "(histogram sweeps; help on outlier-heavy activations)",
     ),
     out: Optional[str] = typer.Option(
         None,

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1707,8 +1707,11 @@ class BaseModel(ABC):
             algorithm: Activation range estimation: "minmax" (absolute
                 extremes across batches; the measured best default),
                 "percentile" (mean of per-batch 0.1/99.9 percentiles; measured
-                to degrade transformer families), or "auto"
-                (minmax).
+                to degrade transformer families), "mse" (histogram sweep
+                minimizing quantization reconstruction error), "entropy"
+                (histogram sweep minimizing KL divergence between the float
+                and quantized distributions), or "auto" (minmax). Weight
+                scales stay per-channel absolute-max in every case.
             keep_high_precision: Substring patterns of module names kept in
                 float. Defaults to the family policy (first layer + heads).
             allow_download_scripts: Allow embedded Python in dataset YAML

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -54,7 +54,12 @@ LINEAR_RECIPES = ("w4a16", "w4a8", "nvfp4", "mxfp4", "int2")
 CALIBRATED_RECIPES = ("int8", "fp8", "w4a8", "int2")
 RESEARCH_RECIPES = ("int2",)
 SUPPORTED_FAMILIES = ("yolo9", "rfdetr", "birefnet", "feynobg")
-CALIB_ALGORITHMS = ("auto", "percentile", "minmax")
+# Activation-range algorithms. minmax/percentile track running extremes;
+# mse/entropy accumulate an absolute-value histogram during the calibration
+# pass and sweep clipping thresholds afterwards (see calibrate.py). All of
+# them set the per-tensor activation range only; weight scales are always
+# per-channel absolute-max regardless of the algorithm.
+CALIB_ALGORITHMS = ("auto", "percentile", "minmax", "mse", "entropy")
 
 GROUP_SIZE = 128  # grouped-int recipes: scale group along in_features
 INT2_GROUP_SIZE = 64

--- a/libreyolo/quant/calibrate.py
+++ b/libreyolo/quant/calibrate.py
@@ -1,0 +1,159 @@
+"""Histogram-based activation amax selection (mse / entropy calibration).
+
+Both algorithms consume the same fixed-width histogram of absolute
+activation values accumulated across calibration batches and return a
+clipping threshold (amax):
+
+- ``mse``: sweep candidate thresholds, simulate quantize/dequantize of every
+  bin center at the activation format's resolution, and pick the threshold
+  minimizing the histogram-weighted squared reconstruction error.
+- ``entropy``: for each candidate threshold, compare the clipped reference
+  distribution (out-of-range mass saturated into the top bin) against the
+  quantized-then-expanded distribution and pick the threshold minimizing
+  their KL divergence.
+
+Everything runs on detached CPU tensors in double precision and the sweeps
+are exhaustive over a fixed candidate grid, so results are deterministic.
+"""
+
+import torch
+
+from .fake_quant import E4M3_MAX
+
+HIST_BINS = 2048
+# Candidate thresholds are histogram bin edges. The coarse pass visits every
+# _SWEEP_STEP-th edge; mse then refines every edge around the coarse winner.
+_SWEEP_STEP = 16
+# Positive-side code count used to simulate the int8 activation format. The
+# deployed scheme is 256-level affine over [lo, hi]; on the absolute-value
+# histogram the symmetric 128-level approximation is the standard stand-in.
+_INT8_LEVELS = 128
+_EPS = 1e-12
+
+# histc chunk size: single-precision counters lose integer exactness past
+# 2**24, so large activations are histogrammed in chunks and accumulated in
+# float64 (also keeps CUDA atomic-add histograms bitwise reproducible).
+_HISTC_CHUNK = 1 << 22
+
+
+def accumulate_abs_histogram(hist, hist_amax: float, x: torch.Tensor):
+    """Fold one batch of activations into the running |x| histogram.
+
+    Returns the updated ``(hist, hist_amax)`` pair; ``hist`` is a float64
+    CPU tensor of ``HIST_BINS`` counts over ``[0, hist_amax]``. When a batch
+    exceeds the current range, the range is doubled (pair-merging existing
+    bins) until it fits, so earlier counts land exactly on the new grid and
+    no second pass over the data is needed.
+    """
+    flat = x.detach().reshape(-1).float().abs()
+    amax = float(flat.max()) if flat.numel() else 0.0
+    if amax == 0.0:
+        return hist, hist_amax
+    if hist is None:
+        hist = torch.zeros(HIST_BINS, dtype=torch.float64)
+        hist_amax = amax
+    while hist_amax < amax:
+        merged = hist.reshape(-1, 2).sum(dim=1)
+        hist = torch.cat([merged, torch.zeros_like(merged)])
+        hist_amax *= 2.0
+    for chunk in flat.split(_HISTC_CHUNK):
+        hist += torch.histc(chunk, bins=HIST_BINS, min=0.0, max=hist_amax).double().cpu()
+    return hist, hist_amax
+
+
+def _candidate_indices(start: int) -> torch.Tensor:
+    idx = list(range(start, HIST_BINS, _SWEEP_STEP))
+    idx.append(HIST_BINS)  # the full observed range (minmax) is always a candidate
+    return torch.tensor(idx, dtype=torch.long)
+
+
+def _reconstruct(centers: torch.Tensor, amaxes: torch.Tensor, aformat: str) -> torch.Tensor:
+    """Dequantized value of each bin center under each candidate amax.
+
+    Returns [candidates, bins]. Saturation is part of the codebook clamp, so
+    clipping error and rounding error come out of the same formula.
+    """
+    if aformat == "fp8":
+        scale = (amaxes / E4M3_MAX).clamp_min(_EPS).unsqueeze(1)
+        scaled = (centers.unsqueeze(0) / scale).clamp(max=E4M3_MAX).float()
+        return scaled.to(torch.float8_e4m3fn).double() * scale
+    scale = (amaxes / (_INT8_LEVELS - 1)).clamp_min(_EPS).unsqueeze(1)
+    codes = torch.round(centers.unsqueeze(0) / scale).clamp(max=_INT8_LEVELS - 1)
+    return codes * scale
+
+
+def mse_amax(hist: torch.Tensor, hist_amax: float, aformat: str = "int8") -> float:
+    """Clipping threshold minimizing histogram-weighted reconstruction MSE."""
+    hist = hist.double()
+    if float(hist.sum()) == 0.0:
+        return hist_amax
+    bin_width = hist_amax / HIST_BINS
+    centers = (torch.arange(HIST_BINS, dtype=torch.float64) + 0.5) * bin_width
+
+    def sweep(indices: torch.Tensor) -> int:
+        amaxes = indices.double() * bin_width
+        recon = _reconstruct(centers, amaxes, aformat)
+        losses = ((centers.unsqueeze(0) - recon) ** 2 * hist.unsqueeze(0)).sum(dim=1)
+        return int(indices[int(torch.argmin(losses))])
+
+    best = sweep(_candidate_indices(start=_SWEEP_STEP))
+    fine = torch.arange(
+        max(1, best - _SWEEP_STEP + 1), min(HIST_BINS, best + _SWEEP_STEP - 1) + 1
+    )
+    return sweep(fine) * bin_width
+
+
+def _quantized_codes(i: int, bin_width: float, aformat: str) -> torch.Tensor:
+    """Group id of each of the first ``i`` bins under a clip at edge ``i``."""
+    if aformat == "fp8":
+        centers = (torch.arange(i, dtype=torch.float64) + 0.5) * bin_width
+        scale = max(i * bin_width / E4M3_MAX, _EPS)
+        snapped = (centers / scale).clamp(max=E4M3_MAX).float().to(torch.float8_e4m3fn)
+        _, codes = torch.unique(snapped.float(), sorted=True, return_inverse=True)
+        return codes
+    # Uniform merge of i bins into the int8 level groups.
+    return torch.arange(i) * _INT8_LEVELS // i
+
+
+def entropy_amax(hist: torch.Tensor, hist_amax: float, aformat: str = "int8") -> float:
+    """Clipping threshold minimizing KL(reference || quantized) divergence.
+
+    The reference keeps the clipped tail (saturated into its top bin); the
+    quantized distribution is built from the in-range mass only, grouped by
+    quantization code and spread back uniformly over that code's occupied
+    bins. The asymmetry is what makes aggressive clipping cost divergence.
+    """
+    hist = hist.double()
+    if float(hist.sum()) == 0.0:
+        return hist_amax
+    bin_width = hist_amax / HIST_BINS
+    best_i, best_kl = HIST_BINS, float("inf")
+    for i in _candidate_indices(start=_INT8_LEVELS).tolist():
+        inside = hist[:i]
+        if float(inside.sum()) == 0.0:
+            continue
+        reference = inside.clone()
+        reference[-1] += hist[i:].sum()
+        reference = reference / reference.sum()
+
+        codes = _quantized_codes(i, bin_width, aformat)
+        ncodes = int(codes[-1]) + 1
+        grouped = torch.zeros(ncodes, dtype=torch.float64).scatter_add_(0, codes, inside)
+        occupied = torch.zeros(ncodes, dtype=torch.float64).scatter_add_(
+            0, codes, (inside > 0).double()
+        )
+        mask = inside > 0
+        quantized = torch.zeros(i, dtype=torch.float64)
+        quantized[mask] = (grouped / occupied.clamp_min(1.0))[codes][mask]
+        quantized = quantized / quantized.sum().clamp_min(_EPS)
+
+        # KL over the reference's support: the saturated tail may sit in a
+        # bin the in-range histogram left empty, and the eps floor on the
+        # quantized side is what prices that clipped mass.
+        support = reference > 0
+        p = reference[support]
+        q = quantized[support].clamp_min(_EPS)
+        kl = float((p * torch.log(p / q)).sum())
+        if kl < best_kl:
+            best_kl, best_i = kl, i
+    return best_i * bin_width

--- a/libreyolo/quant/calibrate.py
+++ b/libreyolo/quant/calibrate.py
@@ -24,10 +24,14 @@ HIST_BINS = 2048
 # Candidate thresholds are histogram bin edges. The coarse pass visits every
 # _SWEEP_STEP-th edge; mse then refines every edge around the coarse winner.
 _SWEEP_STEP = 16
-# Positive-side code count used to simulate the int8 activation format. The
-# deployed scheme is 256-level affine over [lo, hi]; on the absolute-value
-# histogram the symmetric 128-level approximation is the standard stand-in.
+# Positive-side code counts used to simulate the deployed int8 activation
+# format, which is 256-level affine over the intersected [lo, hi] window
+# (see finalize_observation). Two-sided distributions get the standard
+# symmetric 128-level stand-in for [-amax, amax]; one-sided (post-ReLU)
+# distributions keep the full 256 codes on a single side, exactly matching
+# what fake_quant_int8_affine does with a [0, amax] or [-amax, 0] window.
 _INT8_LEVELS = 128
+_INT8_LEVELS_ONE_SIDED = 256
 _EPS = 1e-12
 
 # histc chunk size: single-precision counters lose integer exactness past
@@ -36,29 +40,61 @@ _EPS = 1e-12
 _HISTC_CHUNK = 1 << 22
 
 
-def accumulate_abs_histogram(hist, hist_amax: float, x: torch.Tensor):
+def accumulate_abs_histogram(hist, hist_amax: float, x: torch.Tensor, top: float = 0.0):
     """Fold one batch of activations into the running |x| histogram.
 
-    Returns the updated ``(hist, hist_amax)`` pair; ``hist`` is a float64
-    CPU tensor of ``HIST_BINS`` counts over ``[0, hist_amax]``. When a batch
-    exceeds the current range, the range is doubled (pair-merging existing
-    bins) until it fits, so earlier counts land exactly on the new grid and
-    no second pass over the data is needed.
+    Returns the updated ``(hist, hist_amax, top)`` triple; ``hist`` is a
+    float64 CPU tensor of ``HIST_BINS`` counts over ``[0, hist_amax]`` and
+    ``top`` is the count of samples sitting exactly on the current top edge.
+    When a batch exceeds the current range, the range is doubled
+    (pair-merging existing bins) until it fits, so earlier counts land
+    exactly on the new grid and no second pass over the data is needed.
+
+    The accumulated histogram is bit-identical to a direct ``torch.histc``
+    of the concatenated data on the final grid, for any batch split:
+
+    - ``torch.histc`` bins are left-inclusive except the last, which also
+      includes the top edge. Under a doubling, the old top edge becomes an
+      interior boundary of the new grid, so samples exactly on it move from
+      the merged lower bin to the bin the new grid starts there; ``top``
+      tracks that count so the merge can relocate it.
+    - All-zero batches carry no range information but their mass still
+      belongs in bin 0 on every grid, so it is recorded even before any
+      nonzero sample has established a range (``hist_amax`` stays 0.0 until
+      one does).
     """
     flat = x.detach().reshape(-1).float().abs()
-    amax = float(flat.max()) if flat.numel() else 0.0
-    if amax == 0.0:
-        return hist, hist_amax
+    if not flat.numel():
+        return hist, hist_amax, top
+    amax = float(flat.max())
     if hist is None:
         hist = torch.zeros(HIST_BINS, dtype=torch.float64)
+        hist_amax = 0.0
+    if hist_amax == 0.0:
+        # Only zeros so far (all of them in bin 0): any range works, so the
+        # first nonzero batch establishes it directly.
         hist_amax = amax
     while hist_amax < amax:
         merged = hist.reshape(-1, 2).sum(dim=1)
         hist = torch.cat([merged, torch.zeros_like(merged)])
+        # Samples exactly on the old top edge belong to the new grid's
+        # left-inclusive bin starting there, not the merged lower bin.
+        hist[HIST_BINS // 2 - 1] -= top
+        hist[HIST_BINS // 2] += top
+        top = 0.0
         hist_amax *= 2.0
+    if hist_amax == 0.0:
+        # This batch is all zeros too; zeros land in bin 0 on every grid.
+        hist[0] += float(flat.numel())
+        return hist, hist_amax, top
     for chunk in flat.split(_HISTC_CHUNK):
         hist += torch.histc(chunk, bins=HIST_BINS, min=0.0, max=hist_amax).double().cpu()
-    return hist, hist_amax
+    top += float((flat == hist_amax).sum())
+    return hist, hist_amax, top
+
+
+def _int8_qmax(one_sided: bool) -> int:
+    return (_INT8_LEVELS_ONE_SIDED if one_sided else _INT8_LEVELS) - 1
 
 
 def _candidate_indices(start: int) -> torch.Tensor:
@@ -67,23 +103,40 @@ def _candidate_indices(start: int) -> torch.Tensor:
     return torch.tensor(idx, dtype=torch.long)
 
 
-def _reconstruct(centers: torch.Tensor, amaxes: torch.Tensor, aformat: str) -> torch.Tensor:
+def _reconstruct(
+    centers: torch.Tensor, amaxes: torch.Tensor, aformat: str, one_sided: bool
+) -> torch.Tensor:
     """Dequantized value of each bin center under each candidate amax.
 
     Returns [candidates, bins]. Saturation is part of the codebook clamp, so
-    clipping error and rounding error come out of the same formula.
+    clipping error and rounding error come out of the same formula. The int8
+    branch mirrors ``fake_quant_int8_affine`` on the window the calibrated
+    module will actually use: round to a uniform grid of ``qmax`` steps over
+    [0, amax], clamp at ``qmax``.
     """
     if aformat == "fp8":
         scale = (amaxes / E4M3_MAX).clamp_min(_EPS).unsqueeze(1)
         scaled = (centers.unsqueeze(0) / scale).clamp(max=E4M3_MAX).float()
         return scaled.to(torch.float8_e4m3fn).double() * scale
-    scale = (amaxes / (_INT8_LEVELS - 1)).clamp_min(_EPS).unsqueeze(1)
-    codes = torch.round(centers.unsqueeze(0) / scale).clamp(max=_INT8_LEVELS - 1)
+    qmax = _int8_qmax(one_sided)
+    scale = (amaxes / qmax).clamp_min(_EPS).unsqueeze(1)
+    codes = torch.round(centers.unsqueeze(0) / scale).clamp(max=qmax)
     return codes * scale
 
 
-def mse_amax(hist: torch.Tensor, hist_amax: float, aformat: str = "int8") -> float:
-    """Clipping threshold minimizing histogram-weighted reconstruction MSE."""
+def mse_amax(
+    hist: torch.Tensor,
+    hist_amax: float,
+    aformat: str = "int8",
+    one_sided: bool = False,
+) -> float:
+    """Clipping threshold minimizing histogram-weighted reconstruction MSE.
+
+    ``one_sided`` marks distributions whose observed signed range never
+    crosses zero (post-ReLU activations): the deployed affine window then
+    spends all 256 int8 codes on one side, doubling the resolution the
+    sweep must simulate. Ignored for fp8, whose codebook is symmetric.
+    """
     hist = hist.double()
     if float(hist.sum()) == 0.0:
         return hist_amax
@@ -92,7 +145,7 @@ def mse_amax(hist: torch.Tensor, hist_amax: float, aformat: str = "int8") -> flo
 
     def sweep(indices: torch.Tensor) -> int:
         amaxes = indices.double() * bin_width
-        recon = _reconstruct(centers, amaxes, aformat)
+        recon = _reconstruct(centers, amaxes, aformat, one_sided)
         losses = ((centers.unsqueeze(0) - recon) ** 2 * hist.unsqueeze(0)).sum(dim=1)
         return int(indices[int(torch.argmin(losses))])
 
@@ -103,7 +156,7 @@ def mse_amax(hist: torch.Tensor, hist_amax: float, aformat: str = "int8") -> flo
     return sweep(fine) * bin_width
 
 
-def _quantized_codes(i: int, bin_width: float, aformat: str) -> torch.Tensor:
+def _quantized_codes(i: int, bin_width: float, aformat: str, levels: int) -> torch.Tensor:
     """Group id of each of the first ``i`` bins under a clip at edge ``i``."""
     if aformat == "fp8":
         centers = (torch.arange(i, dtype=torch.float64) + 0.5) * bin_width
@@ -112,23 +165,32 @@ def _quantized_codes(i: int, bin_width: float, aformat: str) -> torch.Tensor:
         _, codes = torch.unique(snapped.float(), sorted=True, return_inverse=True)
         return codes
     # Uniform merge of i bins into the int8 level groups.
-    return torch.arange(i) * _INT8_LEVELS // i
+    return torch.arange(i) * levels // i
 
 
-def entropy_amax(hist: torch.Tensor, hist_amax: float, aformat: str = "int8") -> float:
+def entropy_amax(
+    hist: torch.Tensor,
+    hist_amax: float,
+    aformat: str = "int8",
+    one_sided: bool = False,
+) -> float:
     """Clipping threshold minimizing KL(reference || quantized) divergence.
 
     The reference keeps the clipped tail (saturated into its top bin); the
     quantized distribution is built from the in-range mass only, grouped by
     quantization code and spread back uniformly over that code's occupied
     bins. The asymmetry is what makes aggressive clipping cost divergence.
+    ``one_sided`` has the same meaning as in :func:`mse_amax`: the deployed
+    one-sided int8 window carries 256 codes, so the grouping and the sweep
+    floor use 256 levels instead of the symmetric 128-level stand-in.
     """
     hist = hist.double()
     if float(hist.sum()) == 0.0:
         return hist_amax
     bin_width = hist_amax / HIST_BINS
+    levels = _int8_qmax(one_sided) + 1 if aformat != "fp8" else _INT8_LEVELS
     best_i, best_kl = HIST_BINS, float("inf")
-    for i in _candidate_indices(start=_INT8_LEVELS).tolist():
+    for i in _candidate_indices(start=levels).tolist():
         inside = hist[:i]
         if float(inside.sum()) == 0.0:
             continue
@@ -136,7 +198,7 @@ def entropy_amax(hist: torch.Tensor, hist_amax: float, aformat: str = "int8") ->
         reference[-1] += hist[i:].sum()
         reference = reference / reference.sum()
 
-        codes = _quantized_codes(i, bin_width, aformat)
+        codes = _quantized_codes(i, bin_width, aformat, levels)
         ncodes = int(codes[-1]) + 1
         grouped = torch.zeros(ncodes, dtype=torch.float64).scatter_add_(0, codes, inside)
         occupied = torch.zeros(ncodes, dtype=torch.float64).scatter_add_(

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -149,7 +149,11 @@ class _ActObserverMixin:
 
     def _observe(self, x: torch.Tensor):
         with torch.no_grad():
-            if getattr(self, "_q_obs_method", "minmax") == "percentile":
+            method = getattr(self, "_q_obs_method", "minmax")
+            if method in ("mse", "entropy"):
+                self._observe_histogram(x)
+                return
+            if method == "percentile":
                 # Mean of per-batch (0.1%, 99.9%) quantiles: robust to the
                 # activation outliers that make pure min/max ranges crush
                 # int8 resolution (worst on the smallest models). Strided
@@ -179,15 +183,75 @@ class _ActObserverMixin:
                 self._q_act_hi.copy_(hi)
                 self._q_calibrated.fill_(1)
 
+    def _observe_histogram(self, x: torch.Tensor):
+        """Accumulate the |x| histogram the mse/entropy sweeps consume."""
+        from .calibrate import accumulate_abs_histogram
+
+        x_lo = float(x.detach().amin())
+        x_hi = float(x.detach().amax())
+        lo_run = getattr(self, "_q_obs_lo_run", None)
+        if lo_run is None:
+            self._q_obs_lo_run, self._q_obs_hi_run = x_lo, x_hi
+        else:
+            self._q_obs_lo_run = min(lo_run, x_lo)
+            self._q_obs_hi_run = max(self._q_obs_hi_run, x_hi)
+        self._q_obs_hist, self._q_obs_hist_amax = accumulate_abs_histogram(
+            getattr(self, "_q_obs_hist", None),
+            getattr(self, "_q_obs_hist_amax", 0.0),
+            x,
+        )
+
     def finalize_observation(self):
-        """Write percentile statistics into the calibrated range buffers."""
+        """Write the collected statistics into the calibrated range buffers."""
+        if hasattr(self, "_q_obs_lo_run"):
+            from .calibrate import entropy_amax, mse_amax
+
+            hist = getattr(self, "_q_obs_hist", None)
+            if hist is None:
+                # Every calibration batch was all zeros.
+                lo, hi = 0.0, 0.0
+            else:
+                select = (
+                    mse_amax
+                    if getattr(self, "_q_obs_method", "minmax") == "mse"
+                    else entropy_amax
+                )
+                amax = select(
+                    hist,
+                    self._q_obs_hist_amax,
+                    getattr(self, "_q_aformat", "int8"),
+                )
+                # The sweep chose a symmetric clip; intersect it with the
+                # observed signed range so one-sided activations (post-ReLU)
+                # keep their one-sided affine window.
+                lo = max(self._q_obs_lo_run, -amax)
+                hi = min(self._q_obs_hi_run, amax)
+                if lo > hi:
+                    # A near-constant one-sided distribution can put all its
+                    # mass inside the last histogram bin, letting the sweep
+                    # return an amax a fraction of a bin below max|x| and
+                    # inverting the intersection. Fall back to the observed
+                    # window rather than emit a degenerate range.
+                    lo, hi = self._q_obs_lo_run, self._q_obs_hi_run
+            with torch.no_grad():
+                self._q_act_lo.fill_(lo)
+                self._q_act_hi.fill_(hi)
+                self._q_calibrated.fill_(1)
         n = getattr(self, "_q_obs_n", 0)
         if n:
             with torch.no_grad():
                 self._q_act_lo.fill_(self._q_obs_lo_sum / n)
                 self._q_act_hi.fill_(self._q_obs_hi_sum / n)
                 self._q_calibrated.fill_(1)
-        for attr in ("_q_obs_lo_sum", "_q_obs_hi_sum", "_q_obs_n"):
+        for attr in (
+            "_q_obs_lo_sum",
+            "_q_obs_hi_sum",
+            "_q_obs_n",
+            "_q_obs_lo_run",
+            "_q_obs_hi_run",
+            "_q_obs_hist",
+            "_q_obs_hist_amax",
+        ):
             if hasattr(self, attr):
                 delattr(self, attr)
 

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -195,10 +195,15 @@ class _ActObserverMixin:
         else:
             self._q_obs_lo_run = min(lo_run, x_lo)
             self._q_obs_hi_run = max(self._q_obs_hi_run, x_hi)
-        self._q_obs_hist, self._q_obs_hist_amax = accumulate_abs_histogram(
+        (
+            self._q_obs_hist,
+            self._q_obs_hist_amax,
+            self._q_obs_hist_top,
+        ) = accumulate_abs_histogram(
             getattr(self, "_q_obs_hist", None),
             getattr(self, "_q_obs_hist_amax", 0.0),
             x,
+            getattr(self, "_q_obs_hist_top", 0.0),
         )
 
     def finalize_observation(self):
@@ -207,8 +212,9 @@ class _ActObserverMixin:
             from .calibrate import entropy_amax, mse_amax
 
             hist = getattr(self, "_q_obs_hist", None)
-            if hist is None:
-                # Every calibration batch was all zeros.
+            if hist is None or getattr(self, "_q_obs_hist_amax", 0.0) == 0.0:
+                # Every calibration sample was zero: mass sits in bin 0 and
+                # no range was ever established.
                 lo, hi = 0.0, 0.0
             else:
                 select = (
@@ -220,6 +226,11 @@ class _ActObserverMixin:
                     hist,
                     self._q_obs_hist_amax,
                     getattr(self, "_q_aformat", "int8"),
+                    # One-sided (post-ReLU style) distributions deploy all
+                    # 256 int8 codes on one side of zero after the window
+                    # intersection below; the sweep must simulate that
+                    # resolution or it systematically over-clips.
+                    one_sided=self._q_obs_lo_run >= 0.0 or self._q_obs_hi_run <= 0.0,
                 )
                 # The sweep chose a symmetric clip; intersect it with the
                 # observed signed range so one-sided activations (post-ReLU)
@@ -251,6 +262,7 @@ class _ActObserverMixin:
             "_q_obs_hi_run",
             "_q_obs_hist",
             "_q_obs_hist_amax",
+            "_q_obs_hist_top",
         ):
             if hasattr(self, attr):
                 delattr(self, attr)

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -159,7 +159,7 @@ def test_histogram_calibrators_clip_outliers():
     )
 
     x = _outlier_data()
-    hist, hist_amax = accumulate_abs_histogram(None, 0.0, x)
+    hist, hist_amax, _ = accumulate_abs_histogram(None, 0.0, x)
     assert hist_amax == 25.0
     for select in (mse_amax, entropy_amax):
         chosen = select(hist, hist_amax)
@@ -172,7 +172,7 @@ def test_mse_amax_keeps_clean_uniform_range():
 
     torch.manual_seed(0)
     u = torch.rand(100_000) * 2 - 1
-    hist, hist_amax = accumulate_abs_histogram(None, 0.0, u)
+    hist, hist_amax, _ = accumulate_abs_histogram(None, 0.0, u)
     assert mse_amax(hist, hist_amax) > 0.95 * hist_amax
 
 
@@ -184,8 +184,8 @@ def test_histogram_calibrators_deterministic():
     )
 
     x = _outlier_data()
-    h1, a1 = accumulate_abs_histogram(None, 0.0, x)
-    h2, a2 = accumulate_abs_histogram(None, 0.0, x.clone())
+    h1, a1, _ = accumulate_abs_histogram(None, 0.0, x)
+    h2, a2, _ = accumulate_abs_histogram(None, 0.0, x.clone())
     assert a1 == a2
     assert torch.equal(h1, h2)
     assert mse_amax(h1, a1) == mse_amax(h2, a2)
@@ -196,11 +196,107 @@ def test_histogram_range_growth_preserves_counts():
     from libreyolo.quant.calibrate import accumulate_abs_histogram
 
     torch.manual_seed(1)
-    hist, amax = accumulate_abs_histogram(None, 0.0, torch.randn(50_000))
+    hist, amax, top = accumulate_abs_histogram(None, 0.0, torch.randn(50_000))
     assert amax < 25.0
-    hist, amax = accumulate_abs_histogram(hist, amax, _outlier_data())
+    hist, amax, top = accumulate_abs_histogram(hist, amax, _outlier_data(), top)
     assert amax >= 25.0  # range doubled to cover the spike
     assert float(hist.sum()) == 450_000.0  # pair-merge rescale loses no counts
+
+
+def test_one_sided_mse_sweep_matches_deployed_codebook():
+    """Regression: the sweep used to simulate a symmetric 128-level codebook
+    while the deployed one-sided affine window carries all 256 int8 codes,
+    so post-ReLU distributions were judged at half the real resolution and
+    systematically over-clipped. Reviewer case: a positive gaussian bulk
+    plus one far outlier made mse pick a window whose TRUE fake-quant error
+    was 24 percent worse than plain minmax."""
+    from libreyolo.quant.calibrate import accumulate_abs_histogram, mse_amax
+
+    torch.manual_seed(0)
+    x = (torch.randn(200_000) * 0.05 + 3.0).clamp_min(0.0)
+    x[0] = 8.0
+    hist, hist_amax, _ = accumulate_abs_histogram(None, 0.0, x)
+    amax = mse_amax(hist, hist_amax, one_sided=True)
+    # The buggy sweep chose 3.97 here; the fixed one must not clip so deep
+    # that the deployed reconstruction loses to the minmax window.
+    assert amax > 4.0
+    assert _recon_mse(x, amax) <= _recon_mse(x, float(x.abs().max()))
+
+
+def test_histogram_accumulation_matches_direct_any_split():
+    """Property: the accumulated histogram equals a direct ``torch.histc``
+    of the concatenated data on the final grid, bit for bit, for any batch
+    split, including samples exactly on old and new top edges (which move
+    across a pair-merge boundary when the range doubles) and all-zero
+    batches (whose mass carries no range but still belongs in bin 0)."""
+    from libreyolo.quant.calibrate import HIST_BINS, accumulate_abs_histogram
+
+    torch.manual_seed(0)
+    parts = [
+        torch.full((1000,), 1.0),  # sits exactly on the first top edge
+        torch.zeros(5_000),  # all-zero batch: mass but no range
+        torch.tensor([2.0]),  # doubles the range; 1.0 becomes interior
+        torch.rand(30_000) * 4.0,  # bulk below the final top edge
+        torch.tensor([1.0, 2.0, 4.0]),  # doubles again; old edges revisited
+        torch.zeros(2_000),
+    ]
+    data = torch.cat(parts)
+
+    def accumulate(batches):
+        hist, amax, top = None, 0.0, 0.0
+        for b in batches:
+            hist, amax, top = accumulate_abs_histogram(hist, amax, b, top)
+        return hist, amax
+
+    results = [
+        accumulate([data]),
+        accumulate(parts),
+        accumulate(list(data.split(997))),
+    ]
+    # Every tested split starts from a max that the 4.0 global max is a
+    # power-of-two multiple of, so all splits share the same final grid.
+    ref_hist, ref_amax = results[0]
+    assert ref_amax == 4.0
+    direct = torch.histc(data.abs(), bins=HIST_BINS, min=0.0, max=4.0).double()
+    assert torch.equal(ref_hist, direct)
+    for hist, amax in results[1:]:
+        assert amax == ref_amax
+        assert torch.equal(hist, ref_hist)
+    # The extra split prepends 7000 more zeros; account for them separately.
+    extra_hist, extra_amax = accumulate([torch.zeros(7_000), data])
+    assert extra_amax == 4.0
+    assert float(extra_hist[0]) == float(ref_hist[0]) + 7_000.0
+    assert torch.equal(extra_hist[1:], ref_hist[1:])
+
+
+def test_histogram_partition_invariance_with_zero_batches():
+    """Regression: an all-zero batch used to be dropped from the histogram,
+    so the final window depended on how the same samples were batched
+    (measured: entropy chose 2.0 with zeros in their own batch versus 0.125
+    with the identical multiset concatenated)."""
+    torch.manual_seed(0)
+    uni = torch.rand(10_000) * 2.0
+    zeros = torch.zeros(100_000)
+    partitions = [
+        [zeros, uni],
+        [uni, zeros],
+        [torch.cat([zeros, uni])],
+        [zeros[:50_000], uni, zeros[50_000:]],
+    ]
+    for method in ("mse", "entropy"):
+        windows = []
+        for batches in partitions:
+            q = QuantConv2d.from_float(nn.Conv2d(1, 4, 1))
+            q._q_obs_method = method
+            q._q_observing = True
+            with torch.no_grad():
+                for b in batches:
+                    q(b.reshape(1, 1, 1, -1))
+            q._q_observing = False
+            q.finalize_observation()
+            assert q.q_calibrated, method
+            windows.append((float(q._q_act_lo), float(q._q_act_hi)))
+        assert len(set(windows)) == 1, (method, windows)
 
 
 def test_histogram_observation_clips_below_minmax():

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -123,8 +123,189 @@ def test_percentile_observation_rejects_outliers():
 
 
 def test_invalid_calibration_algorithm_rejected(yolo9t):
-    with pytest.raises(QuantizationError, match="calibration algorithm"):
-        yolo9t.quantize(recipe="int8", calib=None, algorithm="entropy")
+    # The error must list the valid choices, including the histogram pair.
+    with pytest.raises(
+        QuantizationError, match="calibration algorithm.*mse, entropy"
+    ):
+        yolo9t.quantize(recipe="int8", calib=None, algorithm="kldiv")
+
+
+# ---------------------------------------------------------------------------
+# Histogram calibrators (mse / entropy)
+# ---------------------------------------------------------------------------
+
+
+def _outlier_data():
+    """Gaussian bulk with a lone symmetric spike pair far outside it."""
+    torch.manual_seed(0)
+    x = torch.randn(400_000)
+    x[0], x[1] = 25.0, -25.0
+    return x
+
+
+def _recon_mse(x, amax):
+    from libreyolo.quant.fake_quant import fake_quant_int8_affine as fq
+
+    lo = torch.tensor([max(float(x.min()), -amax)])
+    hi = torch.tensor([min(float(x.max()), amax)])
+    return float(((x - fq(x, lo, hi)) ** 2).mean())
+
+
+def test_histogram_calibrators_clip_outliers():
+    from libreyolo.quant.calibrate import (
+        accumulate_abs_histogram,
+        entropy_amax,
+        mse_amax,
+    )
+
+    x = _outlier_data()
+    hist, hist_amax = accumulate_abs_histogram(None, 0.0, x)
+    assert hist_amax == 25.0
+    for select in (mse_amax, entropy_amax):
+        chosen = select(hist, hist_amax)
+        assert chosen < hist_amax, select.__name__
+        assert _recon_mse(x, chosen) <= _recon_mse(x, hist_amax), select.__name__
+
+
+def test_mse_amax_keeps_clean_uniform_range():
+    from libreyolo.quant.calibrate import accumulate_abs_histogram, mse_amax
+
+    torch.manual_seed(0)
+    u = torch.rand(100_000) * 2 - 1
+    hist, hist_amax = accumulate_abs_histogram(None, 0.0, u)
+    assert mse_amax(hist, hist_amax) > 0.95 * hist_amax
+
+
+def test_histogram_calibrators_deterministic():
+    from libreyolo.quant.calibrate import (
+        accumulate_abs_histogram,
+        entropy_amax,
+        mse_amax,
+    )
+
+    x = _outlier_data()
+    h1, a1 = accumulate_abs_histogram(None, 0.0, x)
+    h2, a2 = accumulate_abs_histogram(None, 0.0, x.clone())
+    assert a1 == a2
+    assert torch.equal(h1, h2)
+    assert mse_amax(h1, a1) == mse_amax(h2, a2)
+    assert entropy_amax(h1, a1) == entropy_amax(h2, a2)
+
+
+def test_histogram_range_growth_preserves_counts():
+    from libreyolo.quant.calibrate import accumulate_abs_histogram
+
+    torch.manual_seed(1)
+    hist, amax = accumulate_abs_histogram(None, 0.0, torch.randn(50_000))
+    assert amax < 25.0
+    hist, amax = accumulate_abs_histogram(hist, amax, _outlier_data())
+    assert amax >= 25.0  # range doubled to cover the spike
+    assert float(hist.sum()) == 450_000.0  # pair-merge rescale loses no counts
+
+
+def test_histogram_observation_clips_below_minmax():
+    conv = nn.Conv2d(3, 8, 3, padding=1)
+
+    def calibrate(method):
+        q = QuantConv2d.from_float(conv)
+        q._q_obs_method = method
+        q._q_observing = True
+        torch.manual_seed(0)
+        with torch.no_grad():
+            for _ in range(4):
+                x = torch.randn(2, 3, 64, 64)
+                x[0, 0, 0, 0] = 50.0  # single extreme outlier per batch
+                q(x)
+        q._q_observing = False
+        q.finalize_observation()
+        assert q.q_calibrated
+        # Observer scratch state must not outlive finalization.
+        assert not hasattr(q, "_q_obs_hist")
+        assert not hasattr(q, "_q_obs_lo_run")
+        return float(q._q_act_lo), float(q._q_act_hi)
+
+    _, hi_minmax = calibrate("minmax")
+    assert hi_minmax >= 50.0
+    for method in ("mse", "entropy"):
+        lo, hi = calibrate(method)
+        assert hi < hi_minmax, method
+        assert lo < 0 < hi, method
+
+
+def test_histogram_constant_one_sided_activation_keeps_observed_window():
+    """A near-constant one-sided input can put all its mass in the last
+    histogram bin, letting the sweep pick an amax a fraction of a bin below
+    max|x|. The intersection must not invert into an empty window."""
+    for method in ("mse", "entropy"):
+        q = QuantConv2d.from_float(nn.Conv2d(3, 8, 3, padding=1))
+        q._q_obs_method = method
+        q._q_observing = True
+        with torch.no_grad():
+            q(torch.full((1, 3, 16, 16), -3.0))
+        q._q_observing = False
+        q.finalize_observation()
+        assert q.q_calibrated, method
+        lo, hi = float(q._q_act_lo), float(q._q_act_hi)
+        assert lo <= hi, method
+        assert lo == -3.0 and hi == -3.0, method
+        with torch.no_grad():
+            out = q(torch.full((1, 3, 16, 16), -3.0))
+        assert torch.isfinite(out).all()
+
+
+def test_histogram_calibration_all_zero_activations():
+    for method in ("mse", "entropy"):
+        q = QuantConv2d.from_float(nn.Conv2d(3, 8, 3, padding=1))
+        q._q_obs_method = method
+        q._q_observing = True
+        with torch.no_grad():
+            q(torch.zeros(1, 3, 16, 16))
+        q._q_observing = False
+        q.finalize_observation()
+        assert q.q_calibrated, method
+        assert float(q._q_act_lo) == 0.0 and float(q._q_act_hi) == 0.0
+        with torch.no_grad():
+            out = q(torch.randn(1, 3, 16, 16))
+        assert torch.isfinite(out).all()
+
+
+def test_histogram_single_batch_calibration():
+    torch.manual_seed(0)
+    x = torch.randn(1, 3, 32, 32)
+    for method in ("mse", "entropy"):
+        q = QuantConv2d.from_float(nn.Conv2d(3, 8, 3, padding=1))
+        q._q_obs_method = method
+        q._q_observing = True
+        with torch.no_grad():
+            q(x)
+        q._q_observing = False
+        q.finalize_observation()
+        assert q.q_calibrated, method
+        assert float(q._q_act_lo) < 0 < float(q._q_act_hi)
+        assert float(q._q_act_lo) >= float(x.min())
+        assert float(q._q_act_hi) <= float(x.max())
+
+
+def test_histogram_negative_skew_symmetric_quant():
+    # All-negative activations under the symmetric fp8 activation format:
+    # the chosen window must stay one-sided, not get mirrored around zero.
+    torch.manual_seed(0)
+    data = -torch.randn(4, 3, 32, 32).abs() - 0.01
+    for method in ("mse", "entropy"):
+        q = QuantConv2d.from_float(nn.Conv2d(3, 8, 3, padding=1))
+        q._q_wformat = q._q_aformat = "fp8"
+        q._q_obs_method = method
+        q._q_observing = True
+        with torch.no_grad():
+            q(data)
+        q._q_observing = False
+        q.finalize_observation()
+        assert q.q_calibrated, method
+        assert float(q._q_act_lo) < 0.0
+        assert float(q._q_act_hi) < 0.0
+        with torch.no_grad():
+            out = q(data)
+        assert torch.isfinite(out).all()
 
 
 def test_multi_batch_observation_widens_ranges():
@@ -594,6 +775,61 @@ def test_save_load_roundtrip(tmp_path, yolo9t):
     assert set(src.keys()) == set(dst.keys())
     for key in src:
         assert torch.equal(src[key].cpu(), dst[key].cpu()), key
+
+
+class _StubCalibLoader:
+    """Two synthetic calibration batches, no dataset download."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def __iter__(self):
+        import numpy as np
+
+        rng = np.random.default_rng(0)
+        for _ in range(2):
+            yield rng.random((1, 3, 640, 640), dtype=np.float32)
+
+
+@pytest.mark.parametrize("algorithm", ["mse", "entropy"])
+def test_quantize_e2e_histogram_algorithms(monkeypatch, yolo9t, algorithm):
+    monkeypatch.setattr(
+        "libreyolo.export.calibration.CalibrationDataLoader", _StubCalibLoader
+    )
+    yolo9t.quantize(
+        recipe="int8", calib="x", samples=2, batch=1,
+        algorithm=algorithm, verbose=False,
+    )
+    info = yolo9t.quant_info()
+    assert info["calib_algorithm"] == algorithm
+    assert info["calibrated"]
+    quant = [m for m in yolo9t.model.modules() if isinstance(m, QuantConv2d)]
+    assert quant and all(m.q_calibrated for m in quant)
+    assert all(not hasattr(m, "_q_obs_hist") for m in quant)
+    assert all(float(m._q_act_hi) > float(m._q_act_lo) for m in quant)
+    yolo9t.model.eval()
+    with torch.no_grad():
+        out = yolo9t.model(torch.randn(1, 3, 640, 640))
+    assert torch.isfinite(_leaf(out)).all()
+
+
+def test_quantized_onnx_export_with_histogram_scales(tmp_path, monkeypatch, yolo9t):
+    onnx = pytest.importorskip("onnx")
+    monkeypatch.setattr(
+        "libreyolo.export.calibration.CalibrationDataLoader", _StubCalibLoader
+    )
+    yolo9t.quantize(
+        recipe="int8", calib="x", samples=2, batch=1,
+        algorithm="mse", verbose=False,
+    )
+    ckpt = tmp_path / "LibreYOLO9t-int8-mse.pt"
+    yolo9t.save(str(ckpt))
+    reloaded = LibreYOLO9(str(ckpt), size="t", device="cpu")
+    assert reloaded.quant_info()["calib_algorithm"] == "mse"
+    path = reloaded.export(format="onnx", simplify=False)
+    graph = onnx.load(path).graph
+    n_q = sum(1 for n in graph.node if n.op_type == "QuantizeLinear")
+    assert n_q > 100, f"expected QDQ pairs with mse-calibrated scales, got {n_q}"
 
 
 def test_export_rejected_for_fp16_and_wrong_formats(yolo9t):


### PR DESCRIPTION
Part of #768 (item 1.1).

- New libreyolo/quant/calibrate.py: 2048-bin absolute-value histogram (float64, exact pair-merge range doubling, bit-identical to a direct histogram for any batch split) + mse and entropy amax sweeps.
- mse: coarse-then-fine sweep minimizing histogram-weighted reconstruction error, simulated at the deployed format: full 256-code affine codebook for one-sided (post-ReLU) windows, symmetric stand-in for two-sided, real E4M3 cast for fp8.
- entropy: KL sweep pricing clipped mass.
- Wired through the activation observer mixin: applies to every calibrated recipe (int8, fp8, w4a8, int2). Weights keep per-channel abs-max. "auto" still resolves to minmax; no existing behavior changes.
- Measured: on outlier-heavy one-sided data mse beats minmax at every tested scale; on gaussian+spikes int8, reconstruction MSE 3.20e-3 (minmax) vs 1.58e-3 (mse).
- 72 tests in test_quantize.py including partition invariance, boundary-exact accumulation, e2e model.quantize and QDQ ONNX export with histogram scales; full quant selection 98 passed.

## Code provenance

All code is original, written for this PR. Histogram-based mse/KL amax selection is a standard published calibration technique implemented from its definition; no third-party code was ported or adapted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds histogram-based MSE and entropy activation calibration to all calibrated quantization recipes while retaining minmax as the automatic default.
- Adds deterministic 2048-bin histogram accumulation and MSE/KL threshold sweeps.
- Integrates histogram observation and finalization into quantized convolution and linear modules.
- Exposes the algorithms through the Python API and CLI, with documentation and calibration, checkpoint, and ONNX tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no concrete blocking or independently actionable non-blocking defect remains.

The histogram lifecycle is transactional, temporary state is cleaned before persistence, and same-sign activation windows use the zero-based affine codebook modeled by the new sweeps.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/quant/calibrate.py | Adds deterministic histogram accumulation and format-aware MSE and entropy threshold selection without an accepted correctness issue. |
| libreyolo/quant/modules.py | Routes MSE and entropy observation through histogram state, writes finalized activation ranges, and removes temporary observer state. |
| libreyolo/quant/api.py | Adds MSE and entropy to the supported calibration algorithm contract while preserving the existing default. |
| tests/unit/test_quantize.py | Adds coverage for histogram partition invariance, boundary handling, algorithm behavior, model calibration, checkpoint reload, and ONNX export. |
| docs/quantization.md | Documents the new calibration algorithms, their codebook assumptions, costs, and accuracy caveats. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Calibration batches] --> B[Quantized module observers]
    B --> C[Absolute-value histogram]
    C --> D{Calibration algorithm}
    D -->|mse| E[Reconstruction-error sweep]
    D -->|entropy| F[KL-divergence sweep]
    E --> G[Selected activation amax]
    F --> G
    G --> H[Signed activation range]
    H --> I[Fake-quantized inference and export]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;upstream/d..."](https://github.com/libreyolo/libreyolo/commit/d4ac8178de036b738d2dd70d479260e4f979f284) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53397089)</sub>

**Context used:**

- Knowledge Base — [Kernel and quantization runtime](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/kernel-and-quantization.md)

<!-- /greptile_comment -->