### PR TITLE
Add an opt-in min_samples epoch floor for tiny datasets (#768 item 4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- **`min_samples` epoch-length floor for tiny datasets.** New opt-in training
+  knob (`model.train(..., min_samples=640)` /
+  `libreyolo train --min-samples 640`, issue #768): when the training dataset
+  has fewer images than `min_samples`, each epoch draws `min_samples` samples
+  with replacement instead of one short pass over the dataset, so per-epoch
+  overhead (dataloader spin-up, validation, checkpointing) stops dominating
+  wall-clock time on ~100-image datasets. Under DDP the draw is sharded across
+  ranks (rounded up to a multiple of the world size) and reshuffled each epoch;
+  dataloader workers are clamped to the dataset length while the floor is
+  active. Default `min_samples=0` keeps training byte-identical to before.
+  Honored by the families that build their train loader through the shared
+  detection dataloader; families with hand-built loaders (DEIM/DEIMv2/D-FINE
+  lineage, RF-DETR, FOMO, EC pose, YOLO-NAS pose, V-JEPA 2) and the
+  classify/semantic/depth/restore task loaders ignore it for now.
+
 - **North Micro Vision VLM detector.** New `northmicrovision` LibreVLM family
   (issue #758): `LibreVLM("north-micro-vision")` loads Cohere Labs'
   North-Micro-Vision-Instruct (2.4B, Apache-2.0, native-resolution) as an

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -281,6 +281,12 @@ def train_cmd(
     cache: str = typer.Option(
         "false", help="Cache images to speed dataloading: ram, disk, true, false"
     ),
+    min_samples: int = typer.Option(
+        0,
+        help="Epoch-length floor for tiny datasets: when the dataset has "
+        "fewer images, draw this many samples per epoch with replacement "
+        "(0 = off)",
+    ),
     seed: int = typer.Option(0, help="Random seed"),
     resume: str = typer.Option("", help="Resume training: true, or path to checkpoint"),
     amp: bool = typer.Option(True, help="Automatic Mixed Precision"),
@@ -549,6 +555,7 @@ def train_cmd(
         "device": device,
         "workers": workers,
         "cache": cache_val,
+        "min_samples": min_samples,
         "seed": seed,
         "resume": resume_val,
         "amp": amp,

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -17,7 +17,7 @@ from typing import List, Tuple
 import cv2
 import numpy as np
 import torch
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import Dataset, DataLoader, RandomSampler, Sampler
 from PIL import Image, UnidentifiedImageError
 from tqdm import tqdm
 
@@ -995,6 +995,56 @@ def _pad_stack_mask_tensors(masks_list):
     return out
 
 
+class DistributedWithReplacementSampler(Sampler):
+    """With-replacement, DDP-aware sampler for the ``min_samples`` epoch floor.
+
+    Mirrors ``DistributedSampler`` semantics: every rank makes the same
+    per-epoch draw of ``total_size`` indices with replacement, seeded with
+    ``seed + epoch`` (call ``set_epoch`` each epoch, exactly like
+    ``DistributedSampler``, so draws differ per epoch while staying
+    deterministic for resume), then keeps its ``rank::num_replicas`` slice.
+    ``num_samples`` is rounded up to ``ceil(num_samples / num_replicas)`` per
+    rank so every rank yields the same count and no rank runs out of batches
+    before the others.
+    """
+
+    def __init__(
+        self,
+        dataset,
+        num_samples: int,
+        num_replicas: int,
+        rank: int,
+        seed: int = 0,
+    ):
+        if num_samples <= 0:
+            raise ValueError(f"num_samples must be positive, got {num_samples}")
+        if not 0 <= rank < num_replicas:
+            raise ValueError(
+                f"rank must be in [0, {num_replicas - 1}], got {rank}"
+            )
+        self.dataset = dataset
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.seed = seed
+        self.num_samples = math.ceil(num_samples / num_replicas)
+        self.total_size = self.num_samples * num_replicas
+        self.epoch = 0
+
+    def __iter__(self):
+        g = torch.Generator()
+        g.manual_seed(self.seed + self.epoch)
+        indices = torch.randint(
+            len(self.dataset), (self.total_size,), generator=g
+        ).tolist()
+        return iter(indices[self.rank : self.total_size : self.num_replicas])
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+
 def create_dataloader(
     dataset,
     batch_size: int = 16,
@@ -1002,6 +1052,7 @@ def create_dataloader(
     shuffle: bool = True,
     pin_memory: bool = True,
     sampler=None,
+    min_samples: int = 0,
 ):
     """
     Create a DataLoader for YOLOX training.
@@ -1016,7 +1067,43 @@ def create_dataloader(
         sampler: Optional sampler (e.g. ``DistributedSampler`` for DDP). When
             provided, the sampler's own shuffling takes over and ``shuffle``
             is forced to False to satisfy PyTorch's mutual-exclusion check.
+        min_samples: Opt-in epoch-length floor for tiny datasets. When > 0
+            and ``len(dataset) < min_samples``, each epoch draws
+            ``min_samples`` samples with replacement instead of one short
+            pass over the dataset: a with-replacement ``RandomSampler``
+            replaces shuffling, a ``DistributedSampler`` passed via
+            ``sampler`` is swapped for its with-replacement equivalent (any
+            other custom sampler is respected as-is), and ``num_workers`` is
+            clamped to ``len(dataset)``. 0 (the default) leaves the loader
+            exactly as before the knob existed.
     """
+    if min_samples > 0 and 0 < len(dataset) < min_samples:
+        num_workers = min(num_workers, len(dataset))
+        if sampler is None:
+            # Draws from the global torch RNG, the same source the default
+            # ``shuffle=True`` RandomSampler uses, so sampling stays
+            # reproducible under torch.manual_seed and differs epoch to
+            # epoch.
+            sampler = RandomSampler(
+                dataset, replacement=True, num_samples=min_samples
+            )
+        else:
+            from torch.utils.data.distributed import DistributedSampler
+
+            if isinstance(sampler, DistributedSampler):
+                sampler = DistributedWithReplacementSampler(
+                    dataset,
+                    num_samples=min_samples,
+                    num_replicas=sampler.num_replicas,
+                    rank=sampler.rank,
+                    seed=sampler.seed,
+                )
+        if is_main_process():
+            logger.info(
+                f"min_samples={min_samples} epoch floor active: dataset has "
+                f"{len(dataset)} images; drawing {len(sampler)} samples per "
+                f"epoch per rank with replacement"
+            )
     try:
         visible_samples = len(sampler) if sampler is not None else len(dataset)
     except TypeError:

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -208,6 +208,17 @@ class TrainConfig:
     # flag also enables caching in the per-epoch validation loop. 'disk' is
     # the safest choice with dataloader workers; default is off.
     cache: Union[bool, str] = False
+    # Opt-in epoch-length floor for tiny datasets. When min_samples > 0 and
+    # the training dataset has fewer images, each epoch draws min_samples
+    # samples with replacement instead of one short pass over the dataset, so
+    # per-epoch overhead (dataloader spin-up, validation, checkpointing) stops
+    # dominating wall-clock time on ~100-image datasets. Under DDP the draw is
+    # sharded across ranks (rounded up to a multiple of world_size) and
+    # reshuffled per epoch via set_epoch. Dataloader workers are clamped to
+    # the dataset length while the floor is active. 0 (the default) is off:
+    # behavior is identical to before the knob existed. Only families that
+    # build their train loader through the shared create_dataloader honor it.
+    min_samples: int = 0
     patience: int = 50
     resume: bool = False
     log_interval: int = 10
@@ -241,6 +252,9 @@ class TrainConfig:
             self.eval_max_det = int(self.eval_max_det)
             if self.eval_max_det < 1:
                 raise ValueError(f"eval_max_det must be >= 1, got {self.eval_max_det}")
+        self.min_samples = int(self.min_samples)
+        if self.min_samples < 0:
+            raise ValueError(f"min_samples must be >= 0, got {self.min_samples}")
 
     @classmethod
     def from_kwargs(cls, **kwargs):

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -942,6 +942,7 @@ class BaseTrainer(ABC):
             shuffle=True,
             pin_memory=self.device.type == "cuda",
             sampler=sampler,
+            min_samples=int(getattr(self.config, "min_samples", 0) or 0),
         )
 
         if is_main_process():

--- a/tests/unit/test_min_samples_floor.py
+++ b/tests/unit/test_min_samples_floor.py
@@ -1,0 +1,216 @@
+"""Tests for the opt-in ``min_samples`` epoch-length floor (issue #768)."""
+
+import pytest
+import torch
+from torch.utils.data import RandomSampler, SequentialSampler, SubsetRandomSampler
+from torch.utils.data.distributed import DistributedSampler
+
+from libreyolo.data.dataset import (
+    DistributedWithReplacementSampler,
+    create_dataloader,
+)
+from libreyolo.training.config import TrainConfig
+
+pytestmark = pytest.mark.unit
+
+
+# =============================================================================
+# Default behavior: the floor is opt-in and off by default
+# =============================================================================
+
+
+def test_floor_off_by_default_keeps_sampler_types():
+    """min_samples=0 (and omitted) builds the exact same loader as today."""
+    dataset = [None] * 5
+
+    default_loader = create_dataloader(dataset, batch_size=2, num_workers=0)
+    explicit_loader = create_dataloader(
+        dataset, batch_size=2, num_workers=0, min_samples=0
+    )
+
+    for loader in (default_loader, explicit_loader):
+        assert isinstance(loader.sampler, RandomSampler)
+        assert loader.sampler.replacement is False
+        assert len(loader.sampler) == 5
+        assert loader.num_workers == 0
+        assert len(loader) == 2  # drop_last kicks in: 5 >= batch_size
+
+    sequential = create_dataloader(
+        dataset, batch_size=2, num_workers=0, shuffle=False, min_samples=0
+    )
+    assert isinstance(sequential.sampler, SequentialSampler)
+
+
+def test_floor_off_by_default_keeps_passed_sampler():
+    dataset = [None] * 5
+    sampler = DistributedSampler(dataset, num_replicas=2, rank=0, shuffle=True)
+
+    loader = create_dataloader(
+        dataset, batch_size=2, num_workers=0, sampler=sampler
+    )
+
+    assert loader.sampler is sampler
+
+
+def test_min_samples_leq_dataset_len_is_a_noop():
+    """A floor at or below the dataset length changes nothing."""
+    dataset = [None] * 10
+
+    for min_samples in (5, 10):
+        loader = create_dataloader(
+            dataset,
+            batch_size=2,
+            num_workers=2,
+            min_samples=min_samples,
+        )
+        assert isinstance(loader.sampler, RandomSampler)
+        assert loader.sampler.replacement is False
+        assert len(loader.sampler) == 10
+        assert loader.num_workers == 2
+
+
+def test_train_config_default_and_validation():
+    assert TrainConfig().min_samples == 0
+    with pytest.raises(ValueError, match="min_samples"):
+        TrainConfig(min_samples=-1)
+
+
+# =============================================================================
+# Active floor: single-process path
+# =============================================================================
+
+
+def test_active_floor_draws_exactly_min_samples():
+    dataset = [None] * 7
+    loader = create_dataloader(
+        dataset, batch_size=10, num_workers=0, min_samples=50
+    )
+
+    sampler = loader.sampler
+    assert isinstance(sampler, RandomSampler)
+    assert sampler.replacement is True
+
+    indices = list(iter(sampler))
+    assert len(indices) == 50
+    assert all(0 <= i < 7 for i in indices)
+    # drop_last keeps its meaning against the floored epoch length.
+    assert len(loader) == 5
+
+
+def test_active_floor_epoch_draws_differ_and_are_seed_reproducible():
+    dataset = [None] * 7
+    loader = create_dataloader(
+        dataset, batch_size=10, num_workers=0, min_samples=50
+    )
+    sampler = loader.sampler
+
+    torch.manual_seed(0)
+    first_epoch = list(iter(sampler))
+    second_epoch = list(iter(sampler))
+    assert first_epoch != second_epoch
+
+    torch.manual_seed(0)
+    assert list(iter(sampler)) == first_epoch
+
+
+def test_active_floor_clamps_num_workers_to_dataset_len():
+    dataset = [None] * 3
+    loader = create_dataloader(
+        dataset, batch_size=2, num_workers=8, min_samples=10
+    )
+    assert loader.num_workers == 3
+
+
+def test_active_floor_respects_custom_non_distributed_sampler():
+    """A caller-provided non-DistributedSampler is never swapped out."""
+    dataset = [None] * 5
+    sampler = SubsetRandomSampler([0, 1])
+
+    loader = create_dataloader(
+        dataset, batch_size=2, num_workers=0, sampler=sampler, min_samples=50
+    )
+
+    assert loader.sampler is sampler
+
+
+# =============================================================================
+# Active floor: DDP path
+# =============================================================================
+
+
+def test_active_floor_swaps_distributed_sampler():
+    dataset = [None] * 7
+    ddp_sampler = DistributedSampler(
+        dataset, num_replicas=2, rank=1, shuffle=True
+    )
+
+    loader = create_dataloader(
+        dataset, batch_size=4, num_workers=0, sampler=ddp_sampler, min_samples=50
+    )
+
+    sampler = loader.sampler
+    assert isinstance(sampler, DistributedWithReplacementSampler)
+    assert sampler.num_replicas == 2
+    assert sampler.rank == 1
+    assert sampler.seed == ddp_sampler.seed
+    assert len(sampler) == 25
+
+
+def test_ddp_split_sums_to_min_samples_across_two_fake_ranks():
+    dataset = [None] * 7
+    samplers = [
+        DistributedWithReplacementSampler(
+            dataset, num_samples=50, num_replicas=2, rank=rank, seed=0
+        )
+        for rank in (0, 1)
+    ]
+
+    per_rank = [list(iter(s)) for s in samplers]
+    assert [len(indices) for indices in per_rank] == [25, 25]
+    assert sum(len(indices) for indices in per_rank) == 50
+    for indices in per_rank:
+        assert all(0 <= i < 7 for i in indices)
+
+    # Both ranks shard one shared draw: interleaving the shards reproduces it.
+    g = torch.Generator()
+    g.manual_seed(0)
+    shared = torch.randint(7, (50,), generator=g).tolist()
+    assert per_rank[0] == shared[0:50:2]
+    assert per_rank[1] == shared[1:50:2]
+
+
+def test_ddp_odd_min_samples_rounds_up_per_rank():
+    dataset = [None] * 7
+    sampler = DistributedWithReplacementSampler(
+        dataset, num_samples=51, num_replicas=2, rank=0, seed=0
+    )
+    assert len(sampler) == 26
+    assert sampler.total_size == 52
+
+
+def test_ddp_set_epoch_changes_draws_deterministically():
+    dataset = [None] * 7
+    sampler = DistributedWithReplacementSampler(
+        dataset, num_samples=50, num_replicas=2, rank=0, seed=0
+    )
+
+    sampler.set_epoch(0)
+    epoch0 = list(iter(sampler))
+    sampler.set_epoch(1)
+    epoch1 = list(iter(sampler))
+    assert epoch0 != epoch1
+
+    sampler.set_epoch(0)
+    assert list(iter(sampler)) == epoch0
+
+
+def test_ddp_sampler_rejects_invalid_args():
+    dataset = [None] * 7
+    with pytest.raises(ValueError, match="num_samples"):
+        DistributedWithReplacementSampler(
+            dataset, num_samples=0, num_replicas=2, rank=0
+        )
+    with pytest.raises(ValueError, match="rank"):
+        DistributedWithReplacementSampler(
+            dataset, num_samples=10, num_replicas=2, rank=2
+        )


### PR DESCRIPTION
Part of #768 (item 4.2).

- On tiny datasets (RF100-VL routinely has ~200 images) "100 epochs" means 100 x ~12 iterations and per-epoch overhead dominates. New opt-in TrainConfig knob min_samples (default 0 = off, byte-identical behavior): when the dataset is smaller than the floor, the loader draws min_samples indices per epoch with replacement, decoupling schedule length from dataset size.
- Single-process: RandomSampler(replacement=True) on the global torch RNG (same reproducibility source as shuffle today). DDP: new DistributedWithReplacementSampler mirroring DistributedSampler semantics (shared seed+epoch draw, per-rank slice, set_epoch, ceil rounding so ranks stay batch-equal). num_workers clamps to dataset length. Custom samplers are respected untouched.
- Honored by every family routing through BaseTrainer._setup_data (yolo9 line, yolox, rtdetr/v2, yolonas, ppyoloe, picodet, rtmdet, yolov7). Families with hand-built loaders (deim/dfine lineages, rfdetr, pose/task loaders) bypass it for now; listed in the PR so extending them is a mechanical follow-up.
- CLI: --min-samples. CHANGELOG updated; the website training page needs a matching paragraph separately.
- Tests: 13 new (no-op defaults, exact floor counts, seed/epoch semantics, DDP split, validation); loader/sampler selection 184 passed; config/CLI surfaces 589 passed.

## Code provenance

All code is original, written for this PR.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an opt-in epoch-length floor that samples tiny detection datasets with replacement while preserving existing behavior by default.

- Adds `min_samples` to the training configuration and CLI.
- Introduces single-process and DDP-aware replacement sampling in the shared detection dataloader.
- Integrates the floor with `BaseTrainer._setup_data`, including worker clamping and per-rank rounding.
- Adds unit coverage for defaults, validation, reproducibility, custom samplers, DDP sharding, and epoch changes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The replacement sampler is advanced by the existing epoch loops, scheduler accounting uses the floored loader length consistently, and unsupported hand-built loader paths are explicitly documented.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/data/dataset.py | Adds replacement samplers and conditionally applies the epoch floor while preserving supplied custom samplers. |
| libreyolo/training/trainer.py | Passes the configured floor into the shared detection dataloader; existing epoch and scheduler logic remains aligned with its resulting length. |
| libreyolo/training/config.py | Adds the default-off configuration field and rejects negative values. |
| libreyolo/cli/commands/train.py | Exposes and forwards the new integer training option through existing configuration routing. |
| tests/unit/test_min_samples_floor.py | Covers no-op behavior, replacement sampling, worker clamping, custom-sampler preservation, and deterministic DDP semantics. |
| CHANGELOG.md | Documents behavior, DDP rounding, defaults, and the loader families and tasks that remain unsupported. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TrainConfig min_samples] --> B{Dataset smaller than floor?}
    B -- No --> C[Existing sampler behavior]
    B -- Yes, single process --> D[RandomSampler with replacement]
    B -- Yes, DDP --> E[DistributedWithReplacementSampler]
    E --> F[Shared seeded draw]
    F --> G[Per-rank strided slice]
    D --> H[DataLoader]
    G --> H
    H --> I[Trainer epoch loop]
    I --> J[Scheduler uses floored loader length]
    I --> K[set_epoch updates DDP draw]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add opt-in min\_samples epoch floor for t..."](https://github.com/libreyolo/libreyolo/commit/add26bc6bb70cf59470be236cf5a7fac40602a0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53400672)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
- Knowledge Base — [Data Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/data-pipeline.md)
- Knowledge Base — [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
</details>

<!-- /greptile_comment -->