### PR TITLE
Add the FiftyOne integration

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,6 +71,33 @@ jobs:
           -m "${{ env.PR_GATE_MARKERS }} and not distributed"
           -n auto --dist loadfile --durations=25
 
+  # Optional-dependency job for the FiftyOne integration. Linux only and in its
+  # own job for two reasons: fiftyone starts a local MongoDB, and it pulls
+  # opencv-python-headless, which overwrites the cv2 the rest of the suite
+  # expects to be GUI-capable. The tests here use synthetic data, so nothing is
+  # downloaded.
+  fiftyone-integration:
+    name: fiftyone integration (linux)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Create virtual environment
+        run: uv venv --python 3.10
+
+      - name: Install dependencies
+        run: uv pip install --no-sources --torch-backend cpu --group dev -e ".[fiftyone]"
+
+      - name: Run FiftyOne integration tests
+        run: uv run --no-sync pytest tests/unit/test_integrations_fiftyone.py -m "unit or fiftyone" --durations=25
+
   # Multi-rank gloo tests. Serial, and Linux only.
   #
   # Linux only: they cover distributed-training math, which is platform

--- a/docs/fiftyone.md
+++ b/docs/fiftyone.md
@@ -1,0 +1,159 @@
+# FiftyOne integration
+
+[FiftyOne](https://github.com/voxel51/fiftyone) (Apache-2.0) is a dataset
+curation and prediction-analysis tool. `libreyolo.integrations.fiftyone` sends
+LibreYOLO predictions into a FiftyOne dataset and moves datasets in both
+directions between a LibreYOLO dataset yaml and a FiftyOne dataset.
+
+Nothing is vendored and nothing is imported at `import libreyolo` time. The
+module imports `fiftyone` lazily and raises an install hint when it is absent.
+
+## Install
+
+```bash
+pip install "libreyolo[fiftyone]"
+```
+
+Two things to know before installing into an existing environment:
+
+- FiftyOne depends on `opencv-python-headless` while LibreYOLO depends on
+  `opencv-python`. Both ship the same `cv2` module, so pip leaves whichever
+  landed last in place. Installing FiftyOne second gives a headless `cv2`
+  (`cv2.getBuildInformation()` reports `GUI: NONE`), which breaks the window
+  paths: `predict(show=True)`, video display, and the labeller preview.
+  Reinstall `opencv-python` afterwards if you need those, or keep FiftyOne in
+  its own environment. This is why `libreyolo[fiftyone]` is not part of
+  `libreyolo[all]`.
+- FiftyOne runs a local MongoDB (`fiftyone-db`), started on first use. It needs
+  write access to `~/.fiftyone`.
+
+## Predictions into FiftyOne
+
+```python
+import fiftyone as fo
+from libreyolo import LibreYOLO
+from libreyolo.integrations.fiftyone import apply_model
+
+dataset = fo.load_dataset("my-dataset")
+model = LibreYOLO("LibreYOLO9s.pt")
+apply_model(dataset, model, label_field="predictions", conf=0.25, batch_size=8)
+
+session = fo.launch_app(dataset)
+```
+
+`apply_model` accepts a loaded model or a checkpoint name, forwards `conf`,
+`iou`, `imgsz`, `device`, `classes`, and `max_det` to `model.predict`, and runs
+through FiftyOne's own `apply_model`, so the progress bar, `skip_failures`, and
+batching behave the way FiftyOne users expect. `batch_size` maps onto
+LibreYOLO's batched list inference: one stacked forward per chunk.
+
+To use the model with any other FiftyOne API that takes a model, wrap it
+directly:
+
+```python
+from libreyolo.integrations.fiftyone import to_fiftyone_model
+
+fo_model = to_fiftyone_model("LibreYOLO9s.pt", conf=0.25)
+dataset.apply_model(fo_model, label_field="predictions")
+```
+
+### What each task writes
+
+| Task | FiftyOne label | Field |
+|---|---|---|
+| detect | `fo.Detections` | `label_field` |
+| segment | `fo.Detections` with per-box masks | `label_field` |
+| segment, `mask_format="polyline"` | `fo.Polylines` | `label_field` |
+| obb | `fo.Polylines`, closed and filled | `label_field` |
+| pose | `fo.Keypoints` plus `fo.Detections` | `label_field_keypoints`, `label_field_detections` |
+| classify | `fo.Classification` (top-1) | `label_field` |
+
+Coordinates follow FiftyOne's convention: boxes are normalized `[x, y, w, h]`
+against the original image, keypoints are normalized `[x, y]` with
+`[nan, nan]` for points the model did not see, and instance masks are boolean
+arrays cropped to their box. Boxes are clipped to the image before
+normalization, which is what the COCO evaluators do too. Track ids, when the
+source was tracked, land in `Detection.index`.
+
+## Datasets in and out
+
+```python
+from libreyolo.integrations.fiftyone import from_fiftyone, to_fiftyone
+
+dataset = to_fiftyone("coco128.yaml", split="val")     # ground truth attached
+yaml_path = from_fiftyone(curated_view, "data/curated", split="train")
+```
+
+`to_fiftyone` reads both layouts in
+[`docs/dataset_schema.md`](dataset_schema.md): the YOLO layout (`images/` plus
+`labels/`, including `.txt` image lists) and native COCO JSON through the
+yaml's `annotations` mapping. Ground truth lands in `ground_truth` by default.
+Labels in both layouts are already normalized, so no image is decoded.
+
+`from_fiftyone` exports a dataset or a filtered view as a LibreYOLO-trainable
+dataset and returns the yaml path. Pass `classes=` to fix the class ids:
+without it, the exported yaml only contains the classes present in the view,
+so ids shift. Calling it twice against the same directory with `split="train"`
+and `split="val"` writes one yaml with both splits.
+
+## Workflow: find your model's worst predictions
+
+```python
+import fiftyone as fo
+from libreyolo import LibreYOLO
+from libreyolo.integrations.fiftyone import apply_model, to_fiftyone
+
+dataset = to_fiftyone("coco128.yaml", split="val")
+apply_model(dataset, LibreYOLO("LibreYOLO9s.pt"), label_field="predictions")
+
+results = dataset.evaluate_detections(
+    "predictions", gt_field="ground_truth", eval_key="eval", compute_mAP=True
+)
+print(results.mAP())
+results.print_report()
+
+# Images where the model is most wrong, worst first.
+worst = dataset.sort_by("eval_fp", reverse=True)
+session = fo.launch_app(worst)
+```
+
+`eval_key` writes per-sample `eval_tp` / `eval_fp` / `eval_fn` counts and tags
+every box as a true positive, false positive, or false negative, so the App can
+filter down to the failures themselves.
+
+## Workflow: find label errors before training
+
+```python
+import fiftyone.brain as fob
+from libreyolo import LibreYOLO
+from libreyolo.integrations.fiftyone import apply_model, from_fiftyone, to_fiftyone
+
+dataset = to_fiftyone("my-dataset.yaml", split="train")
+apply_model(dataset, LibreYOLO("LibreYOLO9s.pt"), label_field="predictions")
+
+fob.compute_mistakenness(dataset, "predictions", label_field="ground_truth")
+
+suspect = dataset.sort_by("mistakenness", reverse=True).limit(50)
+# Fix or drop the bad labels in the App, then export what survives.
+clean = dataset.match_tags("bad_label", bool=False)
+yaml_path = from_fiftyone(clean, "data/clean", split="train", classes=classes)
+```
+
+Then train on `yaml_path` as usual. Mistakenness needs predictions from a model
+that did not train on these exact labels for the ranking to mean anything.
+
+## Validated
+
+Local CPU run against coco128 (128 images) with `LibreYOLO9s.pt`:
+
+- `to_fiftyone` loads 128 samples with ground truth; `apply_model` writes 704
+  boxes; `evaluate_detections` reports mAP 0.5238.
+- Box coordinates round-trip against `model.predict` to 3e-5 px, so the
+  letterbox geometry the App draws is the geometry the model produced.
+- `from_fiftyone` output loads back through `load_data_config`.
+- Tasks exercised: YOLO9 detect (single and batched), RF-DETR detect,
+  RF-DETR instance segmentation in both mask and polyline form, RTDETRv2 obb,
+  HRNet pose, DeiT classify.
+
+The `fiftyone`-marked tests in `tests/unit/test_integrations_fiftyone.py` cover
+the same round trip on synthetic data, with no weight downloads.

--- a/libreyolo/integrations/__init__.py
+++ b/libreyolo/integrations/__init__.py
@@ -1,0 +1,8 @@
+"""Optional third-party integrations.
+
+Nothing here is imported by ``import libreyolo``. Each submodule imports its
+third-party package lazily and raises a clear install hint when it is absent,
+so an integration never adds an import-time cost or a hard dependency.
+"""
+
+__all__: list[str] = []

--- a/libreyolo/integrations/fiftyone.py
+++ b/libreyolo/integrations/fiftyone.py
@@ -1,0 +1,706 @@
+"""FiftyOne integration: predictions in, datasets in and out.
+
+FiftyOne (https://github.com/voxel51/fiftyone, Apache-2.0) is a dataset
+curation and prediction-analysis tool. This module is a thin adapter, not a
+port: nothing is vendored, ``fiftyone`` is imported lazily, and every entry
+point sits on LibreYOLO's public predict API, so it works for any family
+whose task is covered below.
+
+Typical use::
+
+    import fiftyone as fo
+    from libreyolo import LibreYOLO
+    from libreyolo.integrations.fiftyone import apply_model, to_fiftyone
+
+    dataset = to_fiftyone("coco128.yaml", split="val")
+    apply_model(dataset, LibreYOLO("LibreYOLO9s.pt"), label_field="predictions")
+
+    results = dataset.evaluate_detections("predictions", gt_field="ground_truth")
+    session = fo.launch_app(dataset)
+
+Coordinates follow FiftyOne's convention: boxes and points are normalized to
+``[0, 1]`` against the original image, and instance masks are stored cropped
+to their box. Boxes are clipped to the image before normalization, which is
+what the COCO evaluators do as well.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import numpy as np
+
+__all__ = [
+    "apply_model",
+    "from_fiftyone",
+    "to_fiftyone",
+    "to_fiftyone_model",
+]
+
+_INSTALL_HINT = (
+    "fiftyone is required by libreyolo.integrations.fiftyone. Install it "
+    "with: pip install libreyolo[fiftyone]"
+)
+
+# Tasks whose Results this module knows how to express as FiftyOne labels.
+SUPPORTED_TASKS = ("detect", "segment", "pose", "obb", "classify")
+
+
+def _import_fiftyone():
+    """Import ``fiftyone``, or raise with an install hint."""
+    try:
+        import fiftyone as fo  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - exercised without fiftyone
+        raise ImportError(_INSTALL_HINT) from exc
+    return fo
+
+
+# =========================================================================
+# Results -> FiftyOne payloads
+#
+# These helpers are deliberately fiftyone-free: they turn a Results into
+# plain dicts with FiftyOne's field names, so the geometry is unit-testable
+# without the optional dependency installed.
+# =========================================================================
+
+
+def _as_numpy(value):
+    if value is None:
+        return None
+    if hasattr(value, "detach"):
+        value = value.detach().cpu()
+    return np.asarray(value)
+
+
+def _class_name(names, class_id: int) -> str:
+    """Map a class id to its name, falling back to the stringified id."""
+    class_id = int(class_id)
+    if isinstance(names, dict):
+        name = names.get(class_id)
+    elif names is not None and 0 <= class_id < len(names):
+        name = names[class_id]
+    else:
+        name = None
+    return str(name) if name is not None else str(class_id)
+
+
+def _bounding_box(xyxy, width: int, height: int) -> List[float]:
+    """Convert absolute xyxy to FiftyOne's normalized ``[x, y, w, h]``."""
+    x1, y1, x2, y2 = (float(v) for v in xyxy[:4])
+    x1 = min(max(x1, 0.0), float(width))
+    x2 = min(max(x2, 0.0), float(width))
+    y1 = min(max(y1, 0.0), float(height))
+    y2 = min(max(y2, 0.0), float(height))
+    return [
+        x1 / width,
+        y1 / height,
+        max(x2 - x1, 0.0) / width,
+        max(y2 - y1, 0.0) / height,
+    ]
+
+
+def _crop_mask(mask: np.ndarray, xyxy, width: int, height: int):
+    """Crop a full-canvas instance mask to its box, FiftyOne's mask layout."""
+    x1 = int(max(math.floor(float(xyxy[0])), 0))
+    y1 = int(max(math.floor(float(xyxy[1])), 0))
+    x2 = int(min(math.ceil(float(xyxy[2])), width))
+    y2 = int(min(math.ceil(float(xyxy[3])), height))
+    if x2 <= x1 or y2 <= y1:
+        return None
+    crop = mask[y1:y2, x1:x2]
+    if crop.size == 0:
+        return None
+    return crop.astype(bool)
+
+
+def _detection_payloads(result) -> List[Dict[str, Any]]:
+    """Per-box dicts with FiftyOne ``Detection`` field names."""
+    boxes = result.boxes
+    if boxes is None or len(boxes) == 0:
+        return []
+
+    height, width = (int(v) for v in result.orig_shape)
+    xyxy = _as_numpy(boxes.xyxy)
+    conf = _as_numpy(boxes.conf)
+    cls = _as_numpy(boxes.cls)
+    track_id = _as_numpy(boxes.id)
+    masks = _as_numpy(result.masks.data) if result.masks is not None else None
+
+    payloads = []
+    for i in range(len(boxes)):
+        payload: Dict[str, Any] = {
+            "label": _class_name(result.names, cls[i]),
+            "bounding_box": _bounding_box(xyxy[i], width, height),
+            "confidence": float(conf[i]),
+        }
+        if track_id is not None:
+            payload["index"] = int(track_id[i])
+        if masks is not None and i < len(masks):
+            crop = _crop_mask(masks[i] > 0.5, xyxy[i], width, height)
+            if crop is not None:
+                payload["mask"] = crop
+        payloads.append(payload)
+    return payloads
+
+
+def _obb_payloads(result) -> List[Dict[str, Any]]:
+    """Per-instance dicts with FiftyOne ``Polyline`` field names."""
+    obb = result.obb
+    if obb is None or len(obb) == 0:
+        return []
+
+    height, width = (int(v) for v in result.orig_shape)
+    corners = _as_numpy(obb.xyxyxyxy)
+    conf = _as_numpy(obb.conf)
+    cls = _as_numpy(obb.cls)
+    track_id = _as_numpy(obb.id)
+
+    payloads = []
+    for i in range(len(obb)):
+        ring = [(float(x) / width, float(y) / height) for x, y in corners[i]]
+        payload: Dict[str, Any] = {
+            "label": _class_name(result.names, cls[i]),
+            "points": [ring],
+            "closed": True,
+            "filled": True,
+            "confidence": float(conf[i]),
+        }
+        if track_id is not None:
+            payload["index"] = int(track_id[i])
+        payloads.append(payload)
+    return payloads
+
+
+def _polyline_payloads(result) -> List[Dict[str, Any]]:
+    """Instance masks as normalized polygon rings."""
+    masks = result.masks
+    if masks is None or len(masks) == 0:
+        return []
+
+    boxes = result.boxes
+    conf = _as_numpy(boxes.conf) if boxes is not None else None
+    cls = _as_numpy(boxes.cls) if boxes is not None else None
+
+    payloads = []
+    for i, contour in enumerate(masks.xyn):
+        if len(contour) < 3:
+            continue
+        payload: Dict[str, Any] = {
+            "label": _class_name(result.names, cls[i]) if cls is not None else "object",
+            "points": [[(float(x), float(y)) for x, y in contour]],
+            "closed": True,
+            "filled": True,
+        }
+        if conf is not None and i < len(conf):
+            payload["confidence"] = float(conf[i])
+        payloads.append(payload)
+    return payloads
+
+
+def _keypoint_payloads(result) -> List[Dict[str, Any]]:
+    """Per-instance dicts with FiftyOne ``Keypoint`` field names."""
+    keypoints = result.keypoints
+    if keypoints is None or len(keypoints) == 0:
+        return []
+
+    height, width = (int(v) for v in result.orig_shape)
+    xy = _as_numpy(keypoints.xy)
+    point_conf = _as_numpy(keypoints.conf)
+    boxes = result.boxes
+    cls = _as_numpy(boxes.cls) if boxes is not None else None
+    box_conf = _as_numpy(boxes.conf) if boxes is not None else None
+
+    payloads = []
+    for i in range(len(xy)):
+        points = []
+        for j in range(xy.shape[1]):
+            visible = point_conf is None or float(point_conf[i][j]) > 0
+            if visible:
+                points.append([float(xy[i][j][0]) / width, float(xy[i][j][1]) / height])
+            else:
+                # FiftyOne's convention for a keypoint that was not detected.
+                points.append([float("nan"), float("nan")])
+
+        payload: Dict[str, Any] = {
+            "label": (
+                _class_name(result.names, cls[i])
+                if cls is not None and i < len(cls)
+                else "keypoints"
+            ),
+            "points": points,
+            "index": i,
+        }
+        if point_conf is not None:
+            payload["confidence"] = [float(c) for c in point_conf[i]]
+        elif box_conf is not None and i < len(box_conf):
+            payload["confidence"] = [float(box_conf[i])] * len(points)
+        payloads.append(payload)
+    return payloads
+
+
+def _classification_payload(result) -> Optional[Dict[str, Any]]:
+    """Top-1 dict with FiftyOne ``Classification`` field names."""
+    probs = result.probs
+    if probs is None:
+        return None
+    top1 = probs.top1
+    return {
+        "label": _class_name(result.names, top1),
+        "confidence": float(_as_numpy(probs.top1conf)),
+    }
+
+
+def _to_fiftyone_labels(result, mask_format: str = "mask"):
+    """Convert one ``Results`` into the matching FiftyOne label(s).
+
+    Returns a single ``fiftyone.Label`` for single-slot tasks, or a dict of
+    labels for pose (boxes plus keypoints), which FiftyOne stores as separate
+    fields derived from ``label_field``.
+    """
+    fo = _import_fiftyone()
+    result = result.numpy()
+
+    if result.probs is not None:
+        payload = _classification_payload(result)
+        return fo.Classification(**payload) if payload else None
+
+    if result.obb is not None:
+        return fo.Polylines(polylines=[fo.Polyline(**p) for p in _obb_payloads(result)])
+
+    if result.keypoints is not None:
+        labels = {
+            "keypoints": fo.Keypoints(
+                keypoints=[fo.Keypoint(**p) for p in _keypoint_payloads(result)]
+            )
+        }
+        if result.boxes is not None:
+            labels["detections"] = fo.Detections(
+                detections=[fo.Detection(**p) for p in _detection_payloads(result)]
+            )
+        return labels
+
+    if result.masks is not None and mask_format == "polyline":
+        return fo.Polylines(
+            polylines=[fo.Polyline(**p) for p in _polyline_payloads(result)]
+        )
+
+    if result.boxes is not None:
+        return fo.Detections(
+            detections=[fo.Detection(**p) for p in _detection_payloads(result)]
+        )
+
+    if result.masks is not None:
+        return fo.Polylines(
+            polylines=[fo.Polyline(**p) for p in _polyline_payloads(result)]
+        )
+
+    raise ValueError(
+        "This result carries no label FiftyOne can represent. Supported "
+        f"tasks: {', '.join(SUPPORTED_TASKS)}."
+    )
+
+
+# =========================================================================
+# Model wrapper
+# =========================================================================
+
+_MODEL_CLASS = None
+
+
+def _model_class():
+    """Build the ``fiftyone.core.models.Model`` subclass on first use.
+
+    The class is defined lazily because subclassing requires fiftyone to be
+    importable, and importing this module must not.
+    """
+    global _MODEL_CLASS
+    if _MODEL_CLASS is not None:
+        return _MODEL_CLASS
+
+    _import_fiftyone()
+    import fiftyone.core.models as fom  # noqa: PLC0415
+
+    class LibreYOLOModel(fom.Model):
+        """Runs a LibreYOLO model through FiftyOne's ``apply_model``."""
+
+        def __init__(self, model, mask_format: str = "mask", **predict_kwargs):
+            self.model = model
+            self.mask_format = mask_format
+            self.predict_kwargs = predict_kwargs
+
+        @property
+        def media_type(self) -> str:
+            return "image"
+
+        @property
+        def ragged_batches(self) -> bool:
+            # False is what unlocks FiftyOne's batching: it means "a batch of
+            # transforms() outputs can be passed to predict_all together".
+            # transforms is None here, so FiftyOne hands predict_all the raw
+            # images without stacking them, and LibreYOLO letterboxes each one
+            # to a common size itself. Returning True would make FiftyOne warn
+            # "Model does not support batching" and fall back to one image at
+            # a time.
+            return False
+
+        @property
+        def transforms(self):
+            return None
+
+        @property
+        def preprocess(self) -> bool:
+            return False
+
+        @preprocess.setter
+        def preprocess(self, _value):
+            # FiftyOne sets this while applying a model; preprocessing is
+            # always ours, so the assignment is accepted and ignored.
+            pass
+
+        def predict(self, arg):
+            result = self.model.predict(arg, color_format="rgb", **self.predict_kwargs)
+            if isinstance(result, list):
+                result = result[0]
+            return _to_fiftyone_labels(result, mask_format=self.mask_format)
+
+        def predict_all(self, args):
+            args = list(args)
+            if not args:
+                return []
+            results = self.model.predict(
+                args,
+                batch=len(args),
+                color_format="rgb",
+                **self.predict_kwargs,
+            )
+            if not isinstance(results, list):
+                results = [results]
+            return [
+                _to_fiftyone_labels(r, mask_format=self.mask_format) for r in results
+            ]
+
+    _MODEL_CLASS = LibreYOLOModel
+    return _MODEL_CLASS
+
+
+def _resolve_model(model):
+    """Accept a loaded LibreYOLO model or a checkpoint name/path."""
+    if isinstance(model, (str, Path)):
+        from ..models import LibreYOLO  # noqa: PLC0415
+
+        return LibreYOLO(str(model))
+    return model
+
+
+def to_fiftyone_model(
+    model,
+    *,
+    conf: float = 0.25,
+    iou: float = 0.45,
+    imgsz: Optional[int] = None,
+    device: Optional[str] = None,
+    classes: Optional[Sequence[int]] = None,
+    max_det: int = 300,
+    mask_format: str = "mask",
+    **predict_kwargs,
+):
+    """Wrap a LibreYOLO model as a ``fiftyone.Model``.
+
+    The wrapper plugs into every FiftyOne API that takes a model, including
+    ``dataset.apply_model(...)``.
+
+    Args:
+        model: A loaded LibreYOLO model, or a checkpoint name/path.
+        conf: Confidence threshold.
+        iou: NMS IoU threshold.
+        imgsz: Input size override (None uses the model default).
+        device: Torch device string.
+        classes: Optional class-id filter.
+        max_det: Maximum detections per image.
+        mask_format: ``"mask"`` stores instance masks on the detections;
+            ``"polyline"`` stores them as polygons instead.
+        **predict_kwargs: Forwarded to ``model.predict``.
+
+    Returns:
+        A ``fiftyone.core.models.Model`` instance.
+    """
+    if mask_format not in ("mask", "polyline"):
+        raise ValueError(
+            f"mask_format must be 'mask' or 'polyline', got {mask_format!r}"
+        )
+    return _model_class()(
+        _resolve_model(model),
+        mask_format=mask_format,
+        conf=conf,
+        iou=iou,
+        imgsz=imgsz,
+        device=device,
+        classes=list(classes) if classes is not None else None,
+        max_det=max_det,
+        **predict_kwargs,
+    )
+
+
+def apply_model(
+    samples,
+    model,
+    label_field: str = "predictions",
+    *,
+    conf: float = 0.25,
+    iou: float = 0.45,
+    imgsz: Optional[int] = None,
+    device: Optional[str] = None,
+    classes: Optional[Sequence[int]] = None,
+    max_det: int = 300,
+    mask_format: str = "mask",
+    batch_size: Optional[int] = None,
+    skip_failures: bool = True,
+    progress: Optional[bool] = None,
+    **predict_kwargs,
+):
+    """Run a LibreYOLO model on a FiftyOne dataset or view.
+
+    Args:
+        samples: A ``fiftyone`` dataset or view.
+        model: A loaded LibreYOLO model, or a checkpoint name/path.
+        label_field: Field to write predictions to. Pose models write
+            ``keypoints`` and ``detections`` into fields derived from this
+            name, since one result carries both.
+        conf: Confidence threshold.
+        iou: NMS IoU threshold.
+        imgsz: Input size override (None uses the model default).
+        device: Torch device string.
+        classes: Optional class-id filter.
+        max_det: Maximum detections per image.
+        mask_format: ``"mask"`` or ``"polyline"`` for instance segmentation.
+        batch_size: Images per forward pass. None runs one image at a time.
+        skip_failures: Keep going when a single sample fails.
+        progress: Whether to render a progress bar (FiftyOne's default when
+            None).
+        **predict_kwargs: Forwarded to ``model.predict``.
+
+    Returns:
+        None. Predictions are written to ``samples`` in place.
+    """
+    fo_model = to_fiftyone_model(
+        model,
+        conf=conf,
+        iou=iou,
+        imgsz=imgsz,
+        device=device,
+        classes=classes,
+        max_det=max_det,
+        mask_format=mask_format,
+        **predict_kwargs,
+    )
+    return samples.apply_model(
+        fo_model,
+        label_field=label_field,
+        batch_size=batch_size,
+        skip_failures=skip_failures,
+        progress=progress,
+    )
+
+
+# =========================================================================
+# Dataset bridges
+# =========================================================================
+
+
+def _yolo_rows(label_file: Path) -> List[List[float]]:
+    rows = []
+    if not label_file.exists():
+        return rows
+    for line in label_file.read_text().splitlines():
+        parts = line.split()
+        if not parts:
+            continue
+        rows.append([float(p) for p in parts])
+    return rows
+
+
+def _sample_labels_from_rows(fo, rows, names, task: str):
+    """Build the ground-truth label for one image from its YOLO label rows.
+
+    Coordinates in LibreYOLO label files are already normalized, which is
+    also FiftyOne's convention, so no image read is needed here.
+    """
+    if task == "segment":
+        polylines = []
+        for row in rows:
+            class_id, coords = int(row[0]), row[1:]
+            if len(coords) == 4:
+                cx, cy, w, h = coords
+                x1, y1, x2, y2 = cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2
+                ring = [(x1, y1), (x2, y1), (x2, y2), (x1, y2)]
+            else:
+                ring = list(zip(coords[0::2], coords[1::2]))
+            if len(ring) < 3:
+                continue
+            polylines.append(
+                fo.Polyline(
+                    label=_class_name(names, class_id),
+                    points=[[(float(x), float(y)) for x, y in ring]],
+                    closed=True,
+                    filled=True,
+                )
+            )
+        return fo.Polylines(polylines=polylines)
+
+    detections = []
+    for row in rows:
+        if len(row) < 5:
+            continue
+        class_id = int(row[0])
+        cx, cy, w, h = row[1:5]
+        detections.append(
+            fo.Detection(
+                label=_class_name(names, class_id),
+                bounding_box=[
+                    float(cx - w / 2),
+                    float(cy - h / 2),
+                    float(w),
+                    float(h),
+                ],
+            )
+        )
+    return fo.Detections(detections=detections)
+
+
+def to_fiftyone(
+    data: Union[str, Path],
+    *,
+    split: str = "val",
+    task: str = "detect",
+    label_field: str = "ground_truth",
+    name: Optional[str] = None,
+    persistent: bool = False,
+    max_samples: Optional[int] = None,
+    autodownload: bool = True,
+):
+    """Load a LibreYOLO dataset yaml as a FiftyOne dataset with ground truth.
+
+    Both dataset layouts documented in ``docs/dataset_schema.md`` are
+    supported: the YOLO layout (``images/`` plus ``labels/``, including
+    ``.txt`` image lists) and native COCO JSON via the yaml's ``annotations``
+    mapping.
+
+    Args:
+        data: Dataset name (e.g. ``"coco128"``) or path to a dataset yaml.
+        split: Split to load: ``"train"``, ``"val"``, or ``"test"``.
+        task: ``"detect"`` for boxes or ``"segment"`` for instance shapes.
+        label_field: Field to store ground truth in.
+        name: FiftyOne dataset name (None generates one).
+        persistent: Whether the FiftyOne dataset survives the session.
+        max_samples: Optional cap on the number of samples loaded.
+        autodownload: Allow LibreYOLO to download a missing dataset.
+
+    Returns:
+        A ``fiftyone.Dataset``.
+    """
+    fo = _import_fiftyone()
+    from ..data.utils import load_data_config  # noqa: PLC0415
+
+    if split not in ("train", "val", "test"):
+        raise ValueError(f"split must be 'train', 'val', or 'test', got {split!r}")
+    if task not in ("detect", "segment"):
+        raise ValueError(f"task must be 'detect' or 'segment', got {task!r}")
+
+    config = load_data_config(str(data), autodownload=autodownload)
+    names = config.get("names")
+
+    annotation_file = config.get(f"{split}_annotation_file")
+    if annotation_file:
+        # label_types must be passed explicitly: without it the importer
+        # writes several label types and suffixes each field name, so the
+        # ground truth would land in "<label_field>_detections" instead of
+        # "<label_field>".
+        return fo.Dataset.from_dir(
+            dataset_type=fo.types.COCODetectionDataset,
+            data_path=str(config[split]),
+            labels_path=str(annotation_file),
+            label_field=label_field,
+            label_types="segmentations" if task == "segment" else "detections",
+            name=name,
+            persistent=persistent,
+            max_samples=max_samples,
+        )
+
+    img_files = config.get(f"{split}_img_files")
+    label_files = config.get(f"{split}_label_files")
+    if not img_files:
+        raise ValueError(
+            f"Dataset '{data}' has no images for split '{split}'. Checked "
+            f"{config.get(split)!r}."
+        )
+    if max_samples is not None:
+        img_files = img_files[:max_samples]
+        label_files = label_files[:max_samples] if label_files else None
+
+    dataset = fo.Dataset(name=name, persistent=persistent)
+    samples = []
+    for i, img_file in enumerate(img_files):
+        sample = fo.Sample(filepath=str(img_file))
+        if label_files is not None and i < len(label_files):
+            rows = _yolo_rows(Path(label_files[i]))
+            sample[label_field] = _sample_labels_from_rows(fo, rows, names, task)
+        samples.append(sample)
+    dataset.add_samples(samples)
+    if isinstance(names, dict):
+        dataset.default_classes = [names[k] for k in sorted(names)]
+    elif names:
+        dataset.default_classes = list(names)
+    return dataset
+
+
+def from_fiftyone(
+    samples,
+    export_dir: Union[str, Path],
+    *,
+    label_field: str = "ground_truth",
+    split: str = "val",
+    classes: Optional[Sequence[str]] = None,
+    export_media: Union[bool, str] = True,
+    yaml_name: str = "dataset.yaml",
+) -> Path:
+    """Export a FiftyOne dataset or view as a LibreYOLO-trainable dataset.
+
+    This is the half of the round trip that makes curation actionable: filter
+    or fix a view in FiftyOne, export it here, and train on the yaml.
+
+    Calling this twice against the same ``export_dir`` with different
+    ``split`` values writes both splits into one yaml, which is what training
+    needs (``train`` plus ``val``).
+
+    Args:
+        samples: A ``fiftyone`` dataset or view.
+        export_dir: Directory to write images, labels, and the yaml into.
+        label_field: Field holding the labels to export.
+        split: Split name to write: ``"train"``, ``"val"``, or ``"test"``.
+        classes: Class list fixing the label ids. Defaults to the field's
+            classes as FiftyOne resolves them.
+        export_media: True copies images, ``"symlink"`` links them, False
+            writes labels only.
+        yaml_name: Name of the dataset yaml inside ``export_dir``.
+
+    Returns:
+        Path to the written dataset yaml, ready for ``model.train(data=...)``.
+    """
+    fo = _import_fiftyone()
+
+    if split not in ("train", "val", "test"):
+        raise ValueError(f"split must be 'train', 'val', or 'test', got {split!r}")
+
+    export_dir = Path(export_dir)
+    samples.export(
+        export_dir=str(export_dir),
+        dataset_type=fo.types.YOLOv5Dataset,
+        label_field=label_field,
+        split=split,
+        classes=list(classes) if classes is not None else None,
+        export_media=export_media,
+        yaml_path=yaml_name,
+    )
+    return export_dir / yaml_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,14 @@ siglip2-convert = [
 coreml = [
     "coremltools>=8.0",
 ]
+fiftyone = [
+    # Dataset curation and prediction analysis (Apache-2.0). Deliberately kept
+    # out of `all`: fiftyone depends on opencv-python-headless while LibreYOLO
+    # depends on opencv-python, and both ship the same `cv2` module, so
+    # installing them together leaves whichever landed last in place. See
+    # docs/fiftyone.md.
+    "fiftyone>=1.0.0",
+]
 tensorboard = [
     "tensorboard>=2.13.0",
 ]
@@ -458,6 +466,7 @@ markers = [
     "tflite: tests requiring TensorFlow Lite export",
     "paddle: tests requiring PaddlePaddle export/runtime",
     "coreml: tests requiring CoreML (macOS only)",
+    "fiftyone: tests requiring the optional FiftyOne integration (fiftyone starts a local MongoDB)",
     "yolox: tests covering the YOLOX model family",
     "yolo7: tests covering the YOLOv7 model family",
     "yolo9: tests covering the YOLO9 model family",

--- a/tests/unit/test_integrations_fiftyone.py
+++ b/tests/unit/test_integrations_fiftyone.py
@@ -1,0 +1,376 @@
+"""Unit tests for the FiftyOne integration.
+
+The geometry conversions are tested without fiftyone installed: they return
+plain dicts keyed by FiftyOne's field names, so the payloads can be checked
+directly. Tests that need the package itself are marked ``fiftyone``.
+"""
+
+import subprocess
+import sys
+import types
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.integrations.fiftyone import (
+    _bounding_box,
+    _class_name,
+    _classification_payload,
+    _crop_mask,
+    _detection_payloads,
+    _import_fiftyone,
+    _keypoint_payloads,
+    _obb_payloads,
+    _polyline_payloads,
+    _sample_labels_from_rows,
+    _yolo_rows,
+)
+from libreyolo.utils.results import (
+    OBB,
+    Boxes,
+    Keypoints,
+    Masks,
+    Probs,
+    Results,
+)
+
+pytestmark = pytest.mark.unit
+
+NAMES = {0: "person", 1: "bicycle"}
+
+
+def _detect_result(orig_shape=(100, 200)):
+    boxes = Boxes(
+        torch.tensor([[10.0, 20.0, 110.0, 70.0], [0.0, 0.0, 20.0, 10.0]]),
+        torch.tensor([0.9, 0.4]),
+        torch.tensor([0.0, 1.0]),
+    )
+    return Results(boxes, orig_shape=orig_shape, names=NAMES)
+
+
+class TestGeometry:
+    def test_bounding_box_is_normalized_xywh(self):
+        assert _bounding_box([10, 20, 110, 70], 200, 100) == pytest.approx(
+            [0.05, 0.2, 0.5, 0.5]
+        )
+
+    def test_bounding_box_clips_to_the_image(self):
+        # A box that runs off the canvas cannot overlap ground truth outside
+        # the image, so clipping keeps IoU honest and the App drawable.
+        assert _bounding_box([-50, -10, 250, 120], 200, 100) == pytest.approx(
+            [0.0, 0.0, 1.0, 1.0]
+        )
+
+    def test_class_name_falls_back_to_the_id(self):
+        assert _class_name(NAMES, 0) == "person"
+        assert _class_name(NAMES, 7) == "7"
+        assert _class_name(["a", "b"], 1) == "b"
+        assert _class_name(None, 3) == "3"
+
+    def test_crop_mask_returns_the_box_region(self):
+        mask = np.zeros((100, 200), dtype=bool)
+        mask[20:70, 10:110] = True
+        crop = _crop_mask(mask, [10, 20, 110, 70], 200, 100)
+        assert crop.shape == (50, 100)
+        assert crop.all()
+
+    def test_crop_mask_rejects_a_degenerate_box(self):
+        mask = np.zeros((10, 10), dtype=bool)
+        assert _crop_mask(mask, [5, 5, 5, 5], 10, 10) is None
+
+
+class TestDetectionPayloads:
+    def test_boxes_become_normalized_detections(self):
+        payloads = _detection_payloads(_detect_result())
+        assert [p["label"] for p in payloads] == ["person", "bicycle"]
+        assert payloads[0]["bounding_box"] == pytest.approx([0.05, 0.2, 0.5, 0.5])
+        assert payloads[0]["confidence"] == pytest.approx(0.9)
+        assert "index" not in payloads[0]
+        assert "mask" not in payloads[0]
+
+    def test_empty_results_produce_no_detections(self):
+        boxes = Boxes(torch.zeros((0, 4)), torch.zeros((0,)), torch.zeros((0,)))
+        result = Results(boxes, orig_shape=(100, 200), names=NAMES)
+        assert _detection_payloads(result) == []
+
+    def test_track_ids_become_the_detection_index(self):
+        result = _detect_result()
+        result.boxes = result.boxes.with_id(torch.tensor([7.0, 8.0]))
+        payloads = _detection_payloads(result)
+        assert [p["index"] for p in payloads] == [7, 8]
+
+    def test_instance_masks_are_cropped_to_their_box(self):
+        result = _detect_result()
+        masks = np.zeros((2, 100, 200), dtype=np.float32)
+        masks[0, 20:70, 10:110] = 1.0
+        masks[1, 0:10, 0:20] = 1.0
+        result.masks = Masks(masks, (100, 200))
+        payloads = _detection_payloads(result)
+        assert payloads[0]["mask"].shape == (50, 100)
+        assert payloads[1]["mask"].shape == (10, 20)
+        assert payloads[0]["mask"].dtype == bool
+
+
+class TestOtherTaskPayloads:
+    def test_obb_becomes_a_closed_filled_polyline(self):
+        # An axis-aligned box at angle 0: cx, cy, w, h, r, conf, cls.
+        data = torch.tensor([[100.0, 50.0, 40.0, 20.0, 0.0, 0.8, 1.0]])
+        result = Results(None, orig_shape=(100, 200), names=NAMES, obb=OBB(data))
+        payloads = _obb_payloads(result)
+        assert len(payloads) == 1
+        assert payloads[0]["label"] == "bicycle"
+        assert payloads[0]["closed"] is True
+        assert payloads[0]["filled"] is True
+        ring = payloads[0]["points"][0]
+        assert len(ring) == 4
+        xs = sorted(x for x, _ in ring)
+        ys = sorted(y for _, y in ring)
+        assert xs[0] == pytest.approx(0.4) and xs[-1] == pytest.approx(0.6)
+        assert ys[0] == pytest.approx(0.4) and ys[-1] == pytest.approx(0.6)
+
+    def test_keypoints_carry_per_point_confidence(self):
+        data = torch.tensor([[[100.0, 50.0, 0.9], [50.0, 25.0, 0.7]]])
+        result = _detect_result()
+        result.boxes = result.boxes[0:1]
+        result.keypoints = Keypoints(data, (100, 200))
+        payloads = _keypoint_payloads(result)
+        assert len(payloads) == 1
+        assert payloads[0]["label"] == "person"
+        assert payloads[0]["points"][0] == pytest.approx([0.5, 0.5])
+        assert payloads[0]["points"][1] == pytest.approx([0.25, 0.25])
+        assert payloads[0]["confidence"] == pytest.approx([0.9, 0.7])
+
+    def test_invisible_keypoints_become_nan(self):
+        data = torch.tensor([[[100.0, 50.0, 0.9], [0.0, 0.0, 0.0]]])
+        result = Results(None, orig_shape=(100, 200), names=NAMES)
+        result.keypoints = Keypoints(data, (100, 200))
+        points = _keypoint_payloads(result)[0]["points"]
+        assert points[0] == pytest.approx([0.5, 0.5])
+        assert all(np.isnan(v) for v in points[1])
+
+    def test_classification_reports_top1(self):
+        probs = Probs(torch.tensor([0.1, 0.9]))
+        result = Results(None, orig_shape=(100, 200), names=NAMES, probs=probs)
+        payload = _classification_payload(result)
+        assert payload == {"label": "bicycle", "confidence": pytest.approx(0.9)}
+
+    def test_masks_become_normalized_polygon_rings(self):
+        masks = np.zeros((1, 100, 200), dtype=np.uint8)
+        masks[0, 20:70, 10:110] = 1
+        result = _detect_result()
+        result.boxes = result.boxes[0:1]
+        result.masks = Masks(masks, (100, 200))
+        payloads = _polyline_payloads(result)
+        assert len(payloads) == 1
+        assert payloads[0]["label"] == "person"
+        ring = payloads[0]["points"][0]
+        assert all(0.0 <= x <= 1.0 and 0.0 <= y <= 1.0 for x, y in ring)
+
+
+class _StubLabel:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _stub_fiftyone():
+    """A stand-in for the fiftyone label classes used by the yaml bridge."""
+    return types.SimpleNamespace(
+        Detection=_StubLabel,
+        Detections=_StubLabel,
+        Polyline=_StubLabel,
+        Polylines=_StubLabel,
+    )
+
+
+class TestDatasetBridge:
+    def test_yolo_rows_skips_blank_lines(self, tmp_path):
+        label_file = tmp_path / "a.txt"
+        label_file.write_text("0 0.5 0.5 0.2 0.4\n\n1 0.1 0.1 0.1 0.1\n")
+        assert _yolo_rows(label_file) == [
+            [0.0, 0.5, 0.5, 0.2, 0.4],
+            [1.0, 0.1, 0.1, 0.1, 0.1],
+        ]
+
+    def test_yolo_rows_treats_a_missing_file_as_no_objects(self, tmp_path):
+        assert _yolo_rows(tmp_path / "missing.txt") == []
+
+    def test_detect_rows_become_corner_normalized_boxes(self):
+        labels = _sample_labels_from_rows(
+            _stub_fiftyone(), [[0.0, 0.5, 0.5, 0.2, 0.4]], NAMES, "detect"
+        )
+        assert len(labels.detections) == 1
+        assert labels.detections[0].label == "person"
+        assert labels.detections[0].bounding_box == pytest.approx([0.4, 0.3, 0.2, 0.4])
+
+    def test_segment_rows_become_polygons(self):
+        rows = [[1.0, 0.1, 0.1, 0.5, 0.1, 0.5, 0.5]]
+        labels = _sample_labels_from_rows(_stub_fiftyone(), rows, NAMES, "segment")
+        assert len(labels.polylines) == 1
+        assert labels.polylines[0].label == "bicycle"
+        assert labels.polylines[0].points == [[(0.1, 0.1), (0.5, 0.1), (0.5, 0.5)]]
+        assert labels.polylines[0].closed is True
+
+    def test_a_box_row_in_a_segment_dataset_becomes_a_rectangle(self):
+        labels = _sample_labels_from_rows(
+            _stub_fiftyone(), [[0.0, 0.5, 0.5, 0.2, 0.4]], NAMES, "segment"
+        )
+        assert labels.polylines[0].points == [
+            [(0.4, 0.3), (0.6, 0.3), (0.6, 0.7), (0.4, 0.7)]
+        ]
+
+
+class TestOptionalDependency:
+    def test_importing_libreyolo_does_not_import_fiftyone(self):
+        code = "import libreyolo, sys; print('fiftyone' in sys.modules)"
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True
+        )
+        assert out.stdout.strip() == "False"
+
+    def test_missing_fiftyone_raises_an_install_hint(self, monkeypatch):
+        # A None entry in sys.modules makes ``import fiftyone`` fail the same
+        # way an uninstalled package does.
+        monkeypatch.setitem(sys.modules, "fiftyone", None)
+        with pytest.raises(ImportError, match=r"pip install libreyolo\[fiftyone\]"):
+            _import_fiftyone()
+
+
+@pytest.mark.fiftyone
+class TestWithFiftyOneInstalled:
+    def test_labels_convert_to_fiftyone_types(self):
+        fo = pytest.importorskip("fiftyone")
+        from libreyolo.integrations.fiftyone import _to_fiftyone_labels
+
+        labels = _to_fiftyone_labels(_detect_result())
+        assert isinstance(labels, fo.Detections)
+        assert len(labels.detections) == 2
+        assert labels.detections[0].label == "person"
+
+    def test_native_coco_json_annotations_are_loaded(self, tmp_path):
+        pytest.importorskip("fiftyone")
+        import json
+
+        import yaml
+        from PIL import Image
+
+        from libreyolo.integrations.fiftyone import to_fiftyone
+
+        root = tmp_path / "coco"
+        (root / "images" / "val").mkdir(parents=True)
+        (root / "annotations").mkdir()
+        Image.new("RGB", (200, 100)).save(root / "images" / "val" / "a.jpg")
+        (root / "annotations" / "val.json").write_text(
+            json.dumps(
+                {
+                    "images": [
+                        {"id": 1, "file_name": "a.jpg", "width": 200, "height": 100}
+                    ],
+                    "annotations": [
+                        {
+                            "id": 1,
+                            "image_id": 1,
+                            "category_id": 1,
+                            "bbox": [80, 30, 40, 40],
+                            "area": 1600,
+                            "iscrowd": 0,
+                        }
+                    ],
+                    "categories": [{"id": 1, "name": "person"}],
+                }
+            )
+        )
+        data_yaml = root / "data.yaml"
+        data_yaml.write_text(
+            yaml.safe_dump(
+                {
+                    "path": str(root),
+                    "val": "images/val",
+                    "names": {0: "person"},
+                    "annotations": {"val": "annotations/val.json"},
+                }
+            )
+        )
+
+        dataset = to_fiftyone(data_yaml, split="val", autodownload=False)
+        try:
+            assert len(dataset) == 1
+            detections = dataset.first().ground_truth.detections
+            assert len(detections) == 1
+            assert detections[0].label == "person"
+            assert detections[0].bounding_box == pytest.approx([0.4, 0.3, 0.2, 0.4])
+        finally:
+            dataset.delete()
+
+    def test_export_keeps_the_class_ids_it_is_given(self, tmp_path):
+        fo = pytest.importorskip("fiftyone")
+        from PIL import Image
+
+        from libreyolo.integrations.fiftyone import from_fiftyone
+
+        image = tmp_path / "a.jpg"
+        Image.new("RGB", (200, 100)).save(image)
+        dataset = fo.Dataset()
+        sample = fo.Sample(filepath=str(image))
+        sample["ground_truth"] = fo.Detections(
+            detections=[
+                fo.Detection(label="bicycle", bounding_box=[0.4, 0.3, 0.2, 0.4])
+            ]
+        )
+        dataset.add_samples([sample])
+        try:
+            yaml_path = from_fiftyone(
+                dataset,
+                tmp_path / "export",
+                split="train",
+                classes=["person", "bicycle"],
+            )
+            import yaml as pyyaml
+
+            written = pyyaml.safe_load(yaml_path.read_text())
+            assert written["names"] == {0: "person", 1: "bicycle"}
+            label_file = next((tmp_path / "export").rglob("a.txt"))
+            assert label_file.read_text().split()[0] == "1"
+        finally:
+            dataset.delete()
+
+    def test_round_trip_through_a_dataset_yaml(self, tmp_path):
+        pytest.importorskip("fiftyone")
+        import yaml
+        from PIL import Image
+
+        from libreyolo.integrations.fiftyone import from_fiftyone, to_fiftyone
+
+        root = tmp_path / "ds"
+        (root / "images" / "val").mkdir(parents=True)
+        (root / "labels" / "val").mkdir(parents=True)
+        Image.new("RGB", (200, 100)).save(root / "images" / "val" / "a.jpg")
+        (root / "labels" / "val" / "a.txt").write_text("0 0.5 0.5 0.2 0.4\n")
+        data_yaml = root / "data.yaml"
+        data_yaml.write_text(
+            yaml.safe_dump(
+                {
+                    "path": str(root),
+                    "train": "images/val",
+                    "val": "images/val",
+                    "names": {0: "person", 1: "bicycle"},
+                }
+            )
+        )
+
+        dataset = to_fiftyone(data_yaml, split="val", autodownload=False)
+        try:
+            assert len(dataset) == 1
+            detections = dataset.first().ground_truth.detections
+            assert len(detections) == 1
+            assert detections[0].label == "person"
+
+            out_yaml = from_fiftyone(dataset, tmp_path / "export", split="val")
+            assert out_yaml.exists()
+
+            from libreyolo.data.utils import load_data_config
+
+            config = load_data_config(str(out_yaml), autodownload=False)
+            assert len(config["val_img_files"]) == 1
+        finally:
+            dataset.delete()

--- a/tests/unit/test_integrations_fiftyone.py
+++ b/tests/unit/test_integrations_fiftyone.py
@@ -334,6 +334,49 @@ class TestWithFiftyOneInstalled:
         finally:
             dataset.delete()
 
+    def test_two_splits_accumulate_in_one_yaml(self, tmp_path):
+        fo = pytest.importorskip("fiftyone")
+        import yaml as pyyaml
+        from PIL import Image
+
+        from libreyolo.data.utils import load_data_config
+        from libreyolo.integrations.fiftyone import from_fiftyone
+
+        def make(name, label):
+            image = tmp_path / f"{name}.jpg"
+            Image.new("RGB", (200, 100)).save(image)
+            sample = fo.Sample(filepath=str(image))
+            sample["ground_truth"] = fo.Detections(
+                detections=[
+                    fo.Detection(label=label, bounding_box=[0.4, 0.3, 0.2, 0.4])
+                ]
+            )
+            dataset = fo.Dataset()
+            dataset.add_samples([sample])
+            return dataset
+
+        train = make("train_a", "person")
+        val = make("val_a", "bicycle")
+        export_dir = tmp_path / "export"
+        try:
+            classes = ["person", "bicycle"]
+            from_fiftyone(train, export_dir, split="train", classes=classes)
+            yaml_path = from_fiftyone(val, export_dir, split="val", classes=classes)
+
+            # The second export must add its split rather than replace the
+            # first: a training yaml needs train and val together.
+            written = pyyaml.safe_load(yaml_path.read_text())
+            assert "train" in written and "val" in written
+
+            config = load_data_config(str(yaml_path), autodownload=False)
+            assert len(config["train_img_files"]) == 1
+            assert len(config["val_img_files"]) == 1
+            assert config["train_img_files"][0].name == "train_a.jpg"
+            assert config["val_img_files"][0].name == "val_a.jpg"
+        finally:
+            train.delete()
+            val.delete()
+
     def test_round_trip_through_a_dataset_yaml(self, tmp_path):
         pytest.importorskip("fiftyone")
         import yaml


### PR DESCRIPTION
Closes #770 (phases 1-3, minus the upstream docs listing, which is not ours to do).

## What

- `libreyolo/integrations/fiftyone.py`: `apply_model`, `to_fiftyone_model`, `to_fiftyone`, `from_fiftyone`.
- `libreyolo[fiftyone]` extra. Lazy import, install hint, nothing vendored.
- `docs/fiftyone.md`: install caveats, task table, two worked workflows.
- Unit tests + one Linux CI job.

## Task coverage

| task | label | field |
|---|---|---|
| detect | `Detections` | `label_field` |
| segment | `Detections` with masks, or `Polylines` | `label_field` |
| obb | `Polylines` | `label_field` |
| pose | `Keypoints` + `Detections` | `label_field_keypoints`, `label_field_detections` |
| classify | `Classification` | `label_field` |

## Verified locally (CPU, fiftyone 1.20.1, python 3.12)

- coco128: `to_fiftyone` 128 samples, `apply_model` 704 boxes, `evaluate_detections` mAP 0.5238 with LibreYOLO9s.
- Box parity vs `model.predict`: max 3e-5 px. Letterbox geometry survives the trip.
- `from_fiftyone` output reloads through `load_data_config`.
- Tasks run: YOLO9 detect (batched + single), RF-DETR detect, RF-DETR seg (mask + polyline), RTDETRv2 obb, HRNet pose, DeiT classify.
- greptile clean against dev.

## Reviewer should check

- `ragged_batches = False` on the model wrapper. False is what unlocks FiftyOne batching; `transforms` is None so nothing gets stacked. True made FiftyOne warn "Model does not support batching" and fall back to one image at a time.
- The COCO-JSON branch of `to_fiftyone` passes `label_types` explicitly. Without it the importer writes `ground_truth_detections`, not `ground_truth`, so the field name would depend on the dataset layout.
- Boxes are clipped to the image before normalizing.

## Not verified

- Any GPU path. All runs were CPU.
- The CI job runs the round trip on synthetic data, not coco128: coco128 + weights would make it a network/external_data job.

## Issue #770 corrections

- `fo.evaluate_detections()` does not exist; it is `dataset.evaluate_detections()`.
- The issue's example uses `libreyolo9-s.pt`; canonical is `LibreYOLO9s.pt`.
- "Zero new hard dependencies" is true for LibreYOLO, but fiftyone pulls `opencv-python-headless` over our `opencv-python` (same `cv2`) and bundles a MongoDB. Measured after install: `cv2.getBuildInformation()` reports `GUI: NONE`, so `show=True` breaks. Hence the extra is out of `[all]` and documented.
- FiftyOne already has its own `apply_model`; ours wraps it rather than reimplementing iteration.

## Code provenance

All code in this PR was written for this PR. No third-party code was copied, adapted, or derived.

FiftyOne (https://github.com/voxel51/fiftyone, Apache-2.0) is used only as an optional runtime dependency: this PR imports its public API and subclasses `fiftyone.core.models.Model`. No FiftyOne source is vendored or reproduced. Its public API docs and field definitions were consulted to match names and coordinate conventions.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an optional FiftyOne adapter for model inference and bidirectional dataset conversion.
- Adds conversions for detection, segmentation, pose, OBB, and classification results.
- Adds FiftyOne dataset import/export workflows and optional dependency packaging.
- Adds documentation and isolated Linux CI coverage, including sequential train/validation split export coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains, and the sequential train/validation export test resolves the previously reported coverage gap.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/integrations/fiftyone.py | Adds lazy FiftyOne model wrapping, result-label conversion, and dataset import/export APIs without an accepted follow-up finding. |
| tests/unit/test_integrations_fiftyone.py | Adds geometry, optional-dependency, dataset round-trip, and sequential multi-split export coverage that resolves the previous review thread. |
| .github/workflows/unit-tests.yml | Adds an isolated Linux job that installs the optional FiftyOne dependency and runs its integration tests. |
| docs/fiftyone.md | Documents installation caveats, supported task mappings, prediction use, and dataset conversion workflows. |
| pyproject.toml | Adds the optional FiftyOne dependency group and corresponding pytest marker. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    LY[LibreYOLO model] --> Wrapper[FiftyOne model wrapper]
    Wrapper --> Predictions[FiftyOne prediction fields]
    YAML[LibreYOLO dataset YAML] --> Import[to_fiftyone]
    Import --> Dataset[FiftyOne dataset or view]
    Dataset --> Export[from_fiftyone]
    Export --> SplitYAML[Train/val LibreYOLO YAML]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Test that two from\_fiftyone exports shar..."](https://github.com/libreyolo/libreyolo/commit/171fdb160ced713764fb4c77bd4cc834315eb25d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53495764)</sub>

**Context used:**

- Knowledge Base — [Data Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/data-pipeline.md)

<!-- /greptile_comment -->