### PR TITLE
Report per-class and global best confidence thresholds from validation (#768 item 3.3)

### DIFF
--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1877,6 +1877,17 @@ class BaseModel(ABC):
         Returns:
             Dictionary with metrics/precision, metrics/recall,
             metrics/mAP50, metrics/mAP50-95.
+
+            Detection validation additionally reports the F1-optimal
+            confidence threshold as a free by-product of the COCO matching:
+            ``metrics/best_conf`` (global, micro-averaged over classes) and
+            ``metrics/best_conf_per_class`` (class name to threshold), with
+            ``metrics/best_conf_f1`` the F1 reached at the global optimum.
+            F1 is defined at IoU 0.50 matching; crowd/ignore regions count
+            as neither TP nor FP. Use it as a data-driven ``conf=`` for
+            deployment instead of a folklore default. Entries are NaN for
+            classes where no threshold reaches F1 > 0 (no predictions, no
+            ground truth, or all false positives).
         """
         from libreyolo.validation import (
             ClassifyValidator,

--- a/libreyolo/validation/coco_evaluator.py
+++ b/libreyolo/validation/coco_evaluator.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Dict, Mapping, Optional
+from typing import Dict, Mapping, Optional, Tuple
 
 import numpy as np
 import torch
@@ -316,6 +316,292 @@ class COCOEvaluator:
         """Clear all accumulated results."""
         self.results = []
         self._img_ids = set()
+
+    @staticmethod
+    def _best_f1_threshold(
+        scores: np.ndarray, tps: np.ndarray, npig: int
+    ) -> Tuple[float, float]:
+        """Sweep F1 over score thresholds with a single sort plus cumsum.
+
+        ``scores`` and ``tps`` are aligned per-detection arrays (ignored
+        detections must already be removed); ``npig`` is the number of
+        non-ignored ground truths. F1 is evaluated once per distinct score,
+        always at the last detection of a tie group, so detections sharing a
+        score are included or excluded as a whole. Ties in F1 resolve to the
+        highest threshold.
+
+        Returns:
+            ``(threshold, f1)``. A NaN pair when no threshold achieves
+            F1 > 0: no predictions, no ground truth, or every prediction
+            is a false positive.
+        """
+        nan = float("nan")
+        scores = np.asarray(scores, dtype=np.float64)
+        tps = np.asarray(tps, dtype=bool)
+        if scores.size == 0 or npig <= 0:
+            return nan, nan
+        order = np.argsort(-scores, kind="stable")
+        scores = scores[order]
+        tp = tps[order].astype(np.float64)
+        tp_cum = np.cumsum(tp)
+        fp_cum = np.cumsum(1.0 - tp)
+        # Candidate cut points: the last detection of every distinct score.
+        cut = np.flatnonzero(np.diff(scores))
+        cut = np.append(cut, scores.size - 1)
+        # F1 = 2*tp / (tp + fp + npig) == 2PR / (P + R) with P = tp/(tp+fp),
+        # R = tp/npig; the denominator is always > 0 at a detection index.
+        f1 = 2.0 * tp_cum[cut] / (tp_cum[cut] + fp_cum[cut] + float(npig))
+        best = int(np.argmax(f1))  # first max == highest threshold on ties
+        if not f1[best] > 0.0:
+            return nan, nan
+        return float(scores[cut[best]]), float(f1[best])
+
+    def best_conf_thresholds(
+        self, iou_thr: float = 0.5
+    ) -> Optional[Dict[str, object]]:
+        """Per-class and micro-averaged global best confidence thresholds.
+
+        Reads the per-image match results (``evalImgs``) of the last
+        :meth:`compute` call, so no matching is re-run; with the
+        faster-coco-eval backend, which keeps matching in C++, the greedy
+        assignment is replayed on its retained IoU matrices instead (see
+        :meth:`_per_class_match_arrays`). F1 is defined at IoU ``iou_thr``
+        matching (0.50 by default; on the ``evalImgs`` path, if that
+        threshold was not evaluated, the lowest evaluated one is used) over
+        the "all" area range. Detections flagged as ignored by COCOeval,
+        which includes detections matched to crowd/ignore ground truths,
+        take part in the sweep as neither TP nor FP, and ignored ground
+        truths do not count toward recall.
+
+        Returns:
+            None when no evaluation ran or the backend exposes no usable
+            match source. Otherwise
+            ``{"global": (thr, f1), "per_class": {label: (thr, f1)}}``
+            where ``label`` is the model class index (category ids are
+            mapped back through ``label_to_category_id``) and entries are
+            NaN pairs for classes where no threshold reaches F1 > 0.
+        """
+        coco_eval = self._last_coco_eval
+        if coco_eval is None:
+            return None
+        try:
+            source = self._per_class_match_arrays(coco_eval, iou_thr)
+            if source is None:
+                return None
+            category_to_label = (
+                {v: k for k, v in self.label_to_category_id.items()}
+                if self.label_to_category_id is not None
+                else {}
+            )
+
+            per_class: Dict[int, Tuple[float, float]] = {}
+            pooled_scores = []
+            pooled_tps = []
+            total_npig = 0
+            for cat_id, (scores, tps, npig) in source.items():
+                label = category_to_label.get(int(cat_id), int(cat_id))
+                per_class[label] = self._best_f1_threshold(scores, tps, npig)
+                pooled_scores.append(scores)
+                pooled_tps.append(tps)
+                total_npig += npig
+
+            global_pair = self._best_f1_threshold(
+                np.concatenate(pooled_scores)
+                if pooled_scores
+                else np.zeros(0, dtype=np.float64),
+                np.concatenate(pooled_tps)
+                if pooled_tps
+                else np.zeros(0, dtype=bool),
+                total_npig,
+            )
+            return {"global": global_pair, "per_class": per_class}
+        except Exception as exc:  # backend without a usable match source
+            logger.debug("Best-conf sweep unavailable: %s", exc)
+            return None
+
+    def _per_class_match_arrays(
+        self, coco_eval, iou_thr: float
+    ) -> Optional[Dict[int, Tuple[np.ndarray, np.ndarray, int]]]:
+        """Per-category ``(scores, tps, npig)`` arrays for the F1 sweep.
+
+        Uses the stock pycocotools ``evalImgs`` match results when the
+        backend populates them. faster-coco-eval keeps matching in C++ and
+        leaves ``evalImgs`` empty, but retains the Python-side IoU matrices
+        (``ious``) and the prepared ``cocoGt``/``cocoDt`` annotations, so
+        the greedy COCO assignment at ``iou_thr`` is replayed on those:
+        the expensive IoU computation is reused, only the trivial matching
+        loop is repeated.
+        """
+        eval_imgs = getattr(coco_eval, "evalImgs", None)
+        if isinstance(eval_imgs, list) and eval_imgs:
+            return self._match_arrays_from_eval_imgs(coco_eval, iou_thr)
+        return self._match_arrays_from_ious(coco_eval, iou_thr)
+
+    @staticmethod
+    def _match_arrays_from_eval_imgs(
+        coco_eval, iou_thr: float
+    ) -> Dict[int, Tuple[np.ndarray, np.ndarray, int]]:
+        """Extract sweep arrays from pycocotools-shaped ``evalImgs``."""
+        params = coco_eval.params
+        iou_thrs = np.asarray(params.iouThrs, dtype=np.float64)
+        iou_matches = np.flatnonzero(np.isclose(iou_thrs, iou_thr))
+        iou_index = int(iou_matches[0]) if iou_matches.size else 0
+        area_index = list(params.areaRngLbl).index("all")
+        n_area = len(params.areaRng)
+        n_img = len(params.imgIds)
+        eval_imgs = coco_eval.evalImgs
+
+        out: Dict[int, Tuple[np.ndarray, np.ndarray, int]] = {}
+        for k, cat_id in enumerate(params.catIds):
+            scores_parts = []
+            tp_parts = []
+            npig = 0
+            base = k * n_area * n_img + area_index * n_img
+            for entry in eval_imgs[base : base + n_img]:
+                if entry is None:
+                    continue
+                gt_ignore = np.asarray(entry["gtIgnore"])
+                npig += int((gt_ignore == 0).sum())
+                dt_scores = np.asarray(entry["dtScores"], dtype=np.float64)
+                if dt_scores.size == 0:
+                    continue
+                keep = ~np.asarray(entry["dtIgnore"], dtype=bool)[iou_index]
+                matches = np.asarray(entry["dtMatches"])[iou_index]
+                scores_parts.append(dt_scores[keep])
+                tp_parts.append(matches[keep] > 0)
+            scores = (
+                np.concatenate(scores_parts)
+                if scores_parts
+                else np.zeros(0, dtype=np.float64)
+            )
+            tps = (
+                np.concatenate(tp_parts)
+                if tp_parts
+                else np.zeros(0, dtype=bool)
+            )
+            out[int(cat_id)] = (scores, tps, npig)
+        return out
+
+    @staticmethod
+    def _match_arrays_from_ious(
+        coco_eval, iou_thr: float
+    ) -> Optional[Dict[int, Tuple[np.ndarray, np.ndarray, int]]]:
+        """Replay COCO's greedy assignment on the retained IoU matrices.
+
+        Faithful port of the ``evaluateImg`` matching loop at a single IoU
+        threshold and the "all" area range: detections are visited in score
+        order, each takes the best still-free ground truth above ``iou_thr``
+        (crowd/ignored ground truths only when no normal one qualifies) and
+        a detection matched to an ignored ground truth is dropped from the
+        sweep (neither TP nor FP).
+        """
+        from collections import defaultdict
+
+        ious_all = getattr(coco_eval, "ious", None)
+        coco_gt = getattr(coco_eval, "cocoGt", None)
+        coco_dt = getattr(coco_eval, "cocoDt", None)
+        if ious_all is None or coco_gt is None or coco_dt is None:
+            return None
+        params = coco_eval.params
+        max_det = int(sorted(params.maxDets)[-1])
+
+        # One pass over each annotation index. Iterating anns in insertion
+        # order preserves the per-image dataset order computeIoU consumed,
+        # so the IoU matrix axes line up below.
+        img_id_set = {int(i) for i in params.imgIds}
+        gt_by_key = defaultdict(list)
+        for ann in coco_gt.anns.values():
+            key = (int(ann["image_id"]), int(ann["category_id"]))
+            if key[0] in img_id_set:
+                gt_by_key[key].append(ann)
+        dt_by_key = defaultdict(list)
+        for ann in coco_dt.anns.values():
+            if ann.get("drop", False):
+                continue
+            key = (int(ann["image_id"]), int(ann["category_id"]))
+            if key[0] in img_id_set:
+                dt_by_key[key].append(ann)
+        imgs_by_cat = defaultdict(set)
+        for img_id, cat_id in list(gt_by_key) + list(dt_by_key):
+            imgs_by_cat[cat_id].add(img_id)
+
+        out: Dict[int, Tuple[np.ndarray, np.ndarray, int]] = {}
+        for cat_id in params.catIds:
+            scores_parts = []
+            tp_parts = []
+            npig = 0
+            for img_id in sorted(imgs_by_cat.get(int(cat_id), ())):
+                gt = gt_by_key.get((img_id, int(cat_id)), [])
+                dt = dt_by_key.get((img_id, int(cat_id)), [])
+                gt_ig = np.asarray(
+                    [
+                        g.get(
+                            "_ignore",
+                            1 if (g.get("ignore") or g.get("iscrowd")) else 0,
+                        )
+                        for g in gt
+                    ],
+                    dtype=np.int64,
+                )
+                npig += int((gt_ig == 0).sum())
+                if not dt:
+                    continue
+                # Sort exactly like evaluateImg: ignored GTs last, detections
+                # by descending score, both with a stable sort; truncate the
+                # detections to the evaluated cap.
+                gtind = np.argsort(gt_ig, kind="mergesort")
+                gt_ig = gt_ig[gtind]
+                crowd = np.asarray(
+                    [int(gt[i].get("iscrowd", 0)) for i in gtind], dtype=np.int64
+                )
+                dt_scores_full = np.asarray(
+                    [d["score"] for d in dt], dtype=np.float64
+                )
+                dtind = np.argsort(-dt_scores_full, kind="mergesort")[:max_det]
+                dt_scores = dt_scores_full[dtind]
+                # IoU rows are already in sorted-truncated detection order
+                # (computeIoU sorts and truncates); columns follow raw GT
+                # order and are permuted here to the sorted GT order.
+                ious = np.asarray(ious_all[img_id, cat_id])
+                if ious.size:
+                    ious = ious[:, gtind]
+                n_dt = len(dtind)
+                tps = np.zeros(n_dt, dtype=bool)
+                ignored = np.zeros(n_dt, dtype=bool)
+                if len(gt) and ious.size:
+                    gt_taken = np.zeros(len(gt), dtype=bool)
+                    for dind in range(n_dt):
+                        best = min(iou_thr, 1.0 - 1e-10)
+                        m = -1
+                        for gind in range(len(gt)):
+                            if gt_taken[gind] and not crowd[gind]:
+                                continue
+                            if m > -1 and gt_ig[m] == 0 and gt_ig[gind] == 1:
+                                break
+                            if ious[dind, gind] < best:
+                                continue
+                            best = ious[dind, gind]
+                            m = gind
+                        if m == -1:
+                            continue
+                        gt_taken[m] = True
+                        ignored[dind] = bool(gt_ig[m])
+                        tps[dind] = not gt_ig[m]
+                keep = ~ignored
+                scores_parts.append(dt_scores[keep])
+                tp_parts.append(tps[keep])
+            scores = (
+                np.concatenate(scores_parts)
+                if scores_parts
+                else np.zeros(0, dtype=np.float64)
+            )
+            tps = (
+                np.concatenate(tp_parts)
+                if tp_parts
+                else np.zeros(0, dtype=bool)
+            )
+            out[int(cat_id)] = (scores, tps, npig)
+        return out
 
     @staticmethod
     def _mean_valid(values: np.ndarray, *, empty: float = 0.0) -> float:

--- a/libreyolo/validation/coco_evaluator.py
+++ b/libreyolo/validation/coco_evaluator.py
@@ -488,12 +488,15 @@ class COCOEvaluator:
     ) -> Optional[Dict[int, Tuple[np.ndarray, np.ndarray, int]]]:
         """Replay COCO's greedy assignment on the retained IoU matrices.
 
-        Faithful port of the ``evaluateImg`` matching loop at a single IoU
-        threshold and the "all" area range: detections are visited in score
-        order, each takes the best still-free ground truth above ``iou_thr``
+        Original reimplementation (no upstream code copied) of the greedy
+        matching rule COCO evaluation defines, at a single IoU threshold and
+        the "all" area range: detections are visited in score order, each
+        takes the best still-free ground truth above ``iou_thr``
         (crowd/ignored ground truths only when no normal one qualifies) and
         a detection matched to an ignored ground truth is dropped from the
-        sweep (neither TP nor FP).
+        sweep (neither TP nor FP). Behavioral equivalence with the reference
+        evaluator is pinned by the cross-backend parity tests in
+        tests/unit/test_best_conf_threshold.py.
         """
         from collections import defaultdict
 

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 COCO_TOPK_FAMILIES = {"dfine", "deim", "deimv2", "tinyformer", "ec", "rfdetr", "rtdetr", "rtdetrv2", "rtdetrv4"}
 _N_VAL_SAMPLES = 8  # maximum sample images stored for visualisation
+BEST_CONF_KEY = "metrics/best_conf"
+BEST_CONF_F1_KEY = "metrics/best_conf_f1"
+BEST_CONF_PER_CLASS_KEY = "metrics/best_conf_per_class"
 
 if TYPE_CHECKING:
     from libreyolo.models.base import BaseModel
@@ -883,7 +886,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
             bm = {
                 k: v
                 for k, v in metrics.items()
-                if not k.startswith(("speed/", "metrics/loss"))
+                if not k.startswith(("speed/", "metrics/loss", "metrics/best_conf"))
             }
 
         # Inject per-IoU-threshold P/R; fallback to aggregate P/R when unavailable
@@ -999,7 +1002,72 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
             "metrics/AR_large": coco_metrics["AR_large"],
         }
         metrics.update(self._validation_loss_metrics())
+        metrics.update(self._best_conf_metrics())
         return metrics
+
+    def _class_display_name(self, label: int) -> str:
+        names = getattr(self, "class_names", None)
+        if names and 0 <= label < len(names):
+            return str(names[label])
+        return str(label)
+
+    def _best_conf_metrics(self) -> Dict[str, Any]:
+        """Free deploy-threshold metric from the finished COCO evaluation.
+
+        Sweeps F1 over the already-scored, already-matched predictions
+        (IoU 0.50 matching, see ``COCOEvaluator.best_conf_thresholds``) and
+        reports the confidence threshold that maximizes it, globally
+        (micro-averaged over all classes) and per class. Purely additive:
+        existing metric keys are untouched.
+
+        New keys:
+            ``metrics/best_conf``: global F1-optimal confidence, NaN when no
+                threshold achieves F1 > 0 (or the sweep source is missing).
+            ``metrics/best_conf_f1``: F1 at that threshold, NaN likewise.
+            ``metrics/best_conf_per_class``: dict of class name to threshold,
+                NaN entries for all-FP or no-prediction classes.
+        """
+        nan = float("nan")
+        self._best_conf_table = None
+        sweep_fn = getattr(self.coco_evaluator, "best_conf_thresholds", None)
+        sweep = sweep_fn() if callable(sweep_fn) else None
+        if sweep is None:
+            return {
+                BEST_CONF_KEY: nan,
+                BEST_CONF_F1_KEY: nan,
+                BEST_CONF_PER_CLASS_KEY: {},
+            }
+
+        global_thr, global_f1 = sweep["global"]
+        per_class: Dict[str, float] = {}
+        table = [("all", float(global_thr), float(global_f1))]
+        for label in sorted(sweep["per_class"]):
+            thr, f1 = sweep["per_class"][label]
+            name = self._class_display_name(label)
+            per_class[name] = float(thr)
+            table.append((name, float(thr), float(f1)))
+        self._best_conf_table = table
+        return {
+            BEST_CONF_KEY: float(global_thr),
+            BEST_CONF_F1_KEY: float(global_f1),
+            BEST_CONF_PER_CLASS_KEY: per_class,
+        }
+
+    def _print_results(self, metrics: Dict[str, float]) -> None:
+        printable = {
+            k: v for k, v in metrics.items() if k != BEST_CONF_PER_CLASS_KEY
+        }
+        super()._print_results(printable)
+
+        table = getattr(self, "_best_conf_table", None)
+        if not table:
+            return
+        logger.info("Best confidence threshold (max F1 at IoU 0.50):")
+        logger.info("  %-24s %10s %8s", "class", "best_conf", "F1")
+        for name, thr, f1 in table:
+            logger.info("  %-24s %10.4f %8.4f", name, thr, f1)
+        if any(np.isnan(thr) for _, thr, _ in table):
+            logger.info("  (nan: no threshold reaches F1 > 0 for that class)")
 
 
 class SegmentationValidator(DetectionValidator):

--- a/tests/unit/test_best_conf_threshold.py
+++ b/tests/unit/test_best_conf_threshold.py
@@ -1,0 +1,500 @@
+"""
+Unit tests for the best-confidence-threshold sweep (issue #768 item 3.3).
+
+The sweep reads the per-image match results of a finished COCO evaluation
+(IoU 0.50 matching) and reports the confidence threshold that maximizes F1,
+per class and micro-averaged globally. Synthetic fixtures with known optima
+verify the sweep; a regression test proves existing metric keys and values
+are untouched.
+"""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pycocotools")
+
+NAN_OK = math.isnan
+
+BACKENDS = ["pycocotools", "faster"]
+
+
+@pytest.fixture(autouse=True)
+def _no_backend_env_override(monkeypatch):
+    monkeypatch.delenv("LIBREYOLO_FASTER_COCO_EVAL", raising=False)
+
+
+def _require_backend(backend):
+    if backend == "faster":
+        pytest.importorskip("faster_coco_eval")
+
+
+def _make_coco(images, annotations, categories):
+    from pycocotools.coco import COCO
+
+    coco = COCO()
+    coco.dataset = {
+        "info": {},
+        "licenses": [],
+        "images": images,
+        "annotations": annotations,
+        "categories": categories,
+    }
+    coco.createIndex()
+    return coco
+
+
+def _gt(ann_id, image_id, category_id, x, y, w=10.0, h=10.0, iscrowd=0):
+    return {
+        "id": ann_id,
+        "image_id": image_id,
+        "category_id": category_id,
+        "bbox": [x, y, w, h],
+        "area": w * h,
+        "iscrowd": iscrowd,
+    }
+
+
+def _pred(x, y, score, label, w=10.0, h=10.0):
+    return [x, y, x + w, y + h], score, label
+
+
+def _run_evaluator(
+    annotations, preds, categories, label_map, image_id=1, backend="pycocotools"
+):
+    """Feed one 200x200 image through COCOEvaluator and return it."""
+    from libreyolo.validation import COCOEvaluator
+
+    coco = _make_coco(
+        [{"id": image_id, "file_name": "img.jpg", "width": 200, "height": 200}],
+        [dict(a) for a in annotations],
+        [dict(c) for c in categories],
+    )
+    evaluator = COCOEvaluator(
+        coco,
+        iou_type="bbox",
+        label_to_category_id=label_map,
+        faster_coco_eval=(backend == "faster"),
+    )
+    boxes, scores, classes = [], [], []
+    for box, score, label in preds:
+        boxes.append(box)
+        scores.append(score)
+        classes.append(label)
+    evaluator.update(
+        {"boxes": boxes, "scores": scores, "classes": classes}, image_id=image_id
+    )
+    evaluator.compute()
+    if backend == "faster":
+        assert evaluator.last_backend.startswith("faster-coco-eval")
+    return evaluator
+
+
+_TWO_CLASS_CATEGORIES = [
+    {"id": 1, "name": "cat"},
+    {"id": 2, "name": "dog"},
+]
+_TWO_CLASS_LABEL_MAP = {0: 1, 1: 2}
+
+
+def _two_class_fixture():
+    """Known optima: cat best at 0.7 (F1 1.0), dog at 0.4 (F1 0.8).
+
+    Global micro-average pools 6 TP/FP detections over 5 GT boxes and peaks
+    at threshold 0.4 with F1 = 10/11.
+    """
+    annotations = [
+        _gt(1, 1, 1, 0, 0),
+        _gt(2, 1, 1, 20, 0),
+        _gt(3, 1, 1, 40, 0),
+        _gt(4, 1, 2, 0, 50),
+        _gt(5, 1, 2, 20, 50),
+    ]
+    preds = [
+        _pred(0, 0, 0.9, 0),     # cat TP
+        _pred(20, 0, 0.8, 0),    # cat TP
+        _pred(40, 0, 0.7, 0),    # cat TP
+        _pred(100, 100, 0.3, 0), # cat FP
+        _pred(120, 100, 0.2, 0), # cat FP
+        _pred(0, 50, 0.6, 1),    # dog TP
+        _pred(100, 150, 0.5, 1), # dog FP
+        _pred(20, 50, 0.4, 1),   # dog TP
+    ]
+    return annotations, preds
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_best_conf_sweep_finds_known_optimum_per_class_and_global(backend):
+    _require_backend(backend)
+    annotations, preds = _two_class_fixture()
+    evaluator = _run_evaluator(
+        annotations, preds, _TWO_CLASS_CATEGORIES, _TWO_CLASS_LABEL_MAP,
+        backend=backend,
+    )
+
+    sweep = evaluator.best_conf_thresholds()
+
+    assert sweep is not None
+    cat_thr, cat_f1 = sweep["per_class"][0]
+    dog_thr, dog_f1 = sweep["per_class"][1]
+    assert cat_thr == pytest.approx(0.7)
+    assert cat_f1 == pytest.approx(1.0)
+    assert dog_thr == pytest.approx(0.4)
+    assert dog_f1 == pytest.approx(0.8)
+    global_thr, global_f1 = sweep["global"]
+    assert global_thr == pytest.approx(0.4)
+    assert global_f1 == pytest.approx(10.0 / 11.0)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_best_conf_tie_group_is_included_or_excluded_as_a_whole(backend):
+    _require_backend(backend)
+    # Two GT; TP@0.8 alone gives F1 2/3, the 0.5 tie group (TP + FP
+    # together) lifts it to 0.8. Cutting inside the tie group is illegal.
+    annotations = [_gt(1, 1, 1, 0, 0), _gt(2, 1, 1, 20, 0)]
+    preds = [
+        _pred(0, 0, 0.8, 0),     # TP
+        _pred(20, 0, 0.5, 0),    # TP, tied score
+        _pred(100, 100, 0.5, 0), # FP, tied score
+    ]
+    evaluator = _run_evaluator(
+        annotations, preds, [{"id": 1, "name": "cat"}], {0: 1}, backend=backend
+    )
+
+    sweep = evaluator.best_conf_thresholds()
+
+    thr, f1 = sweep["per_class"][0]
+    assert thr == pytest.approx(0.5)
+    assert f1 == pytest.approx(0.8)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_best_conf_f1_tie_resolves_to_higher_threshold(backend):
+    _require_backend(backend)
+    # Two GT; F1 is 2/3 both at 0.8 (1 TP, 0 FP) and at 0.2 (2 TP, 2 FP).
+    # The sweep must report the higher threshold.
+    annotations = [_gt(1, 1, 1, 0, 0), _gt(2, 1, 1, 20, 0)]
+    preds = [
+        _pred(0, 0, 0.8, 0),     # TP
+        _pred(100, 100, 0.6, 0), # FP
+        _pred(120, 100, 0.4, 0), # FP
+        _pred(20, 0, 0.2, 0),    # TP
+    ]
+    evaluator = _run_evaluator(
+        annotations, preds, [{"id": 1, "name": "cat"}], {0: 1}, backend=backend
+    )
+
+    thr, f1 = evaluator.best_conf_thresholds()["per_class"][0]
+    assert thr == pytest.approx(0.8)
+    assert f1 == pytest.approx(2.0 / 3.0)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_best_conf_single_prediction(backend):
+    _require_backend(backend)
+    annotations = [_gt(1, 1, 1, 0, 0)]
+    preds = [_pred(0, 0, 0.55, 0)]
+    evaluator = _run_evaluator(
+        annotations, preds, [{"id": 1, "name": "cat"}], {0: 1}, backend=backend
+    )
+
+    sweep = evaluator.best_conf_thresholds()
+
+    assert sweep["per_class"][0] == pytest.approx((0.55, 1.0))
+    assert sweep["global"] == pytest.approx((0.55, 1.0))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_best_conf_all_fp_and_no_prediction_classes_are_nan(backend):
+    _require_backend(backend)
+    # cat: predictions but every one a false positive (GT exists elsewhere
+    # for dog only). dog: ground truth but no predictions. Both NaN; the
+    # pooled global sweep never reaches F1 > 0 either.
+    annotations = [_gt(1, 1, 2, 0, 50)]
+    preds = [
+        _pred(100, 100, 0.9, 0),
+        _pred(120, 100, 0.4, 0),
+    ]
+    evaluator = _run_evaluator(
+        annotations, preds, _TWO_CLASS_CATEGORIES, _TWO_CLASS_LABEL_MAP,
+        backend=backend,
+    )
+
+    sweep = evaluator.best_conf_thresholds()
+
+    assert all(NAN_OK(v) for v in sweep["per_class"][0])
+    assert all(NAN_OK(v) for v in sweep["per_class"][1])
+    assert all(NAN_OK(v) for v in sweep["global"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_best_conf_respects_iscrowd_ignore_regions(backend):
+    _require_backend(backend)
+    # Two normal GT matched at 0.9 and 0.5, plus a detection at 0.7 sitting
+    # exactly on a crowd region. The crowd-matched detection must be neither
+    # TP nor FP and the crowd GT must not count toward recall, so the sweep
+    # still reaches a perfect F1 at threshold 0.5.
+    annotations = [
+        _gt(1, 1, 1, 0, 0),
+        _gt(2, 1, 1, 20, 0),
+        _gt(3, 1, 1, 100, 100, w=40.0, h=40.0, iscrowd=1),
+    ]
+    preds = [
+        _pred(0, 0, 0.9, 0),                     # TP
+        _pred(100, 100, 0.7, 0, w=40.0, h=40.0), # on the crowd region
+        _pred(20, 0, 0.5, 0),                    # TP
+    ]
+    evaluator = _run_evaluator(
+        annotations, preds, [{"id": 1, "name": "cat"}], {0: 1}, backend=backend
+    )
+
+    sweep = evaluator.best_conf_thresholds()
+
+    thr, f1 = sweep["per_class"][0]
+    assert thr == pytest.approx(0.5)
+    assert f1 == pytest.approx(1.0)
+    assert sweep["global"] == pytest.approx((0.5, 1.0))
+
+
+@pytest.mark.unit
+def test_best_conf_backend_parity_on_randomized_fixture():
+    """The faster-coco-eval fallback must reproduce the pycocotools sweep.
+
+    Randomized boxes with duplicate scores, crowds, misses and false
+    positives; both backends must agree on every per-class pair and the
+    global pair (NaN included).
+    """
+    pytest.importorskip("faster_coco_eval")
+    import numpy as np
+
+    rng = np.random.default_rng(768)
+    annotations = []
+    preds = []
+    ann_id = 1
+    score_pool = np.round(rng.uniform(0.05, 0.95, size=40), 2)  # forces ties
+    for cat_label, cat_id in ((0, 1), (1, 2)):
+        for i in range(12):
+            x = float((i % 6) * 30)
+            y = float((i // 6) * 30 + cat_label * 90)
+            iscrowd = 1 if i % 5 == 4 else 0
+            annotations.append(
+                _gt(ann_id, 1, cat_id, x, y, w=20.0, h=20.0, iscrowd=iscrowd)
+            )
+            ann_id += 1
+            roll = rng.uniform()
+            if roll < 0.7:  # jittered detection on this GT
+                dx, dy = rng.uniform(-6, 6, size=2)
+                preds.append(
+                    _pred(
+                        x + float(dx),
+                        y + float(dy),
+                        float(rng.choice(score_pool)),
+                        cat_label,
+                        w=20.0,
+                        h=20.0,
+                    )
+                )
+            # some GTs get a second, weaker detection
+            if roll > 0.55:
+                preds.append(
+                    _pred(
+                        x + 2.0,
+                        y + 2.0,
+                        float(rng.choice(score_pool)),
+                        cat_label,
+                        w=20.0,
+                        h=20.0,
+                    )
+                )
+        # pure false positives far from every GT
+        for j in range(4):
+            preds.append(
+                _pred(
+                    150.0 + j * 10.0,
+                    180.0,
+                    float(rng.choice(score_pool)),
+                    cat_label,
+                    w=8.0,
+                    h=8.0,
+                )
+            )
+
+    sweeps = {}
+    for backend in BACKENDS:
+        evaluator = _run_evaluator(
+            annotations, preds, _TWO_CLASS_CATEGORIES, _TWO_CLASS_LABEL_MAP,
+            backend=backend,
+        )
+        sweeps[backend] = evaluator.best_conf_thresholds()
+
+    reference, fallback = sweeps["pycocotools"], sweeps["faster"]
+    assert reference is not None and fallback is not None
+    assert set(reference["per_class"]) == set(fallback["per_class"])
+    for label, pair in reference["per_class"].items():
+        assert fallback["per_class"][label] == pytest.approx(pair, nan_ok=True)
+    assert fallback["global"] == pytest.approx(reference["global"], nan_ok=True)
+    # The randomized fixture must exercise a real optimum, not the NaN path.
+    assert not math.isnan(reference["global"][0])
+
+
+def _detection_validator(evaluator, class_names):
+    from libreyolo.validation.detection_validator import DetectionValidator
+
+    validator = DetectionValidator.__new__(DetectionValidator)
+    validator.config = SimpleNamespace(verbose=False, save_json=False)
+    validator.save_dir = None
+    validator.coco_evaluator = evaluator
+    validator.class_names = class_names
+    return validator
+
+
+@pytest.mark.unit
+def test_detection_validator_emits_best_conf_keys_with_class_names():
+    annotations, preds = _two_class_fixture()
+    evaluator = _run_evaluator(
+        annotations, preds, _TWO_CLASS_CATEGORIES, _TWO_CLASS_LABEL_MAP
+    )
+    validator = _detection_validator(evaluator, ["cat", "dog"])
+
+    metrics = validator._compute_metrics()
+
+    assert metrics["metrics/best_conf"] == pytest.approx(0.4)
+    assert metrics["metrics/best_conf_f1"] == pytest.approx(10.0 / 11.0)
+    per_class = metrics["metrics/best_conf_per_class"]
+    assert per_class["cat"] == pytest.approx(0.7)
+    assert per_class["dog"] == pytest.approx(0.4)
+
+
+@pytest.mark.unit
+def test_detection_validator_print_results_handles_best_conf_table():
+    annotations, preds = _two_class_fixture()
+    evaluator = _run_evaluator(
+        annotations, preds, _TWO_CLASS_CATEGORIES, _TWO_CLASS_LABEL_MAP
+    )
+    validator = _detection_validator(evaluator, ["cat", "dog"])
+    validator.seen = 1
+    validator.speed = {"total": 0.0}
+
+    metrics = validator._compute_metrics()
+
+    validator._print_results(metrics)  # must not raise on dict/NaN values
+
+
+@pytest.mark.unit
+def test_detection_validator_best_conf_nan_without_sweep_source():
+    """Evaluator stubs without match results degrade to NaN, never crash."""
+
+    class _DummyEvaluator:
+        def compute(self, save_json=None):
+            return {
+                "precision": 0.201,
+                "recall": 0.202,
+                "mAP": 0.2,
+                "mAP50": 0.21,
+                "mAP75": 0.22,
+                "mAP_small": 0.23,
+                "mAP_medium": 0.24,
+                "mAP_large": 0.25,
+                "AR1": 0.26,
+                "AR10": 0.27,
+                "AR100": 0.28,
+                "AR_max_det": 0.28,
+                "max_det": 100.0,
+                "AR_small": 0.29,
+                "AR_medium": 0.30,
+                "AR_large": 0.31,
+            }
+
+    validator = _detection_validator(_DummyEvaluator(), None)
+
+    metrics = validator._compute_metrics()
+
+    # Existing keys keep their exact values.
+    assert metrics["metrics/precision"] == pytest.approx(0.201)
+    assert metrics["metrics/recall"] == pytest.approx(0.202)
+    assert metrics["metrics/mAP50"] == pytest.approx(0.21)
+    assert metrics["metrics/mAP50-95"] == pytest.approx(0.2)
+    # New keys degrade gracefully.
+    assert NAN_OK(metrics["metrics/best_conf"])
+    assert NAN_OK(metrics["metrics/best_conf_f1"])
+    assert metrics["metrics/best_conf_per_class"] == {}
+
+
+@pytest.mark.unit
+def test_best_conf_is_additive_existing_metrics_bit_exact():
+    """Regression: pre-existing keys and values match stock pycocotools."""
+    from pycocotools.cocoeval import COCOeval
+
+    annotations, preds = _two_class_fixture()
+    evaluator = _run_evaluator(
+        annotations, preds, _TWO_CLASS_CATEGORIES, _TWO_CLASS_LABEL_MAP
+    )
+    validator = _detection_validator(evaluator, ["cat", "dog"])
+    metrics = validator._compute_metrics()
+
+    coco = _make_coco(
+        [{"id": 1, "file_name": "img.jpg", "width": 200, "height": 200}],
+        [dict(a) for a in annotations],
+        [dict(c) for c in _TWO_CLASS_CATEGORIES],
+    )
+    results = [
+        {
+            "image_id": 1,
+            "category_id": _TWO_CLASS_LABEL_MAP[label],
+            "bbox": [box[0], box[1], box[2] - box[0], box[3] - box[1]],
+            "score": score,
+        }
+        for box, score, label in preds
+    ]
+    reference = COCOeval(coco, coco.loadRes(results), "bbox")
+    reference.params.imgIds = [1]
+    reference.evaluate()
+    reference.accumulate()
+    reference.summarize()
+
+    assert metrics["metrics/mAP50-95"] == float(reference.stats[0])
+    assert metrics["metrics/mAP50"] == float(reference.stats[1])
+    assert metrics["metrics/mAP75"] == float(reference.stats[2])
+    assert metrics["metrics/AR100"] == float(reference.stats[8])
+    expected_existing = {
+        "metrics/precision",
+        "metrics/recall",
+        "metrics/mAP50-95",
+        "metrics/mAP50",
+        "metrics/mAP75",
+        "metrics/precision(B)",
+        "metrics/recall(B)",
+        "metrics/mAP50(B)",
+        "metrics/mAP50-95(B)",
+        "metrics/mAP_small",
+        "metrics/mAP_medium",
+        "metrics/mAP_large",
+        "metrics/AR1",
+        "metrics/AR10",
+        "metrics/AR100",
+        "metrics/AR_max_det",
+        "metrics/max_det",
+        "metrics/AR_small",
+        "metrics/AR_medium",
+        "metrics/AR_large",
+    }
+    new_keys = {
+        "metrics/best_conf",
+        "metrics/best_conf_f1",
+        "metrics/best_conf_per_class",
+    }
+    assert set(metrics) == expected_existing | new_keys
+
+
+if __name__ == "__main__":
+    # Windows spawn-safe entry point for ad-hoc runs.
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Part of #768 (item 3.3).

- Validation now reports a deploy-ready confidence threshold instead of folklore 0.25: metrics/best_conf (global, micro-averaged), metrics/best_conf_f1, and metrics/best_conf_per_class, defined as the F1-maximizing score threshold at IoU 0.50.
- Zero extra matching cost: one descending sort + cumsum over match results the evaluator already produced. pycocotools path reads evalImgs directly (crowd/ignore semantics preserved: ignored detections are neither TP nor FP). The default faster-coco-eval backend does not retain usable per-IoU matches, so the greedy assignment is replayed at IoU 0.50 on its retained IoU matrices; a randomized cross-backend parity test pins this to the pycocotools reference.
- Additive only: a regression test asserts the pre-existing metric key set and values are bit-exact, with only the three new keys added. Per-class table prints under the existing verbose gate; plots and loggers unaffected.
- Ties handled atomically (a threshold includes or excludes a tie group as a whole, resolving to the higher threshold); undeterminable cases (no predictions, no GT, all-FP) report NaN.
- Tests: 17 new (both backends parametrized); validation/metric/logger selection 721 passed.

## Code provenance

All code is original, written for this PR.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds global and per-class F1-optimal confidence thresholds to detection validation while preserving existing COCO metrics.
- Extracts match results from pycocotools or replays matching over retained IoU matrices for faster-coco-eval.
- Publishes the optimal threshold and F1 through validation metrics and verbose reporting.
- Adds cross-backend and edge-case tests for threshold selection, ties, ignored detections, and metric compatibility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/validation/coco_evaluator.py | Adds F1 threshold sweeping and backend-specific extraction of per-class detection matches; the prior provenance concern is addressed by explicitly identifying the matching logic as an original reimplementation. |
| libreyolo/validation/detection_validator.py | Exposes global and per-class confidence-threshold metrics and prints the detailed threshold table without passing its nested mapping to generic metric formatting. |
| libreyolo/models/base/model.py | Documents the newly returned validation metrics and their NaN semantics. |
| tests/unit/test_best_conf_threshold.py | Tests known optima, score and F1 ties, empty and all-false-positive cases, crowd handling, backend parity, and preservation of existing metric outputs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["State the matching replay is an original..."](https://github.com/libreyolo/libreyolo/commit/0e6dd71a33b976b28a94aa5e4d89fad8fe907593) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53404146)</sub>

**Context used:**

- Knowledge Base — [Validation Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/validation-pipeline.md)

<!-- /greptile_comment -->