### PR TITLE
Close remaining #744 leftovers

### DIFF
--- a/.github/workflows/e2e-nightly-release.yml
+++ b/.github/workflows/e2e-nightly-release.yml
@@ -10,6 +10,10 @@ on:
         description: "Run regardless of SHA cache"
         type: boolean
         default: false
+      ref:
+        description: "Immutable tag to test (vX.Y.Z). Empty means current release tip."
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -21,22 +25,46 @@ jobs:
     outputs:
       should_run: ${{ steps.diff.outputs.should_run }}
       target_sha: ${{ steps.resolve.outputs.target_sha }}
+      target_label: ${{ steps.resolve.outputs.target_label }}
       cache_key: ${{ steps.resolve.outputs.cache_key }}
       cache_hit: ${{ steps.cache-target.outputs.cache-hit }}
     steps:
       - id: resolve
-        name: Resolve current release SHA
+        name: Resolve release target SHA
+        env:
+          REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          TARGET_SHA=$(git ls-remote https://github.com/LibreYOLO/libreyolo refs/heads/release | cut -f1)
+          # A tag pin is required after publish: refs/heads/release can move
+          # between the GitHub release and this dispatch, and then the suite
+          # would test a different commit than the one PyPI just got.
+          if [ -n "${REF:-}" ]; then
+            if ! printf '%s' "$REF" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "ref must look like vX.Y.Z, got: $REF"
+              exit 1
+            fi
+            TARGET_SHA=$(git ls-remote https://github.com/LibreYOLO/libreyolo "refs/tags/${REF}^{}" | cut -f1)
+            if [ -z "$TARGET_SHA" ]; then
+              TARGET_SHA=$(git ls-remote https://github.com/LibreYOLO/libreyolo "refs/tags/${REF}" | cut -f1)
+            fi
+            if [ -z "$TARGET_SHA" ]; then
+              echo "No such tag: $REF"
+              exit 1
+            fi
+            TARGET_LABEL="tag ${REF}"
+          else
+            TARGET_SHA=$(git ls-remote https://github.com/LibreYOLO/libreyolo refs/heads/release | cut -f1)
+            TARGET_LABEL="release tip"
+          fi
           # The cache key carries an ISO week so a frozen target is still
           # retested once a week. A SHA-only key means a quiet branch is never
           # re-run, and the environment underneath it drifts untested.
           WINDOW=$(date -u +%G-W%V)
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+          echo "target_label=$TARGET_LABEL" >> "$GITHUB_OUTPUT"
           echo "window=$WINDOW" >> "$GITHUB_OUTPUT"
           echo "cache_key=last-tested-nightly-release-$TARGET_SHA-$WINDOW" >> "$GITHUB_OUTPUT"
-          echo "Resolved: release=$TARGET_SHA window=$WINDOW"
+          echo "Resolved: ${TARGET_LABEL}=$TARGET_SHA window=$WINDOW"
 
       # restore, not cache: this job never creates the marker file, so the
       # save-on-post of actions/cache would warn every run and could claim the
@@ -53,6 +81,7 @@ jobs:
           FORCE: ${{ inputs.force }}
           HIT_TARGET: ${{ steps.cache-target.outputs.cache-hit }}
           TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+          TARGET_LABEL: ${{ steps.resolve.outputs.target_label }}
           WINDOW: ${{ steps.resolve.outputs.window }}
         run: |
           set -euo pipefail
@@ -61,10 +90,10 @@ jobs:
             REASON="forced by workflow_dispatch input"
           elif [ "${HIT_TARGET:-}" = "true" ]; then
             SHOULD_RUN=false
-            REASON="release@${TARGET_SHA} already passed a nightly in week ${WINDOW}"
+            REASON="${TARGET_LABEL}@${TARGET_SHA} already passed a nightly in week ${WINDOW}"
           else
             SHOULD_RUN=true
-            REASON="no passing nightly recorded for release@${TARGET_SHA} in week ${WINDOW}"
+            REASON="no passing nightly recorded for ${TARGET_LABEL}@${TARGET_SHA} in week ${WINDOW}"
           fi
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
           echo "Should run release: $SHOULD_RUN ($REASON)"
@@ -80,7 +109,7 @@ jobs:
           {
             echo "### Nightly guard: $VERDICT"
             echo
-            echo "- Target: \`release@${TARGET_SHA}\`"
+            echo "- Target: \`${TARGET_LABEL}@${TARGET_SHA}\`"
             echo "- Week window: \`${WINDOW}\`"
             echo "- Reason: ${REASON}"
             echo
@@ -102,7 +131,7 @@ jobs:
     steps:
       - name: Explain the skip
         run: |
-          echo "No GPU suite ran. release@${{ needs.guard.outputs.target_sha }} already"
+          echo "No GPU suite ran. ${{ needs.guard.outputs.target_label }}@${{ needs.guard.outputs.target_sha }} already"
           echo "passed a nightly this week. Re-dispatch with force=true to retest."
 
   e2e:

--- a/NOTICE
+++ b/NOTICE
@@ -33,7 +33,7 @@ DINOv3 (Meta DINOv3 License Agreement)
     rest of LibreYOLO remains under the MIT License.
 
 SenseNova-Vision / Bagel (Apache License 2.0 code; CC BY-NC 4.0 weights,
-not redistributed)
+mirrored under that license)
     Path:    libreyolo/models/sensenova/
     License: libreyolo/models/sensenova/NOTICE  (Apache-2.0 code sources)
     Source:  https://github.com/OpenSenseNova/SenseNova-Vision

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -31,13 +31,33 @@ model-specific engine filename.
 `nvinfer` needs a custom bounding-box parser for this output layout. The
 generated config targets `NvDsInferParseYolo` from the MIT-licensed
 [DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo)
-project. Build it once per device:
+project. Build it once per device, **inside the DeepStream container**.
+A host-side `CUDA_VER=12.8 make` is not enough: on the validated
+`nvcr.io/nvidia/deepstream:8.0-samples-multiarch` image, `/usr/local/cuda-12`
+is a stub (`fatal error: crt/host_defines.h: No such file or directory`)
+and the image ships `libcublas.so.12` but not the unversioned
+`libcublas.so` that `-lcublas` needs.
 
 ```bash
-git clone https://github.com/marcoslucianops/DeepStream-Yolo
-cd DeepStream-Yolo
-# CUDA_VER: see /usr/local/cuda/version.json (Jetson and x86 differ)
-CUDA_VER=12.8 make -C nvdsinfer_custom_impl_Yolo
+git clone --depth 1 https://github.com/marcoslucianops/DeepStream-Yolo.git
+
+# Prefer a toolkit that actually carries the CUDA headers. On the 8.0
+# image that is cuda-12.5, not the cuda-12 stub.
+CUDA_DIR=$(readlink -f /usr/local/cuda)
+[ -f "$CUDA_DIR/include/crt/host_defines.h" ] || \
+  CUDA_DIR=$(ls -d /usr/local/cuda-*.* | sort -Vr | \
+             while read d; do [ -f "$d/include/crt/host_defines.h" ] && echo "$d" && break; done)
+
+# Give the linker the unversioned sonames it asks for.
+mkdir -p /tmp/cudalibs
+for lib in cublas cublasLt cudart; do
+  real=$(find /usr/local -name "lib${lib}.so.1*" | grep -v stubs | sort -V | tail -1)
+  ln -sf "$real" "/tmp/cudalibs/lib${lib}.so"
+done
+export LIBRARY_PATH="/tmp/cudalibs:$LIBRARY_PATH"
+
+make -C DeepStream-Yolo/nvdsinfer_custom_impl_Yolo \
+  CUDA_VER="${CUDA_DIR##*/cuda-}"
 ```
 
 Adjust `custom-lib-path` in the generated config to the built
@@ -65,13 +85,15 @@ as a secondary classifier behind a detector.
 
 **Instance segmentation** (`network-type=3`, needs the *seg* parser build):
 rfdetr, dfine, ec. Rows are the detection row followed by that instance's
-mask, flattened at `(netH / 4, netW / 4)` — the resolution the seg parser
-hardcodes — as probabilities for `segmentation-threshold`. This parser is a
-separate MIT project and a separate build:
+mask, flattened at `(netH / 4, netW / 4)` (the resolution the seg parser
+hardcodes) as probabilities for `segmentation-threshold`. This parser is a
+separate MIT project and a separate build, using the same CUDA_DIR and
+LIBRARY_PATH setup as the detector parser:
 
 ```bash
-git clone https://github.com/marcoslucianops/DeepStream-Yolo-Seg
-CUDA_VER=12.8 make -C DeepStream-Yolo-Seg/nvdsinfer_custom_impl_Yolo_seg
+git clone --depth 1 https://github.com/marcoslucianops/DeepStream-Yolo-Seg.git
+make -C DeepStream-Yolo-Seg/nvdsinfer_custom_impl_Yolo_seg \
+  CUDA_VER="${CUDA_DIR##*/cuda-}"
 ```
 
 LibreYOLO's seg families export per-query masks directly, so the graph only

--- a/libreyolo/models/lingbotvision/model.py
+++ b/libreyolo/models/lingbotvision/model.py
@@ -83,6 +83,10 @@ class LibreLingBotVision(BaseModel):
     DEFAULT_TASK: ClassVar[str] = "semantic"
     REQUIRE_TASK_SUFFIX: ClassVar[bool] = True
     INPUT_SIZES: ClassVar[Dict[str, int]] = {size: 512 for size in SIZE_CONFIGS}
+    # g is the 1.1B teacher: loadable and fine-tunable, but no LibreYOLO-hosted
+    # checkpoint exists for it (see the module docstring). Kept as data so
+    # get_download_url and the error message cannot drift apart.
+    UNPUBLISHED_SIZES: ClassVar[Tuple[str, ...]] = ("g",)
 
     # ViT square canvas: stretch-resize (like LibreDINOv2), patch-16 grid.
     semantic_resize_mode: ClassVar[str] = "stretch"
@@ -90,6 +94,42 @@ class LibreLingBotVision(BaseModel):
     # The linear-probe recipe uses no photometric jitter; SemanticDataset
     # defaults to 0.5, so declare it explicitly (see LibreSegformer precedent).
     semantic_hsv_prob: ClassVar[float] = 0.0
+
+    # ------------------------------------------------------------------
+    # Weight download
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        """Refuse to auto-download the sizes that have no published weights.
+
+        Sizes s/b/l are hosted under ``LibreYOLO/``; g is the 1.1B teacher and
+        is not. Left to the base implementation, ``lingbotvision-g`` builds a
+        URL for a repo that does not exist and the user gets an HTTP failure
+        against ``LibreYOLO/LibreLingBotVisiong-sem``, which reads like an
+        outage rather than a checkpoint that was never published. Raise with
+        the reason instead.
+
+        The size guard matters: ``download_weights`` asks every registered
+        family in turn and takes the first non-None answer, so raising on a
+        filename that is not ours would hijack another family's download.
+        """
+        name = Path(filename).name
+        size = cls.detect_size_from_filename(name)
+        if size is None:
+            return None
+        if size in cls.UNPUBLISHED_SIZES:
+            published = ", ".join(
+                f"{cls.FAMILY}-{s}" for s in SIZE_CONFIGS if s not in cls.UNPUBLISHED_SIZES
+            )
+            raise FileNotFoundError(
+                f"{name}: LibreYOLO publishes no weights for {cls.FAMILY}-{size}. "
+                f"Size {size} is the upstream teacher backbone, supported for loading "
+                f"and fine-tuning from a local checkpoint but never mirrored under "
+                f"LibreYOLO/. Pass a local .pt path, or use one of the published "
+                f"sizes: {published}."
+            )
+        return super().get_download_url(name)
 
     # ------------------------------------------------------------------
     # Registry / can_load interface

--- a/skills/libreyolo-release/SKILL.md
+++ b/skills/libreyolo-release/SKILL.md
@@ -99,8 +99,9 @@ gh pr list -R LibreYOLO/libreyolo --base dev --state open --limit 30
 ```
 
 Confirm with the user: version label (`vX.Y.Z`), base tag, and which gates
-to run (default: all except RF5). Then proceed without further check-ins
-until the go/no-go.
+to run (default: all except RF5). RF5 is skipped by standing decision
+(issue #744 item 18), not by accident; a SKIPPED RF5 row is not an open
+defect. Then proceed without further check-ins until the go/no-go.
 
 ## Phase 1: Changelog by fan-out (facts first, prose second)
 
@@ -271,6 +272,13 @@ Only `status == "passed"` on the candidate SHA counts; then skip the re-run,
 that is the point of reusing the nightly. Anything else, including three
 consecutive green runs, is not evidence about the candidate.
 
+**A green nightly on an ancestor is not a pass on the tag.** v1.5.0 Gate B
+ran on `7fd0c5df`; the tag is `c25f6dff` (version bump, docs, and the
+Windows `os.replace` retry). The next cut must re-run (or wait for a
+nightly that already targeted) the SHA that will be tagged, not the last
+green ancestor. After the version-bump commit lands, Gate B evidence older
+than that commit is stale.
+
 Note the artifact exists **only** for the dev workflow. The release and PyPI
 workflows run on the self-hosted runner and upload nothing, so for those the
 evidence is the job list plus the run conclusion from question 1.
@@ -418,13 +426,19 @@ pip index versions libreyolo
 # POSIX (on Windows use a scratchpad venv + Scripts/python.exe):
 python -m venv /tmp/pypismoke && /tmp/pypismoke/bin/pip install libreyolo==X.Y.Z
 /tmp/pypismoke/bin/python -c "import libreyolo; assert libreyolo.__version__ == 'X.Y.Z'"
-# GPU e2e against the released branch (manual dispatch only)
+# GPU e2e against the tagged SHA (mandatory dispatch; do not skip)
 gh workflow run e2e-nightly-release.yml -R LibreYOLO/libreyolo
+# Confirm the run resolved the tag, not an earlier commit:
+#   gh run list -R LibreYOLO/libreyolo --workflow e2e-nightly-release.yml --limit 1
+#   the run's headSha must equal `git rev-parse vX.Y.Z`
 ```
 
-Append results to the scoreboard. The release is "done" when PyPI installs
-clean and the release nightly is green (or dispatched with the user's OK to
-not wait).
+Append results to the scoreboard. Dispatching the release nightly is
+required; the user may OK not waiting for it to go green, but they may
+not OK skipping the dispatch. The 1.5.0 cut credited Gate B on an
+ancestor of the tag and never dispatched this workflow (issue #744
+item 16). The release is "done" when PyPI installs clean and the
+release nightly has been dispatched against the tag SHA.
 
 ## Phase 5: Marketing handoff
 
@@ -457,6 +471,9 @@ the user to post by hand.
   nor the artifact name is the evidence. The evidence is an `e2e` job that
   concluded `success`, plus `status == "passed"` inside
   `modal-nightly-result.json`.
+- Crediting Gate B on a SHA that is not the tag. An ancestor nightly does
+  not measure the bump commit. Dispatch `e2e-nightly-release.yml` after
+  publish and check that the run's `headSha` equals `git rev-parse vX.Y.Z`.
 - Squash-merging the release PR.
 - Bumping the version on dev instead of on the release-PR branch.
 - Skipping Phase 4 because "publish.yml was green" (green publish and a

--- a/skills/libreyolo-release/SKILL.md
+++ b/skills/libreyolo-release/SKILL.md
@@ -426,11 +426,15 @@ pip index versions libreyolo
 # POSIX (on Windows use a scratchpad venv + Scripts/python.exe):
 python -m venv /tmp/pypismoke && /tmp/pypismoke/bin/pip install libreyolo==X.Y.Z
 /tmp/pypismoke/bin/python -c "import libreyolo; assert libreyolo.__version__ == 'X.Y.Z'"
-# GPU e2e against the tagged SHA (mandatory dispatch; do not skip)
-gh workflow run e2e-nightly-release.yml -R LibreYOLO/libreyolo
-# Confirm the run resolved the tag, not an earlier commit:
-#   gh run list -R LibreYOLO/libreyolo --workflow e2e-nightly-release.yml --limit 1
-#   the run's headSha must equal `git rev-parse vX.Y.Z`
+# GPU e2e against the tagged SHA (mandatory dispatch; do not skip).
+# Pass the tag: the workflow otherwise resolves refs/heads/release, which
+# can move after the tag is cut. github.run.headSha is the default branch
+# at dispatch time and is not the evidence.
+gh workflow run e2e-nightly-release.yml -R LibreYOLO/libreyolo \
+  -f ref=vX.Y.Z -f force=true
+# Confirm the guard resolved that tag. The step summary line is
+# "Target: `tag vX.Y.Z@<sha>`" and <sha> must equal `git rev-parse vX.Y.Z`.
+# github.run.headSha is the default branch at dispatch time; ignore it.
 ```
 
 Append results to the scoreboard. Dispatching the release nightly is
@@ -473,7 +477,8 @@ the user to post by hand.
   `modal-nightly-result.json`.
 - Crediting Gate B on a SHA that is not the tag. An ancestor nightly does
   not measure the bump commit. Dispatch `e2e-nightly-release.yml` after
-  publish and check that the run's `headSha` equals `git rev-parse vX.Y.Z`.
+  publish with `-f ref=vX.Y.Z` and check that the guard resolved that tag
+  SHA, not `refs/heads/release`.
 - Squash-merging the release PR.
 - Bumping the version on dev instead of on the release-PR branch.
 - Skipping Phase 4 because "publish.yml was green" (green publish and a

--- a/tests/unit/test_lingbotvision.py
+++ b/tests/unit/test_lingbotvision.py
@@ -305,3 +305,50 @@ def test_lingbotvision_train_smoke(tmp_path):
         amp=False,
     )
     assert result.get("best_checkpoint") or result.get("last_checkpoint")
+
+
+def test_unpublished_size_download_explains_itself():
+    """``lingbotvision-g`` has no hosted checkpoint, so say so, do not 404.
+
+    Sizes s/b/l are mirrored under ``LibreYOLO/``; g is the 1.1B teacher and
+    never was. Left to the base implementation the user gets an HTTP failure
+    against a repo that does not exist, which reads like an outage rather
+    than a checkpoint that was never published.
+    """
+    from libreyolo.models.lingbotvision.model import LibreLingBotVision
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        LibreLingBotVision.get_download_url("LibreLingBotVisiong-sem.pt")
+    message = str(excinfo.value)
+    assert "publishes no weights" in message
+    assert "lingbotvision-s" in message
+    assert "lingbotvision-l" in message
+    assert "lingbotvision-g" not in message.split("published sizes:")[-1]
+
+
+@pytest.mark.parametrize("size", ["s", "b", "l"])
+def test_published_sizes_still_resolve(size):
+    """The guard must not swallow the sizes that are actually hosted."""
+    from libreyolo.models.lingbotvision.model import LibreLingBotVision
+
+    url = LibreLingBotVision.get_download_url(f"LibreLingBotVision{size}-sem.pt")
+    assert url == (
+        f"https://huggingface.co/LibreYOLO/LibreLingBotVision{size}-sem"
+        f"/resolve/main/LibreLingBotVision{size}-sem.pt"
+    )
+
+
+@pytest.mark.parametrize(
+    "foreign",
+    ["LibreSegformerb0-sem.pt", "LibreDINOv2s-sem.pt", "LibreYOLO9t.pt", "LibreDOMEDETRs-aitod.pt"],
+)
+def test_download_hook_ignores_other_families(foreign):
+    """The hook must claim only LingBot-Vision filenames.
+
+    ``download_weights`` asks every registered family in turn and takes the
+    first non-None answer, so a hook that raised on a foreign name would
+    hijack that family's download with the wrong error.
+    """
+    from libreyolo.models.lingbotvision.model import LibreLingBotVision
+
+    assert LibreLingBotVision.get_download_url(foreign) is None

--- a/tests/unit/test_repository_capability_language.py
+++ b/tests/unit/test_repository_capability_language.py
@@ -41,6 +41,9 @@ def _tracked_paths() -> list[Path]:
 # script now raises TypeError searches the docs for the argument in their own
 # traceback and finds nothing. Keep those two exempt and the guard absolute
 # everywhere else, including every other doc page, model card and source file.
+# Reviewed again after the 1.5.0 cut (#744 item 17): the exemption stays.
+# Naming the retired argument in the historical record is the point of those
+# two files; widening the ban to them would hide the migration path.
 _HISTORICAL_RECORD = ("CHANGELOG.md", "docs/upgrading.md")
 
 

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -552,6 +552,15 @@ project the weights were derived from. Per-family summary:
              No code is ported from either project; both graphs are
              consumed opaquely at runtime.
 
+    SenseNova-Vision (LibreYOLO/SenseNovaVision7b)     CC BY-NC 4.0
+             upstream: OpenSenseNova/SenseNova-Vision (Apache-2.0 code,
+             commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c). Weights are
+             CC BY-NC 4.0, mirrored byte-identically with attribution at
+             LibreYOLO/SenseNovaVision7b. The loader prints the
+             non-commercial notice before every automatic download. NOT
+             covered by LibreYOLO's permissive license. No CC BY-NC 4.0
+             source is ported; see libreyolo/models/sensenova/NOTICE.
+
 The LICENSE and NOTICE files on each Hugging Face model card are the
 authoritative source for redistribution terms. Users converting
 third-party checkpoints locally are responsible for complying with the


### PR DESCRIPTION
What: leftover #744 items plus the unmerged lingbotvision-g hook
Why: these were still open on dev after #773

- lingbotvision-g raises FileNotFoundError and names the published sizes (closed unmerged #741; CHANGELOG already claimed this)
- docs/deepstream.md parser build matches the validated DeepStream 8.0 recipe
- SenseNova CC BY-NC mirrors listed in weights/LICENSE_NOTICE.txt; root NOTICE heading no longer says "not redistributed"
- Release skill: dispatch e2e-nightly-release.yml against the tag SHA; do not credit Gate B on an ancestor; RF5 skip is a standing decision (#744 items 16, 18)
- Capability-language exemption reaffirmed in the test comment (#744 item 17)

Check: tests/unit/test_lingbotvision.py download tests (9 passed); DeepStream recipe vs website export/deepstream.md
Not verified: parser rebuild on DeepStream 8.0; Jetson 1.5.0 Orin re-run (board unreachable this session); FCN -sem HF mirrors (left as the #773 reject path)
Opened by an agent.

## Code provenance
Original code written for this PR. The lingbotvision-g hook follows the in-repo Dome-DETR download-guard pattern. DeepStream build steps transcribe the already-published website recipe; no third-party code is copied. Notice entries transcribe attribution facts already recorded in NOTICE and libreyolo/models/sensenova/NOTICE. No third-party code ported, adapted, or introduced.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR closes release-process, model-download, deployment-documentation, and licensing leftovers from #744.
- Pins release-nightly validation to an immutable version tag and documents the required dispatch procedure.
- Adds an explicit error for unpublished LingBotVision-g weights with coverage for published and foreign model names.
- Updates the DeepStream 8.0 parser build recipe and SenseNova weight attribution.
- Reaffirms the capability-language exemption and standing RF5 decision.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/e2e-nightly-release.yml | Resolves an optional version tag to a commit SHA and propagates that immutable target through the existing guarded e2e checkout. |
| skills/libreyolo-release/SKILL.md | Requires release-nightly dispatch against the published tag and prevents ancestor runs from satisfying the release gate. |
| libreyolo/models/lingbotvision/model.py | Rejects automatic downloads for the unpublished g checkpoint while preserving published-size and foreign-family resolution. |
| docs/deepstream.md | Revises parser compilation instructions for the validated DeepStream 8.0 container environment. |
| weights/LICENSE_NOTICE.txt | Records the SenseNovaVision7b mirror and its CC BY-NC 4.0 restrictions. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Pin the release nightly to the tag, not ..."](https://github.com/libreyolo/libreyolo/commit/ee0c90352399b8b0ab4aa7777becbe41617e9d37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53488829)</sub>

<!-- /greptile_comment -->