### PR TITLE
Guard mid-training dataset mutations against persistent workers (#768 item 3.7)

### DIFF
--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -48,7 +48,7 @@ from ...data.dataset import COCODataset, YOLODataset
 from ...training.config import DEIMConfig, TrainConfig
 from ...training.scheduler import FlatCosineScheduler
 from ...training.optim import build_optimizer
-from ...training.trainer import BaseTrainer
+from ...training.trainer import BaseTrainer, ensure_mutation_reaches_workers
 from .loss import DEIMCriterion
 from .matcher import HungarianMatcher
 from .transforms import (
@@ -541,9 +541,11 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
+            ensure_mutation_reaches_workers(self.train_loader, ds, "set_epoch")
             ds.set_epoch(epoch)
         cf = getattr(self.train_loader, "collate_fn", None)
         if cf is not None and hasattr(cf, "set_epoch"):
+            ensure_mutation_reaches_workers(self.train_loader, cf, "set_epoch")
             cf.set_epoch(epoch)
 
         clip_max_norm = float(getattr(self.config, "clip_max_norm", 0.0))
@@ -677,9 +679,11 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
+            ensure_mutation_reaches_workers(self.train_loader, ds, "set_epoch")
             ds.set_epoch(epoch)
         cf = getattr(self.train_loader, "collate_fn", None)
         if cf is not None and hasattr(cf, "set_epoch"):
+            ensure_mutation_reaches_workers(self.train_loader, cf, "set_epoch")
             cf.set_epoch(epoch)
 
         clip_max_norm = float(getattr(self.config, "clip_max_norm", 0.0))

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -53,7 +53,7 @@ from ...training.config import (
 )
 from ...training.scheduler import FlatCosineScheduler
 from ...training.optim import build_optimizer
-from ...training.trainer import BaseTrainer
+from ...training.trainer import BaseTrainer, ensure_mutation_reaches_workers
 from .loss import DFINECriterion
 from .matcher import HungarianMatcher
 from .transforms import (
@@ -611,9 +611,11 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
+            ensure_mutation_reaches_workers(self.train_loader, ds, "set_epoch")
             ds.set_epoch(epoch)
         cf = getattr(self.train_loader, "collate_fn", None)
         if cf is not None and hasattr(cf, "set_epoch"):
+            ensure_mutation_reaches_workers(self.train_loader, cf, "set_epoch")
             cf.set_epoch(epoch)
 
         clip_max_norm = float(getattr(self.config, "clip_max_norm", 0.0))
@@ -747,9 +749,11 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
+            ensure_mutation_reaches_workers(self.train_loader, ds, "set_epoch")
             ds.set_epoch(epoch)
         cf = getattr(self.train_loader, "collate_fn", None)
         if cf is not None and hasattr(cf, "set_epoch"):
+            ensure_mutation_reaches_workers(self.train_loader, cf, "set_epoch")
             cf.set_epoch(epoch)
 
         clip_max_norm = float(getattr(self.config, "clip_max_norm", 0.0))

--- a/libreyolo/models/yolox/trainer.py
+++ b/libreyolo/models/yolox/trainer.py
@@ -8,7 +8,7 @@ loss extraction, and bias initialisation.
 import torch
 from typing import Dict, Type
 
-from libreyolo.training.trainer import BaseTrainer
+from libreyolo.training.trainer import BaseTrainer, ensure_mutation_reaches_workers
 from libreyolo.training.config import TrainConfig, YOLOXConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.augment import TrainTransform, MosaicMixupDataset
@@ -88,6 +88,9 @@ class YOLOXTrainer(BaseTrainer):
             raw.head.initialize_biases(0.01)
 
     def on_mosaic_disable(self):
+        ensure_mutation_reaches_workers(
+            self.train_loader, self.train_loader.dataset, "close_mosaic"
+        )
         self.train_loader.dataset.close_mosaic()
         raw = getattr(self.model, "module", self.model)
         raw.head.use_l1 = True

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -106,6 +106,40 @@ RECTANGULAR_TRAINING_TASKS = {
 _DEFAULT_RECTANGULAR_TRAINING_TASKS = frozenset({"detect"})
 
 
+def ensure_mutation_reaches_workers(loader, target, hook: str) -> None:
+    """Fail loudly when a main-process mutation of ``target`` cannot reach workers.
+
+    ``close_mosaic`` / ``set_epoch`` style hooks mutate the dataset (or
+    collate) object owned by the main process. Dataloader workers hold their
+    own copies: non-persistent workers are respawned every epoch and inherit
+    the mutated state, but persistent workers live for the whole run and
+    never re-copy it, so the mutation silently never applies and epoch-gated
+    augmentation scheduling (no-aug tail, stop_epoch gating) becomes a no-op.
+
+    ``target`` is the object about to be mutated (usually
+    ``loader.dataset``, or ``loader.collate_fn`` for collate-side epoch
+    gating). No-op when the loader has no workers, when workers are not
+    persistent, or when ``target`` does not implement ``hook``.
+    """
+    if loader is None or target is None:
+        return
+    if not callable(getattr(target, hook, None)):
+        return
+    num_workers = int(getattr(loader, "num_workers", 0) or 0)
+    if num_workers <= 0:
+        return
+    if not getattr(loader, "persistent_workers", False):
+        return
+    raise RuntimeError(
+        f"{type(target).__name__}.{hook}() would have no effect: the train "
+        f"dataloader runs num_workers={num_workers} with "
+        "persistent_workers=True, and persistent workers never observe "
+        "main-process dataset mutations, so augmentation scheduling would "
+        "silently stop working. Rebuild the dataloader after the mutation "
+        "or train with persistent_workers=False."
+    )
+
+
 class BaseTrainer(ABC):
     """Base trainer for all LibreYOLO model families.
 
@@ -346,6 +380,7 @@ class BaseTrainer(ABC):
         """Called when mosaic is disabled for final no-aug epochs."""
         dataset = getattr(self.train_loader, "dataset", None)
         if hasattr(dataset, "close_mosaic"):
+            ensure_mutation_reaches_workers(self.train_loader, dataset, "close_mosaic")
             dataset.close_mosaic()
 
     def on_forward(

--- a/tests/unit/test_persistent_worker_mutation_guard.py
+++ b/tests/unit/test_persistent_worker_mutation_guard.py
@@ -1,0 +1,167 @@
+"""Guard tests: main-process dataset mutations must not silently miss workers.
+
+Mid-training mutations (``close_mosaic`` for the no-aug tail, the DETR-style
+``set_epoch`` gating) only reach dataloader workers because the affected
+loaders run ``persistent_workers=False`` and respawn workers each epoch. With
+``persistent_workers=True`` the forked workers keep their stale dataset copy
+and the mutation is a silent no-op. ``ensure_mutation_reaches_workers`` turns
+that silent no-op into a loud RuntimeError.
+
+All loaders here use ``num_workers=0`` or plain fakes, so no subprocesses are
+spawned and no ``__main__`` guard is needed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from torch.utils.data import DataLoader, Dataset
+
+from libreyolo.training.trainer import BaseTrainer, ensure_mutation_reaches_workers
+
+pytestmark = pytest.mark.unit
+
+
+class _MosaicDataset(Dataset):
+    """Minimal dataset implementing the ``close_mosaic`` mutation hook."""
+
+    def __init__(self):
+        self.mosaic_closed = False
+
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, idx):
+        return idx
+
+    def close_mosaic(self):
+        self.mosaic_closed = True
+
+
+class _PlainDataset(Dataset):
+    """Dataset with no mutation hooks (the pose case)."""
+
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, idx):
+        return idx
+
+
+def _fake_loader(dataset, num_workers, persistent_workers):
+    """A crafted loader stand-in: real DataLoader refuses persistent_workers
+    without workers, and spawning real workers is not what these tests are
+    about."""
+    return SimpleNamespace(
+        dataset=dataset,
+        num_workers=num_workers,
+        persistent_workers=persistent_workers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ensure_mutation_reaches_workers
+# ---------------------------------------------------------------------------
+
+
+def test_guard_raises_on_persistent_workers_with_hook():
+    ds = _MosaicDataset()
+    loader = _fake_loader(ds, num_workers=2, persistent_workers=True)
+    with pytest.raises(RuntimeError, match="persistent_workers"):
+        ensure_mutation_reaches_workers(loader, ds, "close_mosaic")
+
+
+def test_guard_message_names_target_and_hook():
+    ds = _MosaicDataset()
+    loader = _fake_loader(ds, num_workers=2, persistent_workers=True)
+    with pytest.raises(RuntimeError, match=r"_MosaicDataset\.close_mosaic"):
+        ensure_mutation_reaches_workers(loader, ds, "close_mosaic")
+
+
+def test_guard_silent_without_workers():
+    ds = _MosaicDataset()
+    loader = _fake_loader(ds, num_workers=0, persistent_workers=True)
+    ensure_mutation_reaches_workers(loader, ds, "close_mosaic")
+
+
+def test_guard_silent_with_non_persistent_workers():
+    ds = _MosaicDataset()
+    loader = _fake_loader(ds, num_workers=2, persistent_workers=False)
+    ensure_mutation_reaches_workers(loader, ds, "close_mosaic")
+
+
+def test_guard_silent_when_target_lacks_hook():
+    # Persistent workers are fine when the dataset has no mutation hook:
+    # today's pose loaders (persistent_workers=True) must keep working.
+    ds = _PlainDataset()
+    loader = _fake_loader(ds, num_workers=2, persistent_workers=True)
+    ensure_mutation_reaches_workers(loader, ds, "close_mosaic")
+    ensure_mutation_reaches_workers(loader, ds, "set_epoch")
+
+
+def test_guard_silent_on_none_loader_or_target():
+    ds = _MosaicDataset()
+    ensure_mutation_reaches_workers(None, ds, "close_mosaic")
+    loader = _fake_loader(None, num_workers=2, persistent_workers=True)
+    ensure_mutation_reaches_workers(loader, None, "close_mosaic")
+
+
+def test_guard_checks_arbitrary_target_such_as_collate():
+    # deim/dfine also mutate the collate object per epoch; collate runs in
+    # the workers too, so the same guard applies.
+    class _Collate:
+        def set_epoch(self, epoch):
+            pass
+
+    cf = _Collate()
+    loader = _fake_loader(_PlainDataset(), num_workers=2, persistent_workers=True)
+    with pytest.raises(RuntimeError, match=r"_Collate\.set_epoch"):
+        ensure_mutation_reaches_workers(loader, cf, "set_epoch")
+
+
+def test_guard_silent_on_real_inline_dataloader():
+    ds = _MosaicDataset()
+    loader = DataLoader(ds, batch_size=2, num_workers=0)
+    ensure_mutation_reaches_workers(loader, ds, "close_mosaic")
+
+
+# ---------------------------------------------------------------------------
+# BaseTrainer.on_mosaic_disable behavior
+# ---------------------------------------------------------------------------
+
+
+def _call_on_mosaic_disable(loader):
+    """Invoke the base hook against a bare fake trainer (no full setup)."""
+    fake_trainer = SimpleNamespace(train_loader=loader)
+    BaseTrainer.on_mosaic_disable(fake_trainer)
+
+
+def test_on_mosaic_disable_still_closes_mosaic_inline():
+    ds = _MosaicDataset()
+    loader = DataLoader(ds, batch_size=2, num_workers=0)
+    _call_on_mosaic_disable(loader)
+    assert ds.mosaic_closed
+
+
+def test_on_mosaic_disable_still_noop_without_hook():
+    ds = _PlainDataset()
+    loader = DataLoader(ds, batch_size=2, num_workers=0)
+    _call_on_mosaic_disable(loader)
+
+
+def test_on_mosaic_disable_raises_before_mutating_persistent_loader():
+    ds = _MosaicDataset()
+    loader = _fake_loader(ds, num_workers=2, persistent_workers=True)
+    with pytest.raises(RuntimeError, match="persistent_workers"):
+        _call_on_mosaic_disable(loader)
+    # The failed close must not have half-applied in the main process.
+    assert not ds.mosaic_closed
+
+
+def test_on_mosaic_disable_allows_persistent_loader_without_hook():
+    # The live pose configuration: persistent workers, dataset without
+    # close_mosaic. Must stay a silent no-op.
+    ds = _PlainDataset()
+    loader = _fake_loader(ds, num_workers=2, persistent_workers=True)
+    _call_on_mosaic_disable(loader)


### PR DESCRIPTION
Part of #768 (item 3.7).

- Mid-training dataset mutations (close_mosaic in on_mosaic_disable, deim/dfine per-epoch set_epoch on dataset and collate) only reach dataloader workers because the affected loaders run persistent_workers=False today. With persistent workers the mutation silently never propagates and no-aug epochs become a no-op.
- No live bug on dev: the only persistent_workers=True loaders are pose loaders whose dataset has no mutation hooks. The safety is coincidental, and the yolo9 pose config already defaults persistent_workers=True, so a future landing could silently break augmentation scheduling.
- New ensure_mutation_reaches_workers helper raises RuntimeError when a hook-bearing target sits behind a persistent multi-worker loader; wired into BaseTrainer.on_mosaic_disable, the yolox override, and all four deim/dfine epoch-propagation blocks. Raise (not warn) matches the repo's fail-loudly precedent for silent-degradation misconfigurations.
- 12 new tests; mosaic/no_aug/trainer selections 205 passed, yolox 43 passed.

## Code provenance

All code is original, written for this PR.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a fail-fast guard for main-process dataset and collate mutations that cannot propagate to persistent dataloader workers.
- Applies the guard to mosaic shutdown in the shared and YOLOX trainers.
- Applies it to DEIM and D-FINE dataset/collate epoch propagation.
- Adds unit coverage for guarded and permitted loader configurations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete regressions identified in currently reachable training configurations.

The new guard is inactive for current DEIM, D-FINE, and YOLOX loaders because they do not enable persistent workers, while persistent-worker pose loaders lack the guarded mutation hooks.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/trainer.py | Adds the shared persistent-worker mutation guard and applies it to the base mosaic-disable hook without regressing current loader paths. |
| libreyolo/models/deim/trainer.py | Guards dataset and collate epoch propagation in both standard and accumulated training loops. |
| libreyolo/models/dfine/trainer.py | Guards dataset and collate epoch propagation in both standard and accumulated training loops. |
| libreyolo/models/yolox/trainer.py | Rejects unsupported persistent-worker configurations before disabling mosaic and enabling the L1 no-augmentation phase. |
| tests/unit/test_persistent_worker_mutation_guard.py | Covers hook detection, worker configurations, inline dataloaders, and base-trainer mutation behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Hook[Trainer invokes close_mosaic or set_epoch] --> Workers{num_workers > 0?}
    Workers -- No --> Mutate[Apply mutation]
    Workers -- Yes --> Persistent{persistent_workers enabled?}
    Persistent -- No --> Mutate
    Persistent -- Yes --> Fail[Raise RuntimeError before mutation]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Guard mid-training dataset mutations aga..."](https://github.com/libreyolo/libreyolo/commit/7e2ef7fbc413373381984c23b2570272845f37ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53399044)</sub>

**Context used:**

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)

<!-- /greptile_comment -->