### PR TITLE
Draw mosaic and mixup partners from annotated images (#768 item 4.1)

### DIFF
--- a/libreyolo/data/augment/yolo9.py
+++ b/libreyolo/data/augment/yolo9.py
@@ -466,6 +466,24 @@ class YOLO9MosaicMixupDataset:
         img, label = self.preproc(img, label, self.input_dim)
         return img, label, img_info, img_id
 
+    def _rand_partner_index(self):
+        """Sample a partner index, preferring images with annotations.
+
+        Uniform draws on background-heavy datasets frequently land on
+        label-free images, silently degrading mosaic tiles (and mixup
+        partners) to unsupervised pixels. Retry like the YOLOX mixup does;
+        if every sampled candidate is background, keep the last draw so
+        the augmentation still works on datasets with no foreground
+        labels. Extra RNG draws happen only after an empty candidate, so
+        fully annotated datasets sample identically.
+        """
+        index = 0
+        for _ in range(20):
+            index = random.randint(0, len(self.dataset) - 1)
+            if len(self.dataset.load_anno(index)) > 0:
+                break
+        return index
+
     def _get_mosaic_item(self, idx):
         """Get a mosaic-augmented item."""
         input_h, input_w = self.input_dim
@@ -474,8 +492,8 @@ class YOLO9MosaicMixupDataset:
         yc = int(random.uniform(0.5 * input_h, 1.5 * input_h))
         xc = int(random.uniform(0.5 * input_w, 1.5 * input_w))
 
-        # Get 4 random indices
-        indices = [idx] + [random.randint(0, len(self.dataset) - 1) for _ in range(3)]
+        # Get 4 random indices, preferring annotated partners
+        indices = [idx] + [self._rand_partner_index() for _ in range(3)]
 
         # Create mosaic canvas
         mosaic_img = np.full((input_h * 2, input_w * 2, 3), 114, dtype=np.uint8)
@@ -632,9 +650,10 @@ class YOLO9MosaicMixupDataset:
         then re-pad. Mirrors the shared YOLOX mixup, which merges labels before
         padding.
         """
-        # Get another random image (mixup only runs on the non-segment path,
-        # so _get_normal_item returns (img, label, ...); ignore the tail).
-        idx2 = random.randint(0, len(self.dataset) - 1)
+        # Get another random image, preferring an annotated partner (mixup
+        # only runs on the non-segment path, so _get_normal_item returns
+        # (img, label, ...); ignore the tail).
+        idx2 = self._rand_partner_index()
         img2, labels2, *_ = self._get_normal_item(idx2)
 
         # Mix images (beta(32, 32) ≈ 0.5, so both images are ~equally visible

--- a/libreyolo/data/augment/yolox.py
+++ b/libreyolo/data/augment/yolox.py
@@ -136,6 +136,23 @@ class MosaicMixupDataset:
         img, label = self.preproc(img, label, self.input_dim)
         return img, label, img_info, img_id
 
+    def _rand_partner_index(self):
+        """Sample a partner index, preferring images with annotations.
+
+        Uniform draws on background-heavy datasets frequently land on
+        label-free images, silently degrading mosaic tiles to unsupervised
+        pixels. Retry like ``_mixup`` does; if every sampled candidate is
+        background, keep the last draw so mosaic still works on datasets
+        with no foreground labels. Extra RNG draws happen only after an
+        empty candidate, so fully annotated datasets sample identically.
+        """
+        index = 0
+        for _ in range(20):
+            index = random.randint(0, len(self.dataset) - 1)
+            if len(self.dataset.load_anno(index)) > 0:
+                break
+        return index
+
     def _get_mosaic_item(self, idx):
         mosaic_labels = []
         input_h, input_w = self.input_dim[0], self.input_dim[1]
@@ -144,8 +161,8 @@ class MosaicMixupDataset:
         yc = int(random.uniform(0.5 * input_h, 1.5 * input_h))
         xc = int(random.uniform(0.5 * input_w, 1.5 * input_w))
 
-        # 3 additional image indices
-        indices = [idx] + [random.randint(0, len(self.dataset) - 1) for _ in range(3)]
+        # 3 additional image indices, preferring annotated partners
+        indices = [idx] + [self._rand_partner_index() for _ in range(3)]
 
         for i_mosaic, index in enumerate(indices):
             img, _labels, _, img_id = self.dataset.pull_item(index)

--- a/tests/unit/test_copy_paste.py
+++ b/tests/unit/test_copy_paste.py
@@ -223,6 +223,12 @@ class _SegDataset:
     def __len__(self):
         return self.n
 
+    def load_anno(self, idx):
+        return np.array(
+            [[10.0, 12.0, 45.0, 50.0, 1.0], [30.0, 25.0, 70.0, 60.0, 2.0]],
+            dtype=np.float32,
+        )
+
     def pull_item(self, idx):
         r = np.random.RandomState(100 + idx % 4)
         img = r.randint(0, 255, (70, 90, 3), dtype=np.uint8)

--- a/tests/unit/test_mosaic_partner_sampling.py
+++ b/tests/unit/test_mosaic_partner_sampling.py
@@ -1,0 +1,243 @@
+"""Mosaic/mixup partner sampling must prefer annotated images (issue #768).
+
+Partner draws used to be uniform over the whole dataset at three sites
+(YOLO9 mosaic, YOLOX mosaic, YOLO9 mixup). On background-heavy datasets that
+silently degraded mosaic tiles to unsupervised pixels. The fix retries the
+draw (up to 20 times, matching the in-repo YOLOX/YOLO-NAS mixup idiom) until
+an annotated partner is found, falling back to the last draw when the whole
+dataset is background.
+
+The retry consumes extra RNG draws ONLY after an empty candidate, so on a
+fully annotated dataset the augmentation output must stay bitwise identical
+to the pre-change behavior. That reference behavior (one uniform draw, no
+annotation check) is reimplemented inside this test via a subclass override
+and compared byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import pytest
+
+from libreyolo.data.augment.yolo9 import (
+    YOLO9MosaicMixupDataset,
+    YOLO9TrainTransform,
+)
+from libreyolo.data.augment.yolox import MosaicMixupDataset, TrainTransform
+
+pytestmark = pytest.mark.unit
+
+_BOXES = np.array(
+    [[8.0, 10.0, 40.0, 44.0, 0.0], [20.0, 18.0, 60.0, 52.0, 1.0]],
+    dtype=np.float32,
+)
+
+
+def _seed():
+    random.seed(1234)
+    np.random.seed(1234)
+
+
+class _FakeDataset:
+    """Minimal pull_item/load_anno dataset with controllable empty images.
+
+    Images come from per-index RandomState instances so they never touch the
+    global RNG stream (bitwise comparisons below depend on that).
+    """
+
+    def __init__(self, annotated):
+        self.annotated = list(annotated)
+        self.pulled = []
+
+    def __len__(self):
+        return len(self.annotated)
+
+    def load_anno(self, idx):
+        if self.annotated[idx]:
+            return _BOXES.copy()
+        return np.zeros((0, 5), dtype=np.float32)
+
+    def pull_item(self, idx):
+        self.pulled.append(idx)
+        rng = np.random.RandomState(1000 + idx)
+        img = rng.randint(0, 255, (72, 96, 3), dtype=np.uint8)
+        return img, self.load_anno(idx), (72, 96), idx
+
+
+class _UniformPartnerYOLO9(YOLO9MosaicMixupDataset):
+    """Reference (pre-change) sampling: one uniform draw, no annotation check."""
+
+    def _rand_partner_index(self):
+        return random.randint(0, len(self.dataset) - 1)
+
+
+class _UniformPartnerYOLOX(MosaicMixupDataset):
+    """Reference (pre-change) sampling: one uniform draw, no annotation check."""
+
+    def _rand_partner_index(self):
+        return random.randint(0, len(self.dataset) - 1)
+
+
+def _make_yolo9(cls, dataset, enable_mixup=False):
+    return cls(
+        dataset,
+        img_size=(64, 64),
+        mosaic=True,
+        preproc=YOLO9TrainTransform(max_labels=50, flip_prob=0.5, hsv_prob=1.0),
+        enable_mixup=enable_mixup,
+        mosaic_prob=1.0,
+        mixup_prob=1.0,
+    )
+
+
+def _make_yolox(cls, dataset, enable_mixup=False):
+    return cls(
+        dataset,
+        img_size=(64, 64),
+        mosaic=True,
+        preproc=TrainTransform(max_labels=50, flip_prob=0.5, hsv_prob=1.0),
+        enable_mixup=enable_mixup,
+        mosaic_prob=1.0,
+        mixup_prob=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RNG parity: fully annotated datasets must be bitwise identical to the
+# pre-change uniform sampling (the guard only draws extra RNG after an empty
+# candidate).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "guarded_cls,reference_cls,factory",
+    [
+        (YOLO9MosaicMixupDataset, _UniformPartnerYOLO9, _make_yolo9),
+        (MosaicMixupDataset, _UniformPartnerYOLOX, _make_yolox),
+    ],
+    ids=["yolo9", "yolox"],
+)
+def test_fully_annotated_dataset_is_bitwise_identical(
+    guarded_cls, reference_cls, factory
+):
+    annotated = [True] * 12
+    for item_idx in range(4):
+        _seed()
+        img_new, labels_new, *_ = factory(guarded_cls, _FakeDataset(annotated), True)[
+            item_idx
+        ]
+        _seed()
+        img_ref, labels_ref, *_ = factory(reference_cls, _FakeDataset(annotated), True)[
+            item_idx
+        ]
+        np.testing.assert_array_equal(np.asarray(img_new), np.asarray(img_ref))
+        np.testing.assert_array_equal(np.asarray(labels_new), np.asarray(labels_ref))
+
+
+# ---------------------------------------------------------------------------
+# Background-heavy datasets: the guard must (nearly) eliminate empty partners
+# while the reference sampling picks them at roughly the dataset's empty rate.
+# ---------------------------------------------------------------------------
+
+
+def _empty_partner_rate(ds, dataset, n_items=30):
+    """Fraction of partner pulls (everything after the item's own pull) that
+    landed on an image without annotations."""
+    empty = total = 0
+    _seed()
+    for i in range(n_items):
+        dataset.pulled = []
+        ds[i % len(dataset)]
+        for partner_idx in dataset.pulled[1:]:
+            total += 1
+            if not dataset.annotated[partner_idx]:
+                empty += 1
+    assert total >= 3 * n_items  # 3 mosaic partners per item at minimum
+    return empty / total
+
+
+@pytest.mark.parametrize(
+    "guarded_cls,reference_cls,factory",
+    [
+        (YOLO9MosaicMixupDataset, _UniformPartnerYOLO9, _make_yolo9),
+        (MosaicMixupDataset, _UniformPartnerYOLOX, _make_yolox),
+    ],
+    ids=["yolo9", "yolox"],
+)
+def test_background_heavy_dataset_prefers_annotated_partners(
+    guarded_cls, reference_cls, factory
+):
+    # 80% empty: every 5th image is annotated.
+    annotated = [i % 5 == 0 for i in range(40)]
+
+    dataset_ref = _FakeDataset(annotated)
+    rate_ref = _empty_partner_rate(factory(reference_cls, dataset_ref), dataset_ref)
+    dataset_new = _FakeDataset(annotated)
+    rate_new = _empty_partner_rate(factory(guarded_cls, dataset_new), dataset_new)
+
+    # Uniform sampling lands on background roughly 80% of the time.
+    assert rate_ref > 0.5, f"reference empty-partner rate unexpectedly low: {rate_ref}"
+    # With 20 retries at 20% annotated, the miss probability per partner is
+    # 0.8**20 (about 1%). Allow a little slack over the sampled draws.
+    assert rate_new <= 0.05, (
+        f"guarded empty-partner rate {rate_new} did not drop to ~0 "
+        f"(reference rate {rate_ref})"
+    )
+
+
+def test_yolo9_mixup_partner_prefers_annotated():
+    """The mixup partner draw (yolo9's third guarded site) must pick
+    annotated partners on a background-heavy dataset."""
+    annotated = [i % 5 == 0 for i in range(40)]
+    dataset = _FakeDataset(annotated)
+    ds = _make_yolo9(YOLO9MosaicMixupDataset, dataset, enable_mixup=True)
+
+    labels = np.zeros((50, 5), dtype=np.float32)
+    labels[:, 0] = -1
+    labels[0] = [0.0, 0.10, 0.10, 0.50, 0.50]
+    img = np.zeros((3, 64, 64), dtype=np.float32)
+
+    _seed()
+    empty = 0
+    n_draws = 50
+    for _ in range(n_draws):
+        dataset.pulled = []
+        ds._mixup(img.copy(), labels.copy())
+        assert len(dataset.pulled) == 1
+        if not dataset.annotated[dataset.pulled[0]]:
+            empty += 1
+    # The 20-retry guard misses with probability 0.8**20 (about 1%) per draw
+    # and then falls back to the last draw by design; uniform sampling would
+    # land on background ~80% of the time.
+    assert empty / n_draws <= 0.1, (
+        f"mixup drew background partners at rate {empty / n_draws} although "
+        "annotated images exist"
+    )
+
+
+# ---------------------------------------------------------------------------
+# All-background datasets: the fallback keeps the last draw; no infinite
+# loop, no crash, and the output carries no phantom labels.
+# ---------------------------------------------------------------------------
+
+
+def test_all_empty_dataset_yolo9_falls_back():
+    dataset = _FakeDataset([False] * 8)
+    ds = _make_yolo9(YOLO9MosaicMixupDataset, dataset, enable_mixup=True)
+    _seed()
+    img, labels, _info, _id = ds[0]
+    assert np.asarray(img).shape[-2:] == (64, 64)
+    labels = np.asarray(labels)
+    assert int((labels[:, 0] >= 0).sum()) == 0
+
+
+def test_all_empty_dataset_yolox_falls_back():
+    dataset = _FakeDataset([False] * 8)
+    ds = _make_yolox(MosaicMixupDataset, dataset, enable_mixup=True)
+    _seed()
+    img, labels, _info, _id = ds[0]
+    assert np.asarray(img).shape[-2:] == (64, 64)
+    # TrainTransform pads with zero rows; no real boxes may appear.
+    assert not np.any(np.asarray(labels)[:, 1:])


### PR DESCRIPTION
Part of #768 (item 4.1).

- Mosaic partner draws (yolo9, yolox) and yolo9's mixup partner draw sampled uniformly over the whole dataset, so on background-heavy datasets tiles silently degrade to unsupervised pixels. yolox/yolonas mixup already guarded against this; these three sites did not.
- New per-file _rand_partner_index helper (idiom kept per file, matching the deliberate drift): up to 20 draws, accept the first partner with annotations via load_anno (no RNG consumed by the check), fall back to the last draw on all-background data (no infinite loop, no behavior change there).
- Fully annotated datasets consume exactly one draw per partner: bitwise identical to before (asserted in tests, and all 6 mosaic/mixup golden cases replayed old-vs-new: identical on every array; the golden suite itself env-skips on this machine due to a pre-existing cv2 version pin).
- On an 80% background dataset the empty-partner rate drops from ~0.8 to under 0.05.
- New tests: 7 passed; aug/mosaic/mixup selection 114 passed, 41 env-skipped goldens (pre-existing).

## Code provenance

All code is original, written for this PR, extending the guard pattern already present in this repository's yolox/yolonas mixup.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates YOLO9 and YOLOX mosaic partner selection, plus YOLO9 mixup selection, to retry background-only candidates while preserving the final draw as a bounded fallback.
- Adds bounded annotated-partner sampling to both augmentation wrappers.
- Preserves the previous random stream for fully annotated datasets.
- Adds coverage for annotated, background-heavy, and entirely background datasets.
- Updates the copy-paste segmentation fixture to implement the annotation lookup used by partner selection.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness, compatibility, or security failure identified in supported training paths.

Current YOLO9 and YOLOX training callers wrap datasets whose annotations are preloaded and whose `load_anno` results match the labels returned by `pull_item`; the bounded retries therefore improve partner selection without adding costly I/O or changing fully annotated sampling.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/data/augment/yolo9.py | Adds bounded annotation-aware partner selection for YOLO9 mosaic and mixup without exposing a concrete regression in supported dataset paths. |
| libreyolo/data/augment/yolox.py | Applies the existing annotation-retry idiom to YOLOX mosaic partner draws using preloaded annotations. |
| tests/unit/test_copy_paste.py | Extends the segmentation test fixture with the annotation accessor required by the updated augmentation wrapper. |
| tests/unit/test_mosaic_partner_sampling.py | Covers random-stream parity, background-heavy selection, YOLO9 mixup selection, and bounded all-background fallback behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Draw mosaic and mixup partners from anno..."](https://github.com/libreyolo/libreyolo/commit/503cf10f40144884ac80d375eae42f14a1729df2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53399708)</sub>

**Context used:**

- Knowledge Base — [Data Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/data-pipeline.md)

<!-- /greptile_comment -->