### PR TITLE
Add opt-in training helpers (#768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- **Opt-in training helpers (#768).** `class_balanced=True` enables
+  repeat-factor sampling for long-tailed detection datasets;
+  `average_best=N` writes the uniform mean of the N best validation
+  checkpoints; `export_check=True` verifies ONNX export before epoch 1; and
+  `precise_bn=N` recomputes BatchNorm statistics from N training images before
+  final validation. All four default off.
+
 - **Gemma 4 and Moondream in LibreVLM.** `LibreVLM("gemma-4")` loads
   Gemma 4 E4B (Apache-2.0; `e2b` also aliased) and parses the official
   y-first `box_2d` 0-1000 JSON. `LibreVLM("moondream")` loads Moondream 2

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -277,15 +277,22 @@ Used for: PP-LiteSeg semantic segmentation family
           libreyolo/models/ppliteseg/NOTICE.
 
 --------------------------------------------------------------------
-SuperGradients / QAT training safeguards
+SuperGradients / training safeguards and helpers
 --------------------------------------------------------------------
 Source: https://github.com/Deci-AI/super-gradients
         pinned commit 63de22c404d5740f34f7706c302b37fce3c8fe5d
 License: Apache License 2.0 (repository LICENSE.md at that commit)
 Copyright (c) 2021-2024 Deci AI
-Used for: the QAT-time EMA and SyncBatchNorm disable policy in
-          libreyolo/training/qat_defaults.py. The LibreYOLO implementation
-          is original; no upstream source code was copied.
+Used for: original LibreYOLO implementations of the QAT-time EMA and
+          SyncBatchNorm disable policy, metric-gated top-N checkpoint
+          averaging, precise BatchNorm re-estimation, repeat-factor
+          class-balanced sampling, and an epoch-0 ONNX export check. Code
+          lives in libreyolo/training/qat_defaults.py,
+          libreyolo/training/weight_averaging.py,
+          libreyolo/training/precise_bn.py,
+          libreyolo/training/export_check.py, and
+          libreyolo/data/class_balanced.py. No upstream source code was
+          copied.
 
 --------------------------------------------------------------------
 STDC-Seg (MichaelFan01)

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -39,6 +39,16 @@ _LORA_TRAIN_FAMILIES = {
     "convnext",
 }
 
+# Always own their train loader; class_balanced never reaches create_dataloader.
+# EC / YOLO-NAS are task-dependent and are rejected at trainer setup instead.
+_CLASS_BALANCED_UNSUPPORTED_FAMILIES = {
+    "dfine",
+    "deim",
+    "deimv2",
+    "fomo",
+    "vjepa2",
+}
+
 
 def _model_ref_exists(model_path: str) -> bool:
     path = Path(model_path)
@@ -286,6 +296,28 @@ def train_cmd(
         help="Epoch-length floor for tiny datasets: when the dataset has "
         "fewer images, draw this many samples per epoch with replacement "
         "(0 = off)",
+    ),
+    class_balanced: bool = typer.Option(
+        False,
+        "--class-balanced/--no-class-balanced",
+        help="LVIS-style repeat-factor sampling for long-tailed datasets "
+        "(default: off)",
+    ),
+    average_best: int = typer.Option(
+        0,
+        help="Uniform-average the N best checkpoints by the watched metric "
+        "into weights/average.pt at the end of training (0 = off)",
+    ),
+    export_check: bool = typer.Option(
+        False,
+        "--export-check/--no-export-check",
+        help="Export ONNX before epoch 1 and fail the run if export breaks "
+        "(default: off)",
+    ),
+    precise_bn: int = typer.Option(
+        0,
+        help="Recompute BatchNorm running stats from this many train images "
+        "after the last epoch (0 = off)",
     ),
     seed: int = typer.Option(0, help="Random seed"),
     resume: str = typer.Option("", help="Resume training: true, or path to checkpoint"),
@@ -556,6 +588,10 @@ def train_cmd(
         "workers": workers,
         "cache": cache_val,
         "min_samples": min_samples,
+        "class_balanced": class_balanced,
+        "average_best": average_best,
+        "export_check": export_check,
+        "precise_bn": precise_bn,
         "seed": seed,
         "resume": resume_val,
         "amp": amp,
@@ -633,6 +669,22 @@ def train_cmd(
                 f"{', '.join(sorted(ignored_warnings))}"
             )
 
+    if (
+        family in _CLASS_BALANCED_UNSUPPORTED_FAMILIES
+        and "class_balanced" in user_provided
+        and params.get("class_balanced")
+    ):
+        exit_with_error(
+            out,
+            "config_unsupported",
+            f"class_balanced=True is not supported for {family}.",
+            suggestion=(
+                "This family builds its own dataloader. Use a family that "
+                "trains through the shared detection sampler (e.g. YOLO9), "
+                "or omit class_balanced."
+            ),
+        )
+
     # Dry run: validate and show resolved config
     if dry_run:
         resolved_config = {
@@ -648,6 +700,10 @@ def train_cmd(
             "amp": params["amp"],
             "amp_dtype": params["amp_dtype"],
             "max_det": params["max_det"],
+            "class_balanced": params["class_balanced"],
+            "average_best": params["average_best"],
+            "export_check": params["export_check"],
+            "precise_bn": params["precise_bn"],
         }
         if params.get("freeze") is not None:
             resolved_config["freeze"] = params["freeze"]
@@ -679,6 +735,10 @@ def train_cmd(
                 "max_det": params["max_det"],
                 "save_period": params["save_period"],
                 "lora": params["lora"],
+                "class_balanced": params["class_balanced"],
+                "average_best": params["average_best"],
+                "export_check": params["export_check"],
+                "precise_bn": params["precise_bn"],
             }
             if params.get("freeze") is not None:
                 resolved_config["freeze"] = params["freeze"]

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -447,6 +447,10 @@ def _build_rfdetr_train_kwargs(
         "freeze": "freeze",
         "log_interval": "log_interval",
         "cache": "cache",
+        "class_balanced": "class_balanced",
+        "average_best": "average_best",
+        "export_check": "export_check",
+        "precise_bn": "precise_bn",
     }
 
     for cli_name, target_name in direct_mappings.items():

--- a/libreyolo/data/class_balanced.py
+++ b/libreyolo/data/class_balanced.py
@@ -1,0 +1,201 @@
+"""LVIS-style repeat-factor sampling for long-tailed detection sets.
+
+For each class ``c``, ``f(c)`` is the fraction of images that contain it.
+Classes rarer than the median frequency get a repeat factor
+``r(c) = (t / f(c)) ** alpha``; an image's weight is the max ``r(c)`` of
+the classes it contains. Empty images keep weight 1 so they still train
+as background.
+
+Opt-in. Off by default; ``create_dataloader(..., class_balanced=False)``
+is the historical sampler.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Sequence
+
+import numpy as np
+import torch
+from torch.utils.data import Sampler, WeightedRandomSampler
+
+
+def class_ids_from_anno(anno) -> np.ndarray:
+    """Class column from a YOLO-style annotation array (empty-safe)."""
+    arr = np.asarray(anno)
+    if arr.size == 0:
+        return np.zeros((0,), dtype=np.int64)
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    if arr.shape[1] >= 5:
+        return arr[:, 4].astype(np.int64)
+    return arr[:, 0].astype(np.int64)
+
+
+def annotation_source(dataset):
+    """Walk mosaic/mixup wrappers to the dataset that owns labels."""
+    seen: set[int] = set()
+    current = dataset
+    while id(current) not in seen:
+        seen.add(id(current))
+        if callable(getattr(current, "load_anno", None)):
+            return current
+        if getattr(current, "annotations", None) is not None:
+            return current
+        inner = getattr(current, "dataset", None)
+        if inner is None or inner is current:
+            break
+        current = inner
+    raise TypeError(
+        "class_balanced=True needs a dataset with load_anno() or "
+        f"annotations; got {type(dataset).__name__}"
+    )
+
+
+def _load_anno(dataset, index: int):
+    source = annotation_source(dataset)
+    load_anno = getattr(source, "load_anno", None)
+    if callable(load_anno):
+        return load_anno(index)
+    annotations = getattr(source, "annotations", None)
+    if annotations is None:
+        raise TypeError(
+            "class_balanced=True needs a dataset with load_anno() or "
+            f"annotations; got {type(dataset).__name__}"
+        )
+    entry = annotations[index]
+    if isinstance(entry, (tuple, list)) and entry:
+        return entry[0]
+    return entry
+
+
+def image_repeat_factors(
+    dataset,
+    *,
+    alpha: float = 0.5,
+    threshold: float | None = None,
+) -> np.ndarray:
+    """Return a length-``len(dataset)`` float32 weight per image."""
+    n = len(dataset)
+    if n == 0:
+        return np.zeros((0,), dtype=np.float32)
+
+    per_image: List[np.ndarray] = []
+    max_cls = -1
+    source = annotation_source(dataset)
+    declared = (
+        getattr(source, "num_classes", None)
+        or getattr(source, "nc", None)
+        or getattr(dataset, "num_classes", None)
+        or getattr(dataset, "nc", None)
+    )
+    for i in range(n):
+        ids = class_ids_from_anno(_load_anno(dataset, i))
+        ids = ids[ids >= 0]
+        per_image.append(ids)
+        if ids.size:
+            max_cls = max(max_cls, int(ids.max()))
+    nc = max(max_cls + 1, int(declared) if declared else 0)
+    if nc <= 0:
+        return np.ones(n, dtype=np.float32)
+
+    present = np.zeros((n, nc), dtype=np.float32)
+    for i, ids in enumerate(per_image):
+        if ids.size:
+            present[i, np.unique(ids)] = 1.0
+    freq = present.mean(axis=0)
+    positive = freq[freq > 0]
+    if positive.size == 0:
+        return np.ones(n, dtype=np.float32)
+    t = float(np.median(positive) if threshold is None else threshold)
+    if t <= 0:
+        return np.ones(n, dtype=np.float32)
+
+    class_repeat = np.ones(nc, dtype=np.float32)
+    rare = (freq > 0) & (freq < t)
+    class_repeat[rare] = (t / freq[rare]) ** float(alpha)
+
+    weights = np.ones(n, dtype=np.float32)
+    for i, ids in enumerate(per_image):
+        if ids.size:
+            weights[i] = float(class_repeat[np.unique(ids)].max())
+    return weights
+
+
+class DistributedClassBalancedSampler(Sampler):
+    """DDP-aware multinomial draw with the same shard contract as DistributedSampler.
+
+    Every rank draws the same ``total_size`` indices from the shared weights
+    (seeded with ``seed + epoch``), then keeps ``rank::num_replicas``. That
+    keeps collectives aligned while still oversampling rare classes.
+    """
+
+    def __init__(
+        self,
+        weights: Sequence[float],
+        num_samples: int,
+        num_replicas: int,
+        rank: int,
+        seed: int = 0,
+    ):
+        if num_samples <= 0:
+            raise ValueError(f"num_samples must be positive, got {num_samples}")
+        if num_replicas <= 0:
+            raise ValueError(f"num_replicas must be positive, got {num_replicas}")
+        if not 0 <= rank < num_replicas:
+            raise ValueError(f"rank must be in [0, {num_replicas - 1}], got {rank}")
+        self.weights = torch.as_tensor(weights, dtype=torch.double)
+        if self.weights.numel() == 0:
+            raise ValueError("class_balanced sampler needs a non-empty dataset")
+        if torch.any(self.weights < 0) or not bool(torch.any(self.weights > 0)):
+            raise ValueError(
+                "class_balanced weights must be non-negative and not all zero"
+            )
+        self.num_replicas = int(num_replicas)
+        self.rank = int(rank)
+        self.seed = int(seed)
+        self.num_samples = math.ceil(num_samples / num_replicas)
+        self.total_size = self.num_samples * self.num_replicas
+        self.epoch = 0
+
+    def __iter__(self):
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + self.epoch)
+        indices = torch.multinomial(
+            self.weights, self.total_size, replacement=True, generator=generator
+        )
+        return iter(indices[self.rank : self.total_size : self.num_replicas].tolist())
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = int(epoch)
+
+
+def build_class_balanced_sampler(
+    dataset,
+    *,
+    num_samples: int | None = None,
+    distributed_sampler=None,
+    alpha: float = 0.5,
+    seed: int = 0,
+) -> Sampler:
+    """Build a single-process or DDP class-balanced sampler from ``dataset``."""
+    weights = image_repeat_factors(dataset, alpha=alpha)
+    draw = int(num_samples if num_samples is not None else len(dataset))
+    if draw < 1:
+        raise ValueError(f"class_balanced num_samples must be >= 1, got {draw}")
+    if distributed_sampler is not None:
+        return DistributedClassBalancedSampler(
+            weights,
+            draw,
+            num_replicas=distributed_sampler.num_replicas,
+            rank=distributed_sampler.rank,
+            seed=int(getattr(distributed_sampler, "seed", seed) or 0),
+        )
+    return WeightedRandomSampler(
+        weights=torch.as_tensor(weights, dtype=torch.double),
+        num_samples=draw,
+        replacement=True,
+    )

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -1053,6 +1053,7 @@ def create_dataloader(
     pin_memory: bool = True,
     sampler=None,
     min_samples: int = 0,
+    class_balanced: bool = False,
 ):
     """
     Create a DataLoader for YOLOX training.
@@ -1076,8 +1077,38 @@ def create_dataloader(
             other custom sampler is respected as-is), and ``num_workers`` is
             clamped to ``len(dataset)``. 0 (the default) leaves the loader
             exactly as before the knob existed.
+        class_balanced: Opt-in LVIS-style repeat-factor sampling. Off by
+            default. When on, replaces the shuffle / DistributedSampler with
+            a weighted draw; ``min_samples`` still floors the draw length.
+            Cannot be combined with a custom non-distributed sampler.
     """
-    if min_samples > 0 and 0 < len(dataset) < min_samples:
+    if class_balanced:
+        from torch.utils.data.distributed import DistributedSampler
+
+        from .class_balanced import build_class_balanced_sampler
+
+        if sampler is not None and not isinstance(sampler, DistributedSampler):
+            raise ValueError(
+                "class_balanced=True cannot be combined with a custom "
+                f"sampler ({type(sampler).__name__}). Pass sampler=None or "
+                "a DistributedSampler."
+            )
+        draw = len(dataset)
+        if min_samples > 0 and 0 < len(dataset) < min_samples:
+            draw = min_samples
+            num_workers = min(num_workers, len(dataset))
+        sampler = build_class_balanced_sampler(
+            dataset, num_samples=draw, distributed_sampler=sampler
+        )
+        if is_main_process():
+            logger.info(
+                "class_balanced sampling active: %d images, drawing %d "
+                "samples per epoch%s",
+                len(dataset),
+                len(sampler),
+                " (DDP shard)" if hasattr(sampler, "num_replicas") else "",
+            )
+    elif min_samples > 0 and 0 < len(dataset) < min_samples:
         num_workers = min(num_workers, len(dataset))
         if sampler is None:
             # Draws from the global torch RNG, the same source the default

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -219,6 +219,23 @@ class TrainConfig:
     # behavior is identical to before the knob existed. Only families that
     # build their train loader through the shared create_dataloader honor it.
     min_samples: int = 0
+    # Opt-in LVIS-style repeat-factor sampling. Rare classes are oversampled
+    # so long-tailed sets (RF100-style) see them every epoch. Off by default:
+    # the historical uniform / DistributedSampler is unchanged. Honored by
+    # families that build the train loader through create_dataloader.
+    class_balanced: bool = False
+    # Rolling uniform average of the N best checkpoints ranked by the
+    # watched validation metric, written to weights/average.pt at the end
+    # of training. 0 (default) is off: best.pt / last.pt are unchanged.
+    average_best: int = 0
+    # Export the model to ONNX before epoch 1 and fail the run if export
+    # breaks. Numeric compare runs only when torch and ONNX layouts match.
+    export_check: bool = False
+    # Recompute BatchNorm running stats from this many train images after
+    # the last epoch (before its validation), and refresh a historical
+    # best checkpoint if it remains selected. 0 (default) is off. No-op on
+    # LayerNorm-only families.
+    precise_bn: int = 0
     patience: int = 50
     resume: bool = False
     log_interval: int = 10
@@ -255,6 +272,14 @@ class TrainConfig:
         self.min_samples = int(self.min_samples)
         if self.min_samples < 0:
             raise ValueError(f"min_samples must be >= 0, got {self.min_samples}")
+        self.average_best = int(self.average_best)
+        if self.average_best < 0:
+            raise ValueError(f"average_best must be >= 0, got {self.average_best}")
+        self.precise_bn = int(self.precise_bn)
+        if self.precise_bn < 0:
+            raise ValueError(f"precise_bn must be >= 0, got {self.precise_bn}")
+        self.class_balanced = bool(self.class_balanced)
+        self.export_check = bool(self.export_check)
 
     @classmethod
     def from_kwargs(cls, **kwargs):

--- a/libreyolo/training/export_check.py
+++ b/libreyolo/training/export_check.py
@@ -1,0 +1,150 @@
+"""Epoch-0 export sanity check.
+
+Exports the live model to ONNX and, when the raw torch output is a tensor
+(or tuple of tensors) of the same layout as the ONNX graph, asserts numeric
+parity. Layout mismatches (export-time NMS vs raw training heads) are
+logged and skipped: the check still fails if ``export()`` itself raises,
+which is the failure mode this is meant to catch before a long run.
+
+Opt-in. Off by default.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Sequence
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _as_tensor_tuple(value: Any) -> tuple[torch.Tensor, ...] | None:
+    if torch.is_tensor(value):
+        return (value.detach().cpu(),)
+    if isinstance(value, (tuple, list)) and value and all(torch.is_tensor(v) for v in value):
+        return tuple(v.detach().cpu() for v in value)
+    return None
+
+
+def outputs_comparable(
+    torch_out: Sequence[torch.Tensor], onnx_out: Sequence[torch.Tensor]
+) -> bool:
+    if len(torch_out) != len(onnx_out):
+        return False
+    return all(
+        tuple(a.shape) == tuple(b.shape) and a.dtype == b.dtype
+        for a, b in zip(torch_out, onnx_out)
+    )
+
+
+def assert_close(
+    torch_out: Sequence[torch.Tensor],
+    onnx_out: Sequence[torch.Tensor],
+    *,
+    rtol: float = 1e-3,
+    atol: float = 1e-4,
+) -> None:
+    if not outputs_comparable(torch_out, onnx_out):
+        raise ValueError(
+            "export_check: torch and ONNX outputs are not comparable "
+            f"(torch shapes={[tuple(t.shape) for t in torch_out]}, "
+            f"onnx shapes={[tuple(t.shape) for t in onnx_out]})"
+        )
+    for i, (left, right) in enumerate(zip(torch_out, onnx_out)):
+        if not torch.allclose(left.float(), right.float(), rtol=rtol, atol=atol):
+            max_abs = (left.float() - right.float()).abs().max().item()
+            raise AssertionError(
+                f"export_check: ONNX output {i} differs from torch "
+                f"(max abs {max_abs:.4g}, rtol={rtol}, atol={atol})"
+            )
+
+
+def run_export_parity_check(
+    wrapper: Any,
+    *,
+    out_dir: str | Path,
+    imgsz: int | tuple[int, int] = 640,
+    rtol: float = 1e-3,
+    atol: float = 1e-4,
+) -> Path:
+    """Export ONNX next to the run and compare raw outputs when layouts match.
+
+    Returns the written ONNX path. Raises if export fails or if comparable
+    outputs disagree.
+    """
+    try:
+        import onnxruntime  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "export_check=True requires onnxruntime. "
+            "Install it with `pip install onnxruntime`."
+        ) from exc
+
+    if isinstance(imgsz, (list, tuple)):
+        height, width = int(imgsz[0]), int(imgsz[1])
+    else:
+        height = width = int(imgsz)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    onnx_path = out_dir / "export_check.onnx"
+
+    export = getattr(wrapper, "export", None)
+    if not callable(export):
+        raise RuntimeError("export_check=True requires a wrapper with export()")
+
+    live = getattr(wrapper, "model", None)
+    swapped = False
+    try:
+        from .lora import module_has_lora
+
+        if live is not None and module_has_lora(live):
+            # export() folds LoRA in place. Swap a copy so the live
+            # adapters and the optimizer stay intact.
+            import copy
+
+            wrapper.model = copy.deepcopy(live)
+            swapped = True
+        written = export(
+            format="onnx",
+            output_path=str(onnx_path),
+            imgsz=(height, width),
+        )
+    finally:
+        if swapped:
+            wrapper.model = live
+    written_path = Path(written if written else onnx_path)
+    if not written_path.exists():
+        raise RuntimeError(f"export_check: export() did not write {written_path}")
+
+    device = getattr(wrapper, "device", "cpu")
+    dummy = torch.zeros(1, 3, height, width, device=device)
+    raw = getattr(wrapper, "model", wrapper)
+    was_training = raw.training
+    raw.eval()
+    try:
+        with torch.no_grad():
+            torch_raw = raw(dummy)
+    finally:
+        raw.train(was_training)
+    torch_out = _as_tensor_tuple(torch_raw)
+
+    session = __import__("onnxruntime").InferenceSession(
+        str(written_path), providers=["CPUExecutionProvider"]
+    )
+    input_name = session.get_inputs()[0].name
+    onnx_np = session.run(None, {input_name: dummy.detach().cpu().numpy()})
+    onnx_out = tuple(torch.from_numpy(arr) for arr in onnx_np)
+
+    if torch_out is None or not outputs_comparable(torch_out, onnx_out):
+        logger.warning(
+            "export_check: ONNX export succeeded (%s) but raw torch and "
+            "ONNX output layouts differ; numeric compare skipped.",
+            written_path,
+        )
+        return written_path
+
+    assert_close(torch_out, onnx_out, rtol=rtol, atol=atol)
+    logger.info("export_check: ONNX matches torch at %s", written_path)
+    return written_path

--- a/libreyolo/training/precise_bn.py
+++ b/libreyolo/training/precise_bn.py
@@ -1,0 +1,199 @@
+"""Recompute BatchNorm running stats from a clean forward pass.
+
+Under heavy augmentation the EMA-style BN buffers lag the true train-set
+moments. A short forward-only pass accumulates activation moments and
+replaces those buffers with an estimate over the requested samples.
+
+Opt-in. Models with no BatchNorm (RF-DETR and other LayerNorm families)
+are a no-op, so enabling the flag there cannot change weights.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Collection, Iterable, List
+
+import torch
+import torch.nn as nn
+
+from .distributed import is_distributed
+
+logger = logging.getLogger(__name__)
+
+
+def _batchnorm_modules(
+    model: nn.Module,
+    excluded_names: Collection[str] = (),
+) -> List[nn.modules.batchnorm._BatchNorm]:
+    excluded = set(excluded_names)
+    return [
+        module
+        for name, module in model.named_modules()
+        if isinstance(module, nn.modules.batchnorm._BatchNorm)
+        and name not in excluded
+        and module.running_mean is not None
+        and module.running_var is not None
+    ]
+
+
+def _first_tensor(batch) -> torch.Tensor | None:
+    if isinstance(batch, torch.Tensor):
+        return batch
+    if isinstance(batch, (tuple, list)) and batch:
+        return _first_tensor(batch[0])
+    if isinstance(batch, dict):
+        for value in batch.values():
+            found = _first_tensor(value)
+            if found is not None:
+                return found
+    return None
+
+
+@torch.no_grad()
+def compute_precise_bn_stats(
+    model: nn.Module,
+    loader: Iterable,
+    num_samples: int,
+    device: torch.device | str | None = None,
+    *,
+    excluded_names: Collection[str] = (),
+) -> int:
+    """Overwrite BN running_mean/var from ``num_samples`` loader images.
+
+    ``excluded_names`` keeps frozen BatchNorm modules untouched. Returns the
+    number of modules updated (0 if none, so callers can skip work). Module
+    modes, momentums, and counters are restored even if the pass cannot run.
+    """
+    if num_samples <= 0:
+        return 0
+    excluded = set(excluded_names)
+    bns = _batchnorm_modules(model, excluded)
+    if not bns:
+        return 0
+
+    module_modes = [(module, module.training) for module in model.modules()]
+    all_named_bns = {
+        name: module
+        for name, module in model.named_modules()
+        if isinstance(module, nn.modules.batchnorm._BatchNorm)
+    }
+    model.train()
+    for name in excluded:
+        module = all_named_bns.get(name)
+        if module is not None:
+            module.eval()
+
+    momentums = [bn.momentum for bn in bns]
+    counters = [
+        None if bn.num_batches_tracked is None else bn.num_batches_tracked.clone()
+        for bn in bns
+    ]
+    sums = [torch.zeros_like(bn.running_mean, dtype=torch.float32) for bn in bns]
+    square_sums = [torch.zeros_like(bn.running_var, dtype=torch.float32) for bn in bns]
+    counts = [
+        torch.zeros((), dtype=torch.long, device=bn.running_mean.device) for bn in bns
+    ]
+    handles = []
+
+    def make_hook(index: int):
+        def accumulate(_module, inputs) -> None:
+            if not inputs or not torch.is_tensor(inputs[0]):
+                return
+            values = inputs[0].detach().float()
+            if values.ndim < 2 or values.shape[1] != sums[index].numel():
+                return
+            reduce_dims = (0, *range(2, values.ndim))
+            sums[index].add_(values.sum(dim=reduce_dims))
+            square_sums[index].add_(values.square().sum(dim=reduce_dims))
+            counts[index].add_(values.numel() // values.shape[1])
+
+        return accumulate
+
+    for index, bn in enumerate(bns):
+        handles.append(bn.register_forward_pre_hook(make_hook(index)))
+
+    seen = 0
+    batches_used = 0
+    forward_error: Exception | None = None
+    try:
+        for bn in bns:
+            # Keep the existing buffers stable until every forward succeeds.
+            bn.momentum = 0.0
+        for batch in loader:
+            images = _first_tensor(batch)
+            if images is None:
+                continue
+            remaining = num_samples - seen
+            if remaining <= 0:
+                break
+            if int(images.shape[0]) > remaining:
+                images = images[:remaining]
+            if device is not None:
+                images = images.to(device, non_blocking=True)
+            try:
+                model(images)
+            except Exception as exc:
+                forward_error = exc
+                break
+            seen += int(images.shape[0])
+            batches_used += 1
+            if seen >= num_samples:
+                break
+        if is_distributed():
+            import torch.distributed as dist
+
+            ok = torch.tensor(
+                1 if batches_used > 0 and forward_error is None else 0,
+                device=sums[0].device,
+                dtype=torch.int32,
+            )
+            dist.all_reduce(ok, op=dist.ReduceOp.MIN)
+            if int(ok.item()) == 0:
+                if forward_error is not None:
+                    logger.warning(
+                        "Precise BN skipped: model.forward(images) failed (%s). "
+                        "This flag needs a model that accepts a bare image tensor.",
+                        forward_error,
+                    )
+                return 0
+            for tensor in (*sums, *square_sums, *counts):
+                dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+        else:
+            if batches_used == 0 or forward_error is not None:
+                if forward_error is not None:
+                    logger.warning(
+                        "Precise BN skipped: model.forward(images) failed (%s). "
+                        "This flag needs a model that accepts a bare image tensor.",
+                        forward_error,
+                    )
+                return 0
+
+        updated = 0
+        for i, bn in enumerate(bns):
+            count = int(counts[i].item())
+            if count <= 0:
+                continue
+            mean = sums[i] / count
+            centered_ss = square_sums[i] - sums[i].square() / count
+            denominator = max(count - 1, 1)
+            variance = (centered_ss / denominator).clamp_min_(0.0)
+            bn.running_mean.copy_(mean.to(dtype=bn.running_mean.dtype))
+            bn.running_var.copy_(variance.to(dtype=bn.running_var.dtype))
+            updated += 1
+    finally:
+        for handle in handles:
+            handle.remove()
+        for bn, momentum, counter in zip(bns, momentums, counters):
+            bn.momentum = momentum
+            if counter is not None:
+                bn.num_batches_tracked.copy_(counter)
+        for module, was_training in module_modes:
+            module.training = was_training
+    logger.info(
+        "Precise BN: recomputed running stats for %d BatchNorm modules "
+        "from %d images (%d batches)",
+        updated,
+        seen,
+        batches_used,
+    )
+    return updated

--- a/libreyolo/training/qat_defaults.py
+++ b/libreyolo/training/qat_defaults.py
@@ -6,8 +6,12 @@ from typing import Any, Tuple
 def apply_qat_training_guards(config: Any) -> Tuple[str, ...]:
     """Disable training features that can interfere with fake-quant state."""
     changed = []
-    for option in ("ema", "sync_bn"):
-        if getattr(config, option, False):
-            setattr(config, option, False)
+    for option, safe_value in (
+        ("ema", False),
+        ("sync_bn", False),
+        ("average_best", 0),
+    ):
+        if getattr(config, option, safe_value) != safe_value:
+            setattr(config, option, safe_value)
             changed.append(option)
     return tuple(changed)

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -243,6 +243,7 @@ class BaseTrainer(ABC):
         # Profiling (opt-in via config.profile). None = disabled, zero overhead.
         self._profiler = None
         self._stop_training = False
+        self._weight_averager = None
 
         # CUDA graph capture of the training network (opt-in via
         # config.cuda_graph). None = disabled, zero overhead. The family
@@ -979,6 +980,7 @@ class BaseTrainer(ABC):
             pin_memory=self.device.type == "cuda",
             sampler=sampler,
             min_samples=int(getattr(self.config, "min_samples", 0) or 0),
+            class_balanced=bool(getattr(self.config, "class_balanced", False)),
         )
 
         if is_main_process():
@@ -1496,7 +1498,10 @@ class BaseTrainer(ABC):
                     "QAT recipe '%s': disabled %s because these features can "
                     "interfere with fake-quant observer and scale state.",
                     quant_manifest.get("recipe", "unknown"),
-                    ", ".join(f"{option}=False" for option in qat_changes),
+                    ", ".join(
+                        f"{option}={getattr(self.config, option)!r}"
+                        for option in qat_changes
+                    ),
                 )
 
         if getattr(self.config, "lora", False) and not self.supports_lora:
@@ -1616,6 +1621,7 @@ class BaseTrainer(ABC):
                 )
 
         self._setup_data()
+        self._assert_class_balanced_honored()
 
         # DDP loader invariant: trainers that own their data pipeline must
         # shard like BaseTrainer._setup_data does (issue #484: three trainers
@@ -1694,6 +1700,22 @@ class BaseTrainer(ABC):
                     self.config.ema_decay,
                     ema_tau,
                 )
+
+        average_best = int(getattr(self.config, "average_best", 0) or 0)
+        if average_best > 0:
+            from .weight_averaging import MetricGatedAverager
+
+            self._weight_averager = MetricGatedAverager(average_best)
+            if is_main_process():
+                logger.info(
+                    "Averaging the %d best checkpoints by the watched metric "
+                    "(weights/average.pt at the end of training)",
+                    average_best,
+                )
+            deferred = getattr(self, "_resume_average_pool_path", None)
+            if deferred:
+                self._restore_average_pool(deferred)
+                self._resume_average_pool_path = None
 
         # Save-dir creation, config dump, and TB writer all live on rank 0.
         # The resolved name (which may include an auto-increment suffix when
@@ -1847,6 +1869,7 @@ class BaseTrainer(ABC):
         self._stop_training = False
         try:
             self.setup()
+            self._maybe_export_check()
 
             if is_main_process():
                 logger.info(f"Starting training for {self.config.epochs} epochs")
@@ -1897,6 +1920,33 @@ class BaseTrainer(ABC):
                     if profile_truncated
                     else self._update_best_state(epoch, val_metrics)
                 )
+                # Rank 0 owns validation metrics, so broadcast the patience
+                # decision before any rank can enter the next epoch alone.
+                epochs_since_best = (
+                    (epoch + 1) - self.best_epoch if self.best_epoch else 0
+                )
+                should_stop = (
+                    self.config.patience > 0
+                    and self.best_epoch > 0
+                    and epochs_since_best >= self.config.patience
+                )
+                should_stop = self._sync_main_bool(should_stop)
+                if should_stop and not profile_truncated:
+                    save_final_plots = bool(
+                        getattr(self.config, "save_plots", False)
+                    ) and not self._is_final_epoch(epoch)
+                    if self._maybe_precise_bn(epoch, force=True):
+                        refreshed = self._validate_epoch(
+                            epoch, save_plots=save_final_plots
+                        )
+                        if refreshed is not None:
+                            val_metrics = refreshed
+                            is_best = self._update_best_state(epoch, val_metrics)
+                    elif save_final_plots:
+                        self._validate_epoch(epoch, save_plots=True)
+                    should_stop = self._sync_main_bool(
+                        should_stop and not is_best
+                    )
                 # Write ``last.pt`` every epoch so a crash never costs more than
                 # a single epoch. ``best.pt`` (is_best) and periodic
                 # ``epoch_N.pt`` (save_period) stay gated inside
@@ -1906,6 +1956,7 @@ class BaseTrainer(ABC):
                 # partial epoch as complete would make a later resume skip the
                 # rest of it.
                 if not profile_truncated:
+                    self._maybe_offer_average(val_metrics)
                     self._save_checkpoint(
                         epoch, epoch_loss, val_metrics, is_best=is_best
                     )
@@ -1933,26 +1984,7 @@ class BaseTrainer(ABC):
                 # improvement. ``best_epoch`` is the 1-based epoch of the best
                 # result, so this stays meaningful even when validation only
                 # runs on an interval (unlike counting discrete val events).
-                epochs_since_best = (
-                    (epoch + 1) - self.best_epoch if self.best_epoch else 0
-                )
-                should_stop = (
-                    self.config.patience > 0
-                    and self.best_epoch > 0
-                    and epochs_since_best >= self.config.patience
-                )
-                if self.is_distributed:
-                    import torch.distributed as _dist
-
-                    flag = torch.tensor(int(should_stop), dtype=torch.int, device=self.device)
-                    _dist.broadcast(flag, src=0)
-                    should_stop = bool(flag.item())
                 if should_stop:
-                    if (
-                        bool(getattr(self.config, "save_plots", False))
-                        and not self._is_final_epoch(epoch)
-                    ):
-                        self._validate_epoch(epoch, save_plots=True)
                     if is_main_process():
                         logger.info(
                             f"Early stopping triggered after {epoch + 1} epochs "
@@ -1966,6 +1998,8 @@ class BaseTrainer(ABC):
             if getattr(self, "distiller", None) is not None:
                 self.distiller.cleanup()
 
+            self._refresh_best_precise_bn_checkpoint()
+            self._write_average_checkpoint()
             total_time = time.time() - start_time
             if is_main_process():
                 if getattr(self, "_stop_training", False):
@@ -2027,6 +2061,12 @@ class BaseTrainer(ABC):
             "last_checkpoint": (
                 str(last_checkpoint) if last_checkpoint.exists() else None
             ),
+            "average_checkpoint": (
+                str(weights_dir / "average.pt")
+                if (weights_dir / "average.pt").exists()
+                else None
+            ),
+            "average_metrics": getattr(self, "_average_validation_metrics", None),
         }
 
     def _event_context(self) -> Dict[str, Any]:
@@ -2236,6 +2276,15 @@ class BaseTrainer(ABC):
         else:
             self.patience_counter += 1
         return is_best
+
+    def _sync_main_bool(self, value: bool) -> bool:
+        if not self.is_distributed:
+            return value
+        import torch.distributed as _dist
+
+        flag = torch.tensor(int(value), dtype=torch.int, device=self.device)
+        _dist.broadcast(flag, src=0)
+        return bool(flag.item())
 
     def _get_clip_max_norm(self) -> float:
         value = getattr(self.config, "clip_max_norm", 0.0)
@@ -2460,6 +2509,8 @@ class BaseTrainer(ABC):
         if is_main_process():
             logger.info(f"Epoch {epoch + 1} - Average loss: {avg_loss:.4f}")
 
+        self._maybe_precise_bn(epoch)
+
         # Validation. A profile-only run (profile_then_stop) truncated the
         # epoch, so validating the barely-trained weights would waste time and
         # could poison the best-metric state.
@@ -2644,6 +2695,8 @@ class BaseTrainer(ABC):
         if is_main_process():
             logger.info(f"Epoch {epoch + 1} - Average loss: {avg_loss:.4f}")
 
+        self._maybe_precise_bn(epoch)
+
         # Validation. A profile-only run (profile_then_stop) truncated the
         # epoch, so validating the barely-trained weights would waste time and
         # could poison the best-metric state.
@@ -2668,7 +2721,11 @@ class BaseTrainer(ABC):
             bool(getattr(self.config, "save_plots", False))
             and self._is_final_epoch(epoch)
         )
-        return scheduled or final_plot
+        precise_bn_final = (
+            int(getattr(self.config, "precise_bn", 0) or 0) > 0
+            and self._is_final_epoch(epoch)
+        )
+        return scheduled or final_plot or precise_bn_final
 
     def _is_final_epoch(self, epoch: int) -> bool:
         return (epoch + 1) >= self.config.epochs
@@ -3084,6 +3141,481 @@ class BaseTrainer(ABC):
             logger.debug(f"Validation traceback:\n{traceback.format_exc()}")
             return None
 
+    def _maybe_export_check(self) -> None:
+        if not bool(getattr(self.config, "export_check", False)):
+            return
+        error: Optional[BaseException] = None
+        if is_main_process():
+            try:
+                from .export_check import run_export_parity_check
+
+                wrapper = self.wrapper_model
+                if wrapper is None:
+                    raise RuntimeError("export_check=True requires a wrapper model")
+                logger.info("export_check: exporting ONNX before epoch 1")
+                run_export_parity_check(
+                    wrapper,
+                    out_dir=self.save_dir,
+                    imgsz=getattr(self.config, "imgsz", 640),
+                )
+            except BaseException as exc:
+                error = exc
+        barrier()
+        if self.is_distributed:
+            import torch.distributed as dist
+
+            payload = [None if error is None else f"{type(error).__name__}: {error}"]
+            dist.broadcast_object_list(payload, src=0)
+            if payload[0] is not None:
+                if error is not None:
+                    raise error
+                raise RuntimeError(f"export_check failed on rank 0: {payload[0]}")
+        elif error is not None:
+            raise error
+
+    def _assert_class_balanced_honored(self) -> None:
+        if not bool(getattr(self.config, "class_balanced", False)):
+            return
+        from torch.utils.data import WeightedRandomSampler
+
+        from ..data.class_balanced import DistributedClassBalancedSampler
+
+        sampler = getattr(getattr(self, "train_loader", None), "sampler", None)
+        if isinstance(
+            sampler, (WeightedRandomSampler, DistributedClassBalancedSampler)
+        ):
+            return
+        raise ValueError(
+            f"class_balanced=True is not supported for {self.get_model_family()}: "
+            "this family does not build the train loader through the shared "
+            "detection sampler. Omit class_balanced or use a family that does "
+            "(e.g. YOLO9 / YOLOX)."
+        )
+
+    def _maybe_precise_bn(self, epoch: int, *, force: bool = False) -> bool:
+        samples = int(getattr(self.config, "precise_bn", 0) or 0)
+        if samples <= 0:
+            return False
+        if not force and not self._is_final_epoch(epoch):
+            return False
+        if getattr(self, "_stop_training", False):
+            return False
+        if getattr(self, "_precise_bn_done", False):
+            return False
+        from .precise_bn import compute_precise_bn_stats
+
+        updated = 0
+        raw_model = unwrap_model(self.model)
+        frozen_ids = {id(module) for module in getattr(self, "_frozen_bn_modules", ())}
+        excluded_names = {
+            name
+            for name, module in raw_model.named_modules()
+            if id(module) in frozen_ids
+        }
+        targets = [raw_model]
+        ema = getattr(self, "ema_model", None)
+        if ema is not None and getattr(ema, "ema", None) is not None:
+            targets.append(ema.ema)
+        for net in targets:
+            updated = max(
+                updated,
+                compute_precise_bn_stats(
+                    net,
+                    self.train_loader,
+                    samples,
+                    device=self.device,
+                    excluded_names=excluded_names,
+                ),
+            )
+        self._precise_bn_done = True
+        return updated > 0
+
+    def _refresh_best_precise_bn_checkpoint(self) -> bool:
+        """Recompute BN statistics for a historical best checkpoint.
+
+        The final epoch path recalibrates the live model before validation and
+        checkpointing. If an earlier epoch remains best, rank 0 loads that
+        state and broadcasts it before recalibration so no shared filesystem is
+        required. Live last-epoch weights are restored afterward.
+        """
+        samples = int(getattr(self.config, "precise_bn", 0) or 0)
+        if samples <= 0 or getattr(self, "_stop_training", False):
+            return False
+
+        from .precise_bn import compute_precise_bn_stats
+
+        distributed = bool(getattr(self, "is_distributed", False))
+        refresh = int(getattr(self, "best_epoch", 0) or 0) != self.current_epoch + 1
+        refresh = self._sync_main_bool(refresh)
+        if not refresh:
+            return False
+        try:
+            best_path = self.save_dir / "weights" / "best.pt"
+            checkpoint = None
+            model_state = None
+            checkpoint_error = None
+            if not distributed or is_main_process():
+                if not best_path.is_file():
+                    checkpoint_error = f"best checkpoint not found: {best_path}"
+                else:
+                    try:
+                        checkpoint = load_trusted_torch_file(
+                            best_path,
+                            map_location="cpu",
+                            context="precise BN best checkpoint",
+                        )
+                    except Exception as exc:
+                        checkpoint_error = (
+                            f"could not read best checkpoint {best_path}: {exc}"
+                        )
+                    else:
+                        model_state = (
+                            checkpoint.get("model")
+                            if isinstance(checkpoint, Mapping)
+                            else None
+                        )
+                        if not isinstance(model_state, Mapping):
+                            checkpoint_error = (
+                                f"best checkpoint has no model state: {best_path}"
+                            )
+
+            if distributed:
+                import torch.distributed as _dist
+
+                status = [checkpoint_error]
+                _dist.broadcast_object_list(status, src=0)
+                checkpoint_error = status[0]
+            if checkpoint_error is not None:
+                if is_main_process():
+                    logger.warning("precise_bn: %s", checkpoint_error)
+                return False
+
+            raw_model = unwrap_model(self.model)
+            ema = getattr(self, "ema_model", None)
+            ema_model = getattr(ema, "ema", None) if ema is not None else None
+            raw_checkpoint_state = (
+                checkpoint.get("train_model", model_state)
+                if checkpoint is not None
+                else None
+            )
+            targets = [
+                (
+                    raw_model,
+                    raw_checkpoint_state,
+                    "train_model" if ema_model is not None else "model",
+                )
+            ]
+            if ema_model is not None:
+                targets.append(
+                    (
+                        ema_model,
+                        checkpoint.get("ema", model_state)
+                        if checkpoint is not None
+                        else None,
+                        "ema",
+                    )
+                )
+
+            frozen_ids = {
+                id(module) for module in getattr(self, "_frozen_bn_modules", ())
+            }
+            excluded_names = {
+                name
+                for name, module in raw_model.named_modules()
+                if id(module) in frozen_ids
+            }
+            live_states = [
+                {
+                    key: value.detach().to("cpu").clone()
+                    for key, value in target.state_dict().items()
+                }
+                for target, _state, _key in targets
+            ]
+            refreshed_states: dict[str, dict[str, torch.Tensor]] = {}
+            updated = 0
+            try:
+                load_error = None
+                if not distributed or is_main_process():
+                    try:
+                        for target, state, _key in targets:
+                            target.load_state_dict(state, strict=True)
+                    except Exception as exc:
+                        load_error = f"could not load historical best state: {exc}"
+                if distributed:
+                    status = [load_error]
+                    _dist.broadcast_object_list(status, src=0)
+                    load_error = status[0]
+                if load_error is not None:
+                    raise RuntimeError(f"precise_bn: {load_error}")
+
+                if distributed:
+                    for target, _state, _key in targets:
+                        for value in target.state_dict().values():
+                            _dist.broadcast(value, src=0)
+
+                for target, state, key in targets:
+                    count = compute_precise_bn_stats(
+                        target,
+                        self.train_loader,
+                        samples,
+                        device=self.device,
+                        excluded_names=excluded_names,
+                    )
+                    updated = max(updated, count)
+                    if is_main_process():
+                        refreshed_states[key] = {
+                            name: value.detach().to("cpu").clone()
+                            for name, value in target.state_dict().items()
+                        }
+            finally:
+                for (target, _state, _key), live_state in zip(
+                    targets, live_states, strict=True
+                ):
+                    target.load_state_dict(live_state, strict=True)
+
+            if updated <= 0:
+                return False
+            if is_main_process():
+                assert checkpoint is not None
+                raw_state = refreshed_states[targets[0][2]]
+                selected_state = (
+                    refreshed_states["ema"] if ema_model is not None else raw_state
+                )
+                checkpoint["model"] = selected_state
+                if ema_model is not None:
+                    checkpoint["train_model"] = raw_state
+                    checkpoint["ema"] = selected_state
+                validate_checkpoint_metadata(checkpoint, strict=True)
+                torch.save(checkpoint, best_path)
+                logger.info(
+                    "precise_bn: refreshed historical best checkpoint: %s",
+                    best_path,
+                )
+            return True
+        finally:
+            if distributed:
+                barrier()
+
+    def _maybe_offer_average(self, val_metrics: Optional[Dict[str, Any]]) -> None:
+        averager = getattr(self, "_weight_averager", None)
+        if averager is None or not val_metrics or not is_main_process():
+            return
+        metric = self._best_metric_value(val_metrics)
+        source = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
+        if averager.consider(source, metric):
+            logger.info(
+                "average_best: admitted snapshot (metric=%.5f, pool=%d/%d)",
+                metric,
+                averager.size,
+                averager.n,
+            )
+            self._persist_average_pool()
+
+    def _write_average_checkpoint(self) -> Optional[Path]:
+        averager = getattr(self, "_weight_averager", None)
+        if averager is None:
+            return None
+        distributed = bool(getattr(self, "is_distributed", False))
+        if not is_main_process():
+            if distributed:
+                barrier()
+            return None
+        try:
+            averaged = averager.average_state_dict()
+            if averaged is None:
+                return None
+
+            logger.info("average_best: validating averaged weights")
+            average_metrics = self._validate_average_state(averaged)
+            self._average_validation_metrics = average_metrics
+            if average_metrics is None:
+                logger.warning(
+                    "average_best: averaged weights were written without validation "
+                    "metrics because final validation did not complete"
+                )
+
+            weights_dir = self.save_dir / "weights"
+            weights_dir.mkdir(exist_ok=True)
+            path = weights_dir / "average.pt"
+            names = (
+                self.wrapper_model.names
+                if self.wrapper_model is not None
+                and hasattr(self.wrapper_model, "names")
+                else build_class_names(
+                    int(getattr(self, "num_classes", self.config.num_classes))
+                )
+            )
+            checkpoint_imgsz = getattr(self.config, "imgsz", 640)
+            extra_checkpoint_meta = {}
+            if isinstance(checkpoint_imgsz, (list, tuple)):
+                cp_h, cp_w = int(checkpoint_imgsz[0]), int(checkpoint_imgsz[1])
+                checkpoint_imgsz = max(cp_h, cp_w)
+                if cp_h != cp_w:
+                    extra_checkpoint_meta["imgsz_h"] = cp_h
+                    extra_checkpoint_meta["imgsz_w"] = cp_w
+            extra_checkpoint_meta.update(self._checkpoint_extra_metadata())
+            average_metric_key = (
+                average_metrics.get("best_metric_key") if average_metrics else None
+            )
+            average_metric_value = (
+                self._best_metric_value(average_metrics) if average_metrics else None
+            )
+            checkpoint = wrap_libreyolo_checkpoint(
+                averaged,
+                model_family=self.get_model_family(),
+                size=self.config.size,
+                task=getattr(getattr(self, "wrapper_model", None), "task", "detect"),
+                nc=int(getattr(self, "num_classes", self.config.num_classes)),
+                names=names,
+                imgsz=int(checkpoint_imgsz),
+                epoch=self.current_epoch,
+                best_mAP50_95=self.best_mAP50_95,
+                best_mAP50=self.best_mAP50,
+                best_metric_key=getattr(self, "best_metric_key", "metrics/mAP50-95"),
+                best_metric_value=self.best_mAP50_95,
+                best_epoch=self.best_epoch,
+                is_ema_weights=self.ema_model is not None,
+                averaged_snapshot_count=averager.size,
+                average_metric_key=average_metric_key,
+                average_metric_value=average_metric_value,
+                **extra_checkpoint_meta,
+            )
+            torch.save(checkpoint, path)
+            logger.info(
+                "average_best: wrote %s from %d snapshots (source metrics=%s)",
+                path,
+                averager.size,
+                averager.metrics(),
+            )
+            return path
+        finally:
+            if distributed:
+                barrier()
+
+    def _validate_average_state(
+        self, averaged: Mapping[str, torch.Tensor]
+    ) -> Optional[Dict[str, Any]]:
+        """Validate averaged weights once without changing the live train state."""
+        source = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
+        live_state = {
+            key: value.detach().to("cpu").clone()
+            for key, value in source.state_dict().items()
+        }
+        try:
+            source.load_state_dict(averaged, strict=True)
+            return self._run_validation(self.current_epoch, save_plots=False)
+        finally:
+            source.load_state_dict(live_state, strict=True)
+
+    def _average_pool_path(self, directory: Path | None = None) -> Path:
+        root = directory if directory is not None else (self.save_dir / "weights")
+        return Path(root) / "average_pool.pt"
+
+    def _persist_average_pool(self) -> None:
+        averager = getattr(self, "_weight_averager", None)
+        if averager is None or averager.size == 0 or not is_main_process():
+            return
+        save_dir = getattr(self, "save_dir", None)
+        if save_dir is None:
+            return
+        averager.save(self._average_pool_path())
+
+    def _restore_average_pool(self, checkpoint_path: str | Path) -> None:
+        averager = getattr(self, "_weight_averager", None)
+        if averager is None:
+            self._resume_average_pool_path = str(checkpoint_path)
+            return
+        checkpoint_path = Path(checkpoint_path)
+        sidecar = checkpoint_path.parent / "average_pool.pt"
+        if sidecar.is_file():
+            try:
+                loaded = averager.load(sidecar)
+            except Exception as exc:
+                logger.warning(
+                    "Could not restore average_best pool from %s: %s", sidecar, exc
+                )
+            else:
+                if loaded and is_main_process():
+                    logger.info(
+                        "average_best: restored %d snapshot(s) from %s",
+                        loaded,
+                        sidecar,
+                    )
+                return
+        # last.pt (or any non-best resume) is not the historical best. Tagging
+        # those live weights with best_mAP50_95 would let them block later
+        # snapshots while the real best stays out of average.pt.
+        seed = self._average_seed_snapshot(checkpoint_path)
+        if seed is None:
+            if is_main_process():
+                logger.info(
+                    "average_best: starting with an empty pool; no average_pool.pt "
+                    "next to %s and the resumed weights are not the recorded best",
+                    checkpoint_path,
+                )
+            return
+        seed_state, metric = seed
+        if averager.consider_state(seed_state, metric) and is_main_process():
+            logger.info(
+                "average_best: seeded pool from the recorded best weights "
+                "(metric=%.5f); no average_pool.pt next to %s",
+                metric,
+                checkpoint_path,
+            )
+
+    def _average_seed_snapshot(
+        self, checkpoint_path: Path
+    ) -> Optional[Tuple[Dict[str, torch.Tensor], float]]:
+        """State and metric that were recorded together, or None."""
+        resumed_metric = float(getattr(self, "best_mAP50_95", 0.0) or 0.0)
+        if checkpoint_path.name.lower() == "best.pt":
+            return self._live_average_source_state(), resumed_metric
+        sibling = checkpoint_path.parent / "best.pt"
+        if sibling.is_file():
+            snapshot = self._snapshot_from_checkpoint(sibling)
+            if snapshot is not None:
+                return snapshot
+        resumed_epoch = int(getattr(self, "start_epoch", 1))
+        if resumed_epoch == int(getattr(self, "best_epoch", -1)):
+            return self._live_average_source_state(), resumed_metric
+        return None
+
+    def _live_average_source_state(self) -> Dict[str, torch.Tensor]:
+        source = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
+        return source.state_dict()
+
+    def _snapshot_from_checkpoint(
+        self, path: Path
+    ) -> Optional[Tuple[Dict[str, torch.Tensor], float]]:
+        try:
+            blob = load_trusted_torch_file(
+                path, map_location="cpu", context="average_best seed checkpoint"
+            )
+        except Exception as exc:
+            logger.warning("Could not read %s to seed average_best: %s", path, exc)
+            return None
+        state = blob.get("model") if isinstance(blob, Mapping) else None
+        if not isinstance(state, Mapping):
+            logger.warning(
+                "Checkpoint %s has no model state to seed average_best", path
+            )
+            return None
+        metric = None
+        for key in ("best_metric_value", "best_metric", "best_mAP50_95"):
+            try:
+                candidate = float(blob[key])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if math.isfinite(candidate):
+                metric = candidate
+                break
+        if metric is None:
+            logger.warning(
+                "Checkpoint %s has no finite best metric to seed average_best", path
+            )
+            return None
+        return state, metric
+
     # =========================================================================
     # Checkpointing
     # =========================================================================
@@ -3375,6 +3907,7 @@ class BaseTrainer(ABC):
                 logger.warning(f"Could not restore RNG state: {e}")
 
         self.patience_counter = 0
+        self._restore_average_pool(checkpoint_path)
         logger.info(
             f"Resumed from epoch {self.start_epoch} "
             f"(will train to epoch {self.config.epochs})"

--- a/libreyolo/training/weight_averaging.py
+++ b/libreyolo/training/weight_averaging.py
@@ -1,0 +1,148 @@
+"""Metric-gated top-N checkpoint averaging.
+
+Keeps the N best (by the watched validation metric) full state dicts on
+CPU and, at the end of training, writes their uniform average. Unlike EMA
+this never admits a divergent epoch: a snapshot only enters the pool when
+it beats the current worst member.
+
+Opt-in. ``n=0`` is a no-op so default training is unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import torch
+from torch import nn
+
+
+def _cpu_float_state(model: nn.Module) -> Dict[str, torch.Tensor]:
+    return {
+        key: value.detach().to("cpu").clone()
+        for key, value in model.state_dict().items()
+    }
+
+
+class MetricGatedAverager:
+    """Rolling pool of the N best snapshots, ranked by a scalar metric."""
+
+    def __init__(self, n: int, *, greater_is_better: bool = True):
+        if n < 0:
+            raise ValueError(f"average_best must be >= 0, got {n}")
+        self.n = int(n)
+        self.greater_is_better = bool(greater_is_better)
+        self._pool: List[Tuple[float, Dict[str, torch.Tensor]]] = []
+
+    @property
+    def size(self) -> int:
+        return len(self._pool)
+
+    def consider(self, model: nn.Module, metric: float) -> bool:
+        """Offer a snapshot. Returns True if it entered the pool."""
+        return self.consider_state(_cpu_float_state(model), metric)
+
+    def consider_state(self, state: Mapping[str, torch.Tensor], metric: float) -> bool:
+        """Offer a CPU state dict. Returns True if it entered the pool."""
+        if self.n <= 0 or not _finite(metric):
+            return False
+        snapshot = {
+            key: value.detach().to("cpu").clone() if torch.is_tensor(value) else value
+            for key, value in state.items()
+        }
+        if len(self._pool) < self.n:
+            self._pool.append((float(metric), snapshot))
+            return True
+        worst_i = self._worst_index()
+        worst_metric = self._pool[worst_i][0]
+        better = (
+            metric > worst_metric if self.greater_is_better else metric < worst_metric
+        )
+        if not better:
+            return False
+        self._pool[worst_i] = (float(metric), snapshot)
+        return True
+
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {
+                "n": self.n,
+                "greater_is_better": self.greater_is_better,
+                "metrics": [float(metric) for metric, _ in self._pool],
+                "states": [state for _, state in self._pool],
+            },
+            path,
+        )
+
+    def load(self, path: str | Path) -> int:
+        """Replace the pool from a sidecar written by :meth:`save`.
+
+        Keeps this instance's ``n`` (the live config). Extra snapshots from a
+        larger saved pool are dropped worst-first. Returns how many loaded.
+        """
+        blob = torch.load(path, map_location="cpu", weights_only=True)
+        metrics = list(blob.get("metrics") or [])
+        states = list(blob.get("states") or [])
+        self._pool = []
+        for metric, state in zip(metrics, states):
+            self.consider_state(state, float(metric))
+        return len(self._pool)
+
+    def average_state_dict(self) -> Optional[Dict[str, torch.Tensor]]:
+        if not self._pool:
+            return None
+        keys = self._pool[0][1].keys()
+        n = len(self._pool)
+        best_i = self._best_index()
+        out: Dict[str, torch.Tensor] = {}
+        for key in keys:
+            acc = self._pool[0][1][key].to(dtype=torch.float32)
+            for _, state in self._pool[1:]:
+                acc = acc + state[key].to(dtype=torch.float32)
+            averaged = acc / n
+            ref = self._pool[0][1][key]
+            if not ref.dtype.is_floating_point:
+                # Integer / bool buffers (e.g. num_batches_tracked) stay as
+                # the best snapshot's value, not a fractional mean.
+                out[key] = self._pool[best_i][1][key].clone()
+            else:
+                out[key] = averaged.to(dtype=ref.dtype)
+        return out
+
+    def metrics(self) -> List[float]:
+        return [metric for metric, _ in self._pool]
+
+    def _worst_index(self) -> int:
+        if self.greater_is_better:
+            return min(range(len(self._pool)), key=lambda i: self._pool[i][0])
+        return max(range(len(self._pool)), key=lambda i: self._pool[i][0])
+
+    def _best_index(self) -> int:
+        if self.greater_is_better:
+            return max(range(len(self._pool)), key=lambda i: self._pool[i][0])
+        return min(range(len(self._pool)), key=lambda i: self._pool[i][0])
+
+
+def _finite(value: Any) -> bool:
+    try:
+        return bool(value == value) and abs(float(value)) != float("inf")
+    except (TypeError, ValueError):
+        return False
+
+
+def average_state_dicts(
+    states: Mapping[str, torch.Tensor] | List[Mapping[str, torch.Tensor]],
+) -> Dict[str, torch.Tensor]:
+    """Uniform average of one or more state dicts. Exposed for tests."""
+    if isinstance(states, Mapping):
+        states = [states]
+    if not states:
+        raise ValueError("average_state_dicts requires at least one state dict")
+    averager = MetricGatedAverager(n=len(states))
+    # Bypass consider() so tests can average arbitrary dicts.
+    averager._pool = [(0.0, dict(s)) for s in states]
+    out = averager.average_state_dict()
+    assert out is not None
+    return out

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -234,6 +234,105 @@ def test_train_dry_run_rejects_ambiguous_freeze_true():
     assert "freeze=True is ambiguous" in data["message"]
 
 
+@pytest.mark.parametrize("model_name", ["LibreDFINEs.pt"])
+def test_train_dry_run_rejects_class_balanced_on_custom_loaders(model_name):
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        [
+            "data=coco8.yaml",
+            f"model={model_name}",
+            "class_balanced=true",
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 2, result.stdout
+    data = json.loads(result.stdout)
+    assert data["error"] == "config_unsupported"
+    assert "class_balanced" in data["message"]
+
+
+def test_train_dry_run_accepts_class_balanced_for_rfdetr_detection(monkeypatch):
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train._create_explicit_task_train_model",
+        lambda **_kwargs: None,
+    )
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        [
+            "data=coco8.yaml",
+            "model=rfdetr-n",
+            "task=detect",
+            "class_balanced=true",
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    config = json.loads(result.stdout)["resolved_config"]
+    assert config["class_balanced"] is True
+
+
+def test_train_dry_run_optin_helpers_both_grammars():
+    """New #768 knobs parse in both CLI grammars and stay off by default."""
+    app = _make_app()
+
+    default = runner.invoke(
+        app,
+        ["data=coco8.yaml", "model=LibreYOLO9t.pt", "--dry-run", "--json"],
+    )
+    assert default.exit_code == 0, default.stdout
+    default_cfg = json.loads(default.stdout)["resolved_config"]
+    assert default_cfg["class_balanced"] is False
+    assert default_cfg["average_best"] == 0
+    assert default_cfg["export_check"] is False
+    assert default_cfg["precise_bn"] == 0
+
+    kv = runner.invoke(
+        app,
+        [
+            "data=coco8.yaml",
+            "model=LibreYOLO9t.pt",
+            "class_balanced=true",
+            "average_best=5",
+            "export_check=true",
+            "precise_bn=128",
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert kv.exit_code == 0, kv.stdout
+    kv_cfg = json.loads(kv.stdout)["resolved_config"]
+    assert kv_cfg["class_balanced"] is True
+    assert kv_cfg["average_best"] == 5
+    assert kv_cfg["export_check"] is True
+    assert kv_cfg["precise_bn"] == 128
+
+    dashed = runner.invoke(
+        app,
+        [
+            "data=coco8.yaml",
+            "model=LibreYOLO9t.pt",
+            "--class-balanced",
+            "--average-best",
+            "5",
+            "--export-check",
+            "--precise-bn",
+            "128",
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert dashed.exit_code == 0, dashed.stdout
+    dashed_cfg = json.loads(dashed.stdout)["resolved_config"]
+    assert dashed_cfg["class_balanced"] is True
+    assert dashed_cfg["average_best"] == 5
+    assert dashed_cfg["export_check"] is True
+    assert dashed_cfg["precise_bn"] == 128
+
+
 def test_train_dry_run_distill_model_is_visible():
     """A distillation teacher resolves into the config without error."""
     app = _make_app()
@@ -706,7 +805,3 @@ def test_train_rfdetr_detect_checkpoint_switches_to_obb_architecture(
     data = json.loads(result.stdout)
     assert data["model_family"] == "rfdetr"
     assert data["epochs_completed"] == 1
-
-
-
-

--- a/tests/unit/test_qat_defaults.py
+++ b/tests/unit/test_qat_defaults.py
@@ -35,26 +35,28 @@ class _ProbeTrainer(BaseTrainer):
         raise NotImplementedError
 
 
-def test_qat_guards_disable_ema_and_sync_bn():
-    config = SimpleNamespace(ema=True, sync_bn=True)
+def test_qat_guards_disable_ema_sync_bn_and_checkpoint_averaging():
+    config = SimpleNamespace(ema=True, sync_bn=True, average_best=5)
 
     changed = apply_qat_training_guards(config)
 
-    assert changed == ("ema", "sync_bn")
+    assert changed == ("ema", "sync_bn", "average_best")
     assert config.ema is False
     assert config.sync_bn is False
+    assert config.average_best == 0
 
 
 def test_qat_guards_leave_disabled_options_unchanged():
-    config = SimpleNamespace(ema=False, sync_bn=False)
+    config = SimpleNamespace(ema=False, sync_bn=False, average_best=0)
 
     assert apply_qat_training_guards(config) == ()
     assert config.ema is False
     assert config.sync_bn is False
+    assert config.average_best == 0
 
 
 def test_trainer_logs_qat_guard_changes(caplog):
-    config = SimpleNamespace(ema=True, sync_bn=True, imgsz=(32, 64))
+    config = SimpleNamespace(ema=True, sync_bn=True, average_best=3, imgsz=(32, 64))
     trainer = _ProbeTrainer.__new__(_ProbeTrainer)
     trainer._is_setup = False
     trainer.config = config
@@ -68,12 +70,13 @@ def test_trainer_logs_qat_guard_changes(caplog):
 
     assert config.ema is False
     assert config.sync_bn is False
-    assert "ema=False, sync_bn=False" in caplog.text
+    assert config.average_best == 0
+    assert "ema=False, sync_bn=False, average_best=0" in caplog.text
     assert "QAT recipe 'int8'" in caplog.text
 
 
 def test_float_trainer_does_not_apply_qat_guards():
-    config = SimpleNamespace(ema=True, sync_bn=True, imgsz=(32, 64))
+    config = SimpleNamespace(ema=True, sync_bn=True, average_best=3, imgsz=(32, 64))
     trainer = _ProbeTrainer.__new__(_ProbeTrainer)
     trainer._is_setup = False
     trainer.config = config
@@ -84,3 +87,4 @@ def test_float_trainer_does_not_apply_qat_guards():
 
     assert config.ema is True
     assert config.sync_bn is True
+    assert config.average_best == 3

--- a/tests/unit/test_sg_optin_helpers.py
+++ b/tests/unit/test_sg_optin_helpers.py
@@ -1,0 +1,999 @@
+"""Opt-in training helpers from issue #768.
+
+Defaults stay off so existing training calls are unchanged. These tests lock
+that contract and the helpers' math without running a full training job.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import RandomSampler, WeightedRandomSampler
+from torch.utils.data.distributed import DistributedSampler
+
+from libreyolo.data.class_balanced import (
+    DistributedClassBalancedSampler,
+    class_ids_from_anno,
+    image_repeat_factors,
+)
+from libreyolo.data.dataset import create_dataloader
+from libreyolo.training.config import TrainConfig
+from libreyolo.training.export_check import assert_close, outputs_comparable
+from libreyolo.training.precise_bn import compute_precise_bn_stats
+from libreyolo.training.weight_averaging import MetricGatedAverager
+from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Defaults: nothing new turns on by accident
+# ---------------------------------------------------------------------------
+
+
+def test_train_config_new_knobs_default_off():
+    cfg = TrainConfig()
+    assert cfg.class_balanced is False
+    assert cfg.average_best == 0
+    assert cfg.export_check is False
+    assert cfg.precise_bn == 0
+    assert cfg.ema is True
+    assert cfg.sync_bn is False
+    assert cfg.min_samples == 0
+
+
+def test_train_config_rejects_negative_knobs():
+    with pytest.raises(ValueError, match="average_best"):
+        TrainConfig(average_best=-1)
+    with pytest.raises(ValueError, match="precise_bn"):
+        TrainConfig(precise_bn=-1)
+
+
+# ---------------------------------------------------------------------------
+# Weight averaging
+# ---------------------------------------------------------------------------
+
+
+class _Tiny(nn.Module):
+    def __init__(self, fill: float, *, steps: int = 1):
+        super().__init__()
+        self.w = nn.Parameter(torch.full((2,), fill))
+        self.register_buffer("steps", torch.tensor(steps, dtype=torch.long))
+
+
+def test_averager_off_never_stores():
+    averager = MetricGatedAverager(0)
+    assert averager.consider(_Tiny(1.0), 0.9) is False
+    assert averager.average_state_dict() is None
+
+
+def test_averager_keeps_top_n_and_means_weights():
+    averager = MetricGatedAverager(2)
+    assert averager.consider(_Tiny(1.0, steps=1), 0.10)
+    assert averager.consider(_Tiny(3.0, steps=3), 0.30)
+    assert averager.consider(_Tiny(5.0, steps=5), 0.20) is True  # replaces 0.10
+    assert averager.consider(_Tiny(7.0, steps=7), 0.05) is False
+    avg = averager.average_state_dict()
+    assert avg is not None
+    # pool is 3.0 @ 0.30 and 5.0 @ 0.20 → mean 4.0
+    assert torch.allclose(avg["w"], torch.tensor([4.0, 4.0]))
+    assert avg["steps"].dtype == torch.long
+    assert avg["steps"].item() == 3
+
+
+def test_averager_rejects_nan():
+    averager = MetricGatedAverager(2)
+    assert averager.consider(_Tiny(1.0), float("nan")) is False
+    assert averager.size == 0
+
+
+def test_averager_pool_roundtrip(tmp_path):
+    src = MetricGatedAverager(2)
+    src.consider(_Tiny(1.0), 0.10)
+    src.consider(_Tiny(3.0), 0.30)
+    path = tmp_path / "average_pool.pt"
+    src.save(path)
+    dst = MetricGatedAverager(2)
+    assert dst.load(path) == 2
+    assert sorted(dst.metrics()) == [0.10, 0.30]
+    avg = dst.average_state_dict()
+    assert torch.allclose(avg["w"], torch.tensor([2.0, 2.0]))
+
+
+def test_averager_load_keeps_live_n(tmp_path):
+    src = MetricGatedAverager(3)
+    src.consider(_Tiny(1.0), 0.10)
+    src.consider(_Tiny(3.0), 0.30)
+    src.consider(_Tiny(5.0), 0.50)
+    path = tmp_path / "average_pool.pt"
+    src.save(path)
+    dst = MetricGatedAverager(2)
+    dst.load(path)
+    assert dst.size == 2
+    assert sorted(dst.metrics()) == [0.30, 0.50]
+
+
+def test_average_validation_restores_live_weights():
+    from libreyolo.training.trainer import BaseTrainer
+
+    live = _Tiny(9.0)
+    observed = {}
+    trainer = SimpleNamespace(model=live, ema_model=None, current_epoch=4)
+
+    def run_validation(epoch, *, save_plots):
+        observed["epoch"] = epoch
+        observed["save_plots"] = save_plots
+        observed["weights"] = live.w.detach().clone()
+        return {"best_metric": 0.5}
+
+    trainer._run_validation = run_validation
+    metrics = BaseTrainer._validate_average_state(trainer, _Tiny(3.0).state_dict())
+
+    assert metrics == {"best_metric": 0.5}
+    assert observed["epoch"] == 4
+    assert observed["save_plots"] is False
+    assert torch.equal(observed["weights"], torch.tensor([3.0, 3.0]))
+    assert torch.equal(live.w, torch.tensor([9.0, 9.0]))
+
+
+def test_average_checkpoint_records_separate_validation(tmp_path):
+    from libreyolo.training.trainer import BaseTrainer
+
+    averager = MetricGatedAverager(2)
+    averager.consider(_Tiny(1.0), 0.2)
+    averager.consider(_Tiny(3.0), 0.4)
+    average_metrics = {
+        "best_metric": 0.35,
+        "best_metric_key": "metrics/mAP50-95",
+    }
+    trainer = SimpleNamespace(
+        _weight_averager=averager,
+        is_distributed=False,
+        save_dir=tmp_path,
+        wrapper_model=SimpleNamespace(names={0: "object"}, task="detect"),
+        config=SimpleNamespace(size="t", imgsz=32, num_classes=1),
+        num_classes=1,
+        current_epoch=4,
+        best_mAP50_95=0.4,
+        best_mAP50=0.5,
+        best_metric_key="metrics/mAP50-95",
+        best_epoch=3,
+        ema_model=None,
+    )
+    trainer.get_model_family = lambda: "yolo9"
+    trainer._checkpoint_extra_metadata = lambda: {}
+    trainer._validate_average_state = lambda _state: average_metrics
+    trainer._best_metric_value = lambda values: float(values["best_metric"])
+
+    path = BaseTrainer._write_average_checkpoint(trainer)
+
+    assert path == tmp_path / "weights" / "average.pt"
+    checkpoint = torch.load(path, map_location="cpu", weights_only=True)
+    assert checkpoint["averaged_snapshot_count"] == 2
+    assert checkpoint["average_metric_key"] == "metrics/mAP50-95"
+    assert checkpoint["average_metric_value"] == pytest.approx(0.35)
+    assert checkpoint["is_ema_weights"] is False
+    assert torch.equal(checkpoint["model"]["w"], torch.tensor([2.0, 2.0]))
+
+
+def _restore_pool_trainer(tmp_path, *, start_epoch, best_epoch, fill=1.0):
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = SimpleNamespace(
+        model=_Tiny(fill),
+        ema_model=None,
+        _weight_averager=MetricGatedAverager(2),
+        best_mAP50_95=0.42,
+        start_epoch=start_epoch,
+        best_epoch=best_epoch,
+    )
+    trainer._average_seed_snapshot = lambda path: (
+        BaseTrainer._average_seed_snapshot(trainer, path)
+    )
+    trainer._live_average_source_state = lambda: BaseTrainer._live_average_source_state(
+        trainer
+    )
+    trainer._snapshot_from_checkpoint = lambda path: (
+        BaseTrainer._snapshot_from_checkpoint(trainer, path)
+    )
+    return trainer
+
+
+def test_restore_average_pool_prefers_sidecar(tmp_path):
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = _restore_pool_trainer(tmp_path, start_epoch=5, best_epoch=2)
+    last = tmp_path / "last.pt"
+    last.write_bytes(b"")
+    src = MetricGatedAverager(2)
+    src.consider(_Tiny(3.0), 0.30)
+    src.consider(_Tiny(5.0), 0.50)
+    src.save(tmp_path / "average_pool.pt")
+    BaseTrainer._restore_average_pool(trainer, last)
+    assert sorted(trainer._weight_averager.metrics()) == [0.30, 0.50]
+    avg = trainer._weight_averager.average_state_dict()
+    assert torch.allclose(avg["w"], torch.tensor([4.0, 4.0]))
+
+
+def test_restore_average_pool_seeds_sibling_best_not_last(tmp_path):
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = _restore_pool_trainer(tmp_path, start_epoch=5, best_epoch=2, fill=1.0)
+    last = tmp_path / "last.pt"
+    last.write_bytes(b"")
+    torch.save(
+        {"model": _Tiny(9.0).state_dict(), "best_metric_value": 0.73},
+        tmp_path / "best.pt",
+    )
+    BaseTrainer._restore_average_pool(trainer, last)
+    assert trainer._weight_averager.metrics() == [0.73]
+    avg = trainer._weight_averager.average_state_dict()
+    assert torch.allclose(avg["w"], torch.tensor([9.0, 9.0]))
+
+
+def test_restore_average_pool_does_not_mislabel_sibling_without_metric(tmp_path):
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = _restore_pool_trainer(tmp_path, start_epoch=5, best_epoch=2)
+    last = tmp_path / "last.pt"
+    last.write_bytes(b"")
+    torch.save({"model": _Tiny(9.0).state_dict()}, tmp_path / "best.pt")
+    BaseTrainer._restore_average_pool(trainer, last)
+    assert trainer._weight_averager.size == 0
+
+
+def test_restore_average_pool_empty_when_last_is_not_best(tmp_path):
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = _restore_pool_trainer(tmp_path, start_epoch=5, best_epoch=2, fill=1.0)
+    last = tmp_path / "last.pt"
+    last.write_bytes(b"")
+    BaseTrainer._restore_average_pool(trainer, last)
+    assert trainer._weight_averager.size == 0
+
+
+def test_restore_average_pool_seeds_when_resume_is_best_epoch(tmp_path):
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = _restore_pool_trainer(tmp_path, start_epoch=2, best_epoch=2, fill=4.0)
+    last = tmp_path / "last.pt"
+    last.write_bytes(b"")
+    BaseTrainer._restore_average_pool(trainer, last)
+    assert trainer._weight_averager.metrics() == [0.42]
+    avg = trainer._weight_averager.average_state_dict()
+    assert torch.allclose(avg["w"], torch.tensor([4.0, 4.0]))
+
+
+def test_restore_average_pool_seeds_resumed_best_pt(tmp_path):
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = _restore_pool_trainer(tmp_path, start_epoch=5, best_epoch=2, fill=7.0)
+    best = tmp_path / "best.pt"
+    best.write_bytes(b"")
+    BaseTrainer._restore_average_pool(trainer, best)
+    assert trainer._weight_averager.metrics() == [0.42]
+    avg = trainer._weight_averager.average_state_dict()
+    assert torch.allclose(avg["w"], torch.tensor([7.0, 7.0]))
+
+
+# ---------------------------------------------------------------------------
+# Precise BN
+# ---------------------------------------------------------------------------
+
+
+class _BnNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bn = nn.BatchNorm2d(1)
+        self.bn.running_mean.fill_(99.0)
+        self.bn.running_var.fill_(99.0)
+
+    def forward(self, x):
+        return self.bn(x)
+
+
+def _precise_bn_nonshared_best_worker(rank, world_size, port, out_dir):
+    import os
+    from datetime import timedelta
+
+    import torch.distributed as dist
+
+    out_path = Path(out_dir) / f"precise_bn_rank_{rank}.txt"
+    try:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(port)
+        dist.init_process_group(
+            "gloo",
+            rank=rank,
+            world_size=world_size,
+            timeout=timedelta(seconds=60),
+        )
+
+        from libreyolo.training.trainer import BaseTrainer
+
+        rank_dir = Path(out_dir) / f"rank_{rank}"
+        if rank == 0:
+            weights_dir = rank_dir / "weights"
+            weights_dir.mkdir(parents=True)
+            historical_best = _BnNet()
+            historical_best.bn.running_mean.fill_(11.0)
+            checkpoint = wrap_libreyolo_checkpoint(
+                historical_best.state_dict(),
+                model_family="yolo9",
+                size="t",
+                task="detect",
+                nc=1,
+                names={0: "object"},
+                imgsz=32,
+            )
+            torch.save(checkpoint, weights_dir / "best.pt")
+        dist.barrier()
+
+        live = _BnNet()
+        live.bn.running_mean.fill_(7.0)
+        trainer = SimpleNamespace(
+            config=SimpleNamespace(precise_bn=2),
+            model=live,
+            ema_model=None,
+            train_loader=[(torch.ones(2, 1, 2, 2) * (1.0 + 4.0 * rank),)],
+            device=torch.device("cpu"),
+            save_dir=rank_dir,
+            current_epoch=4,
+            best_epoch=2 if rank == 0 else 0,
+            is_distributed=True,
+            _stop_training=False,
+            _frozen_bn_modules=(),
+        )
+        trainer._sync_main_bool = lambda value: BaseTrainer._sync_main_bool(
+            trainer, value
+        )
+
+        assert BaseTrainer._refresh_best_precise_bn_checkpoint(trainer) is True
+        assert torch.equal(live.bn.running_mean, torch.tensor([7.0]))
+        if rank == 0:
+            refreshed = torch.load(
+                rank_dir / "weights" / "best.pt",
+                map_location="cpu",
+                weights_only=True,
+            )
+            assert torch.allclose(
+                refreshed["model"]["bn.running_mean"],
+                torch.tensor([3.0]),
+                atol=1e-5,
+            )
+        else:
+            assert not (rank_dir / "weights" / "best.pt").exists()
+        out_path.write_text("ok\n")
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_precise_bn_historical_best_works_without_shared_rank_paths(tmp_path):
+    import contextlib
+    import socket
+
+    import torch.multiprocessing as mp
+
+    with contextlib.closing(socket.socket()) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = int(sock.getsockname()[1])
+    mp.spawn(
+        _precise_bn_nonshared_best_worker,
+        args=(2, port, str(tmp_path)),
+        nprocs=2,
+        join=True,
+    )
+    for rank in range(2):
+        result = (tmp_path / f"precise_bn_rank_{rank}.txt").read_text()
+        assert result == "ok\n", f"rank {rank}: {result!r}"
+
+
+def test_precise_bn_zero_samples_is_noop():
+    net = _BnNet()
+    before = net.bn.running_mean.clone()
+    assert compute_precise_bn_stats(net, [torch.zeros(2, 1, 4, 4)], 0) == 0
+    assert torch.equal(net.bn.running_mean, before)
+
+
+def test_precise_bn_no_bn_is_noop():
+    net = nn.Linear(3, 3)
+    assert compute_precise_bn_stats(net, [torch.zeros(2, 3)], 8) == 0
+
+
+def test_precise_bn_rewrites_running_stats_and_restores_momentum():
+    net = _BnNet()
+    images = torch.ones(4, 1, 2, 2) * 3.0
+    updated = compute_precise_bn_stats(net, [(images, "ignored")], num_samples=4)
+    assert updated == 1
+    assert net.bn.momentum == 0.1
+    assert torch.allclose(net.bn.running_mean, torch.tensor([3.0]), atol=1e-5)
+
+
+def test_precise_bn_skips_when_forward_rejects_bare_images():
+    class _NeedsTargets(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.bn = nn.BatchNorm2d(1)
+
+        def forward(self, x, targets):
+            return self.bn(x)
+
+    net = _NeedsTargets()
+    mean_before = net.bn.running_mean.clone()
+    assert compute_precise_bn_stats(net, [torch.zeros(2, 1, 2, 2)], 4) == 0
+    assert torch.equal(net.bn.running_mean, mean_before)
+    assert net.bn.momentum == 0.1
+
+
+def test_precise_bn_rolls_back_partial_forward_updates():
+    class _FailsAfterBn(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.bn = nn.BatchNorm2d(1)
+
+        def forward(self, x):
+            self.bn(x)
+            raise RuntimeError("after BN")
+
+    net = _FailsAfterBn()
+    mean_before = net.bn.running_mean.clone()
+    var_before = net.bn.running_var.clone()
+    count_before = net.bn.num_batches_tracked.clone()
+    assert compute_precise_bn_stats(net, [torch.ones(2, 1, 2, 2)], 2) == 0
+    assert torch.equal(net.bn.running_mean, mean_before)
+    assert torch.equal(net.bn.running_var, var_before)
+    assert torch.equal(net.bn.num_batches_tracked, count_before)
+
+
+def test_precise_bn_excludes_frozen_modules():
+    class _TwoBn(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.frozen = nn.BatchNorm2d(1)
+            self.trainable = nn.BatchNorm2d(1)
+            self.frozen.running_mean.fill_(11.0)
+            self.trainable.running_mean.fill_(22.0)
+
+        def forward(self, x):
+            return self.trainable(self.frozen(x))
+
+    net = _TwoBn()
+    updated = compute_precise_bn_stats(
+        net,
+        [torch.ones(2, 1, 2, 2) * 3.0],
+        2,
+        excluded_names={"frozen"},
+    )
+    assert updated == 1
+    assert torch.equal(net.frozen.running_mean, torch.tensor([11.0]))
+    expected = (3.0 - 11.0) / (1.0 + net.frozen.eps) ** 0.5
+    assert torch.allclose(net.trainable.running_mean, torch.tensor([expected]))
+
+
+def test_precise_bn_hook_runs_on_force_before_last_epoch():
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = SimpleNamespace(
+        config=TrainConfig(precise_bn=4, epochs=10),
+        model=_BnNet(),
+        train_loader=[(torch.ones(2, 1, 2, 2) * 3.0,)],
+        device="cpu",
+        _stop_training=False,
+    )
+    trainer._is_final_epoch = lambda epoch: BaseTrainer._is_final_epoch(trainer, epoch)
+    BaseTrainer._maybe_precise_bn(trainer, 2)
+    assert not getattr(trainer, "_precise_bn_done", False)
+    assert BaseTrainer._maybe_precise_bn(trainer, 2, force=True) is True
+    assert trainer._precise_bn_done is True
+    assert torch.allclose(trainer.model.bn.running_mean, torch.tensor([3.0]), atol=1e-5)
+
+
+def test_precise_bn_hook_updates_ema_copy():
+    from libreyolo.training.trainer import BaseTrainer
+
+    raw = _BnNet()
+    ema = _BnNet()
+    trainer = SimpleNamespace(
+        config=TrainConfig(precise_bn=4, epochs=1),
+        model=raw,
+        ema_model=SimpleNamespace(ema=ema),
+        train_loader=[(torch.ones(2, 1, 2, 2) * 3.0,)],
+        device="cpu",
+        _stop_training=False,
+    )
+    trainer._is_final_epoch = lambda epoch: True
+    assert BaseTrainer._maybe_precise_bn(trainer, 0) is True
+    assert torch.allclose(raw.bn.running_mean, torch.tensor([3.0]), atol=1e-5)
+    assert torch.allclose(ema.bn.running_mean, torch.tensor([3.0]), atol=1e-5)
+
+
+def test_precise_bn_forces_validation_on_final_epoch():
+    from libreyolo.training.trainer import BaseTrainer
+
+    trainer = SimpleNamespace(
+        config=TrainConfig(epochs=10, eval_interval=6, precise_bn=4)
+    )
+    trainer._is_final_epoch = lambda epoch: BaseTrainer._is_final_epoch(trainer, epoch)
+
+    assert BaseTrainer._should_validate_epoch(trainer, 8) is False
+    assert BaseTrainer._should_validate_epoch(trainer, 9) is True
+
+
+@pytest.mark.parametrize("use_ema", [False, True])
+def test_precise_bn_refreshes_historical_best_and_restores_live_model(
+    tmp_path, use_ema
+):
+    from libreyolo.training.trainer import BaseTrainer
+
+    live = _BnNet()
+    live.bn.running_mean.fill_(7.0)
+    live_ema = _BnNet()
+    live_ema.bn.running_mean.fill_(8.0)
+    historical_best = _BnNet()
+    historical_best.bn.running_mean.fill_(11.0)
+    historical_ema = _BnNet()
+    historical_ema.bn.running_mean.fill_(12.0)
+    weights_dir = tmp_path / "weights"
+    weights_dir.mkdir()
+    checkpoint = wrap_libreyolo_checkpoint(
+        (
+            historical_ema.state_dict()
+            if use_ema
+            else historical_best.state_dict()
+        ),
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=1,
+        names={0: "object"},
+        imgsz=32,
+    )
+    if use_ema:
+        checkpoint["train_model"] = historical_best.state_dict()
+        checkpoint["ema"] = historical_ema.state_dict()
+    torch.save(checkpoint, weights_dir / "best.pt")
+
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(precise_bn=2),
+        model=live,
+        ema_model=SimpleNamespace(ema=live_ema) if use_ema else None,
+        train_loader=[(torch.ones(2, 1, 2, 2) * 3.0,)],
+        device="cpu",
+        save_dir=tmp_path,
+        current_epoch=4,
+        best_epoch=2,
+        is_distributed=False,
+        _stop_training=False,
+        _frozen_bn_modules=(),
+    )
+    trainer._sync_main_bool = lambda value: BaseTrainer._sync_main_bool(
+        trainer, value
+    )
+
+    assert BaseTrainer._refresh_best_precise_bn_checkpoint(trainer) is True
+    refreshed = torch.load(
+        weights_dir / "best.pt", map_location="cpu", weights_only=True
+    )
+    assert torch.allclose(
+        refreshed["model"]["bn.running_mean"], torch.tensor([3.0]), atol=1e-5
+    )
+    if use_ema:
+        assert torch.allclose(
+            refreshed["train_model"]["bn.running_mean"],
+            torch.tensor([3.0]),
+            atol=1e-5,
+        )
+        assert torch.equal(
+            refreshed["ema"]["bn.running_mean"],
+            refreshed["model"]["bn.running_mean"],
+        )
+    assert torch.equal(live.bn.running_mean, torch.tensor([7.0]))
+    assert torch.equal(live_ema.bn.running_mean, torch.tensor([8.0]))
+
+
+def test_precise_bn_nonmain_refresh_does_not_require_best_file(tmp_path, monkeypatch):
+    from libreyolo.training import trainer as trainer_module
+    from libreyolo.training.trainer import BaseTrainer
+
+    live = _BnNet()
+    live.bn.running_mean.fill_(7.0)
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(precise_bn=2),
+        model=live,
+        ema_model=None,
+        train_loader=[(torch.ones(2, 1, 2, 2) * 3.0,)],
+        device="cpu",
+        save_dir=tmp_path,
+        current_epoch=4,
+        best_epoch=2,
+        is_distributed=True,
+        _stop_training=False,
+        _frozen_bn_modules=(),
+        _sync_main_bool=lambda _value: True,
+    )
+    barriers = []
+    monkeypatch.setattr(trainer_module, "is_main_process", lambda: False)
+    monkeypatch.setattr(trainer_module, "barrier", lambda: barriers.append(True))
+    monkeypatch.setattr(
+        torch.distributed, "broadcast_object_list", lambda _values, src: None
+    )
+    monkeypatch.setattr(torch.distributed, "broadcast", lambda _value, src: None)
+
+    assert BaseTrainer._refresh_best_precise_bn_checkpoint(trainer) is True
+    assert barriers == [True]
+    assert not (tmp_path / "weights" / "best.pt").exists()
+    assert torch.equal(live.bn.running_mean, torch.tensor([7.0]))
+
+
+def test_precise_bn_improvement_cancels_early_stop():
+    from libreyolo.training.trainer import BaseTrainer
+
+    trained_epochs = []
+    initial_metrics = [0.5, 0.4, 0.55]
+
+    def train_epoch(epoch):
+        trained_epochs.append(epoch)
+        return 1.0, {"best_metric": initial_metrics[epoch]}, {}, {}
+
+    def no_op(*_args, **_kwargs):
+        return None
+
+    callbacks = SimpleNamespace(
+        on_train_start=no_op,
+        on_train_epoch_end=no_op,
+        on_train_end=no_op,
+    )
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(
+            epochs=3,
+            no_aug_epochs=0,
+            patience=1,
+            save_plots=False,
+            batch=1,
+            imgsz=32,
+        ),
+        is_distributed=False,
+        device=torch.device("cpu"),
+        start_epoch=0,
+        current_epoch=0,
+        best_epoch=0,
+        best_mAP50_95=0.0,
+        best_mAP50=0.0,
+        patience_counter=0,
+        final_loss=0.0,
+        epoch_losses=[],
+        epoch_events=[],
+        _stop_training=False,
+        distiller=None,
+        callbacks=callbacks,
+        input_size=(32, 32),
+        effective_lr=0.01,
+    )
+    trainer.setup = no_op
+    trainer._maybe_export_check = no_op
+    trainer.get_model_tag = lambda: "test-model"
+    trainer._build_train_start_event = lambda: None
+    trainer._dispatch_artifact_callbacks = no_op
+    trainer._train_epoch = train_epoch
+    trainer._normalize_epoch_result = lambda result: result
+    trainer._best_metric_value = lambda metrics: BaseTrainer._best_metric_value(
+        trainer, metrics
+    )
+    trainer._as_float = BaseTrainer._as_float
+    trainer._update_best_state = lambda epoch, metrics: BaseTrainer._update_best_state(
+        trainer, epoch, metrics
+    )
+    trainer._sync_main_bool = lambda value: BaseTrainer._sync_main_bool(
+        trainer, value
+    )
+    trainer._maybe_precise_bn = lambda epoch, force=False: force and epoch == 1
+    trainer._validate_epoch = lambda epoch, save_plots=False: {"best_metric": 0.6}
+    trainer._maybe_offer_average = no_op
+    trainer._save_checkpoint = no_op
+    trainer._build_train_epoch_event = lambda **kwargs: kwargs
+    trainer._refresh_best_precise_bn_checkpoint = no_op
+    trainer._write_average_checkpoint = no_op
+    trainer._build_train_results = lambda: {"trained_epochs": trained_epochs}
+    trainer._build_train_end_event = lambda *_args: None
+    trainer._build_train_exception_event = lambda *_args: None
+
+    result = BaseTrainer.train(trainer)
+
+    assert result["trained_epochs"] == [0, 1, 2]
+    assert trainer.best_epoch == 2
+
+
+# ---------------------------------------------------------------------------
+# Export-check comparison
+# ---------------------------------------------------------------------------
+
+
+def test_export_check_comparable_and_close():
+    a = (torch.zeros(1, 4),)
+    b = (torch.zeros(1, 4),)
+    assert outputs_comparable(a, b)
+    assert_close(a, b)
+
+
+def test_export_check_mismatch_raises():
+    a = (torch.zeros(1, 4),)
+    b = (torch.ones(1, 4),)
+    with pytest.raises(AssertionError, match="differs"):
+        assert_close(a, b)
+
+
+def test_export_check_layout_mismatch_is_not_comparable():
+    a = (torch.zeros(1, 4),)
+    b = (torch.zeros(2, 4), torch.zeros(2, 1))
+    assert not outputs_comparable(a, b)
+
+
+# ---------------------------------------------------------------------------
+# Class-balanced sampler
+# ---------------------------------------------------------------------------
+
+
+class _AnnoDataset:
+    def __init__(self, rows):
+        self._rows = rows
+        self.num_classes = 2
+
+    def __len__(self):
+        return len(self._rows)
+
+    def load_anno(self, index):
+        return np.asarray(self._rows[index], dtype=np.float32)
+
+
+def test_class_ids_from_empty_anno():
+    assert class_ids_from_anno(np.zeros((0, 5))).size == 0
+    assert class_ids_from_anno([]).size == 0
+
+
+def test_repeat_factors_boost_rare_class_images():
+    # 3 images of class 0, 1 image of class 1 → class 1 is below the median
+    dataset = _AnnoDataset(
+        [
+            [[0, 0, 1, 1, 0]],
+            [[0, 0, 1, 1, 0]],
+            [[0, 0, 1, 1, 0]],
+            [[0, 0, 1, 1, 1]],
+        ]
+    )
+    weights = image_repeat_factors(dataset, alpha=0.5)
+    assert weights.shape == (4,)
+    assert weights[3] > weights[0]
+    assert np.allclose(weights[:3], weights[0])
+
+
+def test_repeat_factors_unwrap_mosaic_wrapper():
+    inner = _AnnoDataset(
+        [
+            [[0, 0, 1, 1, 0]],
+            [[0, 0, 1, 1, 0]],
+            [[0, 0, 1, 1, 1]],
+        ]
+    )
+
+    class _Mosaic:
+        def __init__(self, dataset):
+            self.dataset = dataset
+
+        def __len__(self):
+            return len(self.dataset)
+
+    weights = image_repeat_factors(_Mosaic(inner))
+    assert weights.shape == (3,)
+    assert weights[2] > weights[0]
+
+
+def test_create_dataloader_class_balanced_off_keeps_random_sampler():
+    dataset = [None] * 6
+    loader = create_dataloader(dataset, batch_size=2, num_workers=0)
+    assert isinstance(loader.sampler, RandomSampler)
+    assert loader.sampler.replacement is False
+
+
+def test_create_dataloader_class_balanced_uses_weighted_sampler():
+    dataset = _AnnoDataset(
+        [
+            [[0, 0, 1, 1, 0]],
+            [[0, 0, 1, 1, 0]],
+            [[0, 0, 1, 1, 1]],
+        ]
+    )
+    loader = create_dataloader(
+        dataset, batch_size=2, num_workers=0, class_balanced=True
+    )
+    assert isinstance(loader.sampler, WeightedRandomSampler)
+    assert len(loader.sampler) == 3
+
+
+def test_create_dataloader_class_balanced_rejects_custom_sampler():
+    dataset = _AnnoDataset([[[0, 0, 1, 1, 0]]])
+    custom = RandomSampler(dataset)
+    with pytest.raises(ValueError, match="custom"):
+        create_dataloader(
+            dataset, batch_size=1, num_workers=0, sampler=custom, class_balanced=True
+        )
+
+
+def test_create_dataloader_class_balanced_replaces_distributed_sampler():
+    dataset = _AnnoDataset(
+        [
+            [[0, 0, 1, 1, 0]],
+            [[0, 0, 1, 1, 1]],
+        ]
+    )
+    sampler = DistributedSampler(dataset, num_replicas=2, rank=0, shuffle=True)
+    loader = create_dataloader(
+        dataset, batch_size=1, num_workers=0, sampler=sampler, class_balanced=True
+    )
+    assert isinstance(loader.sampler, DistributedClassBalancedSampler)
+    assert loader.sampler.num_replicas == 2
+    assert loader.sampler.rank == 0
+    assert hasattr(loader.sampler, "set_epoch")
+
+
+# ---------------------------------------------------------------------------
+# DDP calib gather: single-process path is a plain forward
+# ---------------------------------------------------------------------------
+
+
+def test_rfdetr_cli_forwards_all_supported_helpers(tmp_path):
+    from libreyolo.cli.config import _build_rfdetr_train_kwargs
+
+    kwargs = _build_rfdetr_train_kwargs(
+        {
+            "project": str(tmp_path),
+            "name": "exp",
+            "exist_ok": True,
+            "average_best": 5,
+            "export_check": True,
+            "precise_bn": 64,
+            "class_balanced": True,
+        }
+    )
+    assert kwargs["average_best"] == 5
+    assert kwargs["export_check"] is True
+    assert kwargs["precise_bn"] == 64
+    assert kwargs["class_balanced"] is True
+
+
+def test_build_train_kwargs_forwards_new_knobs():
+    from libreyolo.cli.config import build_train_kwargs
+
+    kwargs = build_train_kwargs(
+        {
+            "class_balanced": True,
+            "average_best": 5,
+            "export_check": True,
+            "precise_bn": 128,
+        }
+    )
+    assert kwargs["class_balanced"] is True
+    assert kwargs["average_best"] == 5
+    assert kwargs["export_check"] is True
+    assert kwargs["precise_bn"] == 128
+
+
+def test_export_check_uses_output_path_and_restores_live_model(tmp_path, monkeypatch):
+    import sys
+
+    import libreyolo.training.export_check as export_check
+
+    class _Tiny(nn.Module):
+        def forward(self, x):
+            return x.mean(dim=(2, 3))
+
+    live = _Tiny()
+    seen = {}
+
+    class _Wrapper:
+        def __init__(self):
+            self.model = live
+            self.device = torch.device("cpu")
+
+        def export(self, **kwargs):
+            seen["kwargs"] = kwargs
+            seen["model_id"] = id(self.model)
+            path = Path(kwargs["output_path"])
+            path.write_bytes(b"onnx")
+            return str(path)
+
+    class _Sess:
+        def get_inputs(self):
+            return [SimpleNamespace(name="x")]
+
+        def run(self, *args, **kwargs):
+            return [torch.zeros(1, 1).numpy()]
+
+    class _ORT:
+        @staticmethod
+        def InferenceSession(*args, **kwargs):
+            return _Sess()
+
+    wrapper = _Wrapper()
+    monkeypatch.setitem(sys.modules, "onnxruntime", _ORT)
+    monkeypatch.setattr(
+        export_check,
+        "module_has_lora",
+        lambda _m: False,
+        raising=False,
+    )
+    # module_has_lora is imported inside the function; patch the lora module.
+    import libreyolo.training.lora as lora
+
+    monkeypatch.setattr(lora, "module_has_lora", lambda _m: False)
+
+    out = export_check.run_export_parity_check(wrapper, out_dir=tmp_path, imgsz=32)
+    assert seen["kwargs"]["output_path"] == str(tmp_path / "export_check.onnx")
+    assert seen["kwargs"]["format"] == "onnx"
+    assert "out" not in seen["kwargs"]
+    assert wrapper.model is live
+    assert Path(out).name == "export_check.onnx"
+
+
+def test_export_check_exports_a_copy_when_lora_is_live(tmp_path, monkeypatch):
+    import sys
+
+    import libreyolo.training.export_check as export_check
+    import libreyolo.training.lora as lora
+
+    class _Tiny(nn.Module):
+        def forward(self, x):
+            return x.mean(dim=(2, 3))
+
+    live = _Tiny()
+    seen = {}
+
+    class _Wrapper:
+        def __init__(self):
+            self.model = live
+            self.device = torch.device("cpu")
+
+        def export(self, **kwargs):
+            seen["model_id"] = id(self.model)
+            path = Path(kwargs["output_path"])
+            path.write_bytes(b"onnx")
+            return str(path)
+
+    class _Sess:
+        def get_inputs(self):
+            return [SimpleNamespace(name="x")]
+
+        def run(self, *args, **kwargs):
+            return [torch.zeros(1, 3).numpy()]
+
+    class _ORT:
+        @staticmethod
+        def InferenceSession(*args, **kwargs):
+            return _Sess()
+
+    monkeypatch.setitem(sys.modules, "onnxruntime", _ORT)
+    monkeypatch.setattr(lora, "module_has_lora", lambda _m: True)
+    wrapper = _Wrapper()
+    export_check.run_export_parity_check(wrapper, out_dir=tmp_path, imgsz=32)
+    assert wrapper.model is live
+    assert seen["model_id"] != id(live)
+
+
+def test_assert_class_balanced_rejected_on_plain_sampler():
+    from libreyolo.training.trainer import BaseTrainer
+    from torch.utils.data import RandomSampler
+
+    trainer = SimpleNamespace(
+        config=TrainConfig(class_balanced=True),
+        train_loader=SimpleNamespace(sampler=RandomSampler([0, 1, 2])),
+    )
+    trainer.get_model_family = lambda: "dfine"
+    with pytest.raises(ValueError, match="class_balanced"):
+        BaseTrainer._assert_class_balanced_honored(trainer)


### PR DESCRIPTION
- Add opt-in `class_balanced`, `average_best`, `export_check`, and `precise_bn` training helpers.
- Keep defaults unchanged and support YOLO9 plus RF-DETR detection through the shared sampler.
- Disable EMA, SyncBatchNorm, and top-N averaging during QAT to protect fake-quant state.
- Validate averaged weights separately, restore averaging pools on resume, and preserve frozen BatchNorm statistics.
- Remove the superseded QAT duplicate and obsolete calibration no-op from the old branch.

Verified: 1,296 relevant unit tests passed (19 skipped, 3 xfailed); Greptile local review 5/5 with no comments.
Not verified: live multi-GPU or GPU training.
Opened by an agent.

Closes #768

## Code provenance

Original code written for this PR. Algorithms were independently implemented from ideas documented in Deci-AI/super-gradients at commit `63de22c404d5740f34f7706c302b37fce3c8fe5d` (Apache-2.0). No upstream source code was copied. `THIRD_PARTY_NOTICES.txt` is updated.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds opt-in class-balanced sampling, top-N checkpoint averaging, pre-training ONNX export validation, and precise BatchNorm recalibration while preserving existing defaults.
- Adds shared configuration and CLI plumbing for all four helpers.
- Restores averaging pools and safely seeds historical snapshots during resume.
- Reworks early-stop and distributed precise-BN handling to refresh selected checkpoints without rank-local branching.
- Disables EMA, SyncBatchNorm, and checkpoint averaging during QAT.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/trainer.py | Integrates all four helpers and resolves the previously reported early-stop, resume, checkpoint-refresh, and distributed synchronization defects. |
| libreyolo/training/precise_bn.py | Recomputes BatchNorm moments with mode restoration, frozen-module exclusion, failure rollback, and distributed reductions. |
| libreyolo/training/weight_averaging.py | Implements metric-gated snapshot retention, persistence, restoration, and uniform floating-point state averaging. |
| libreyolo/data/class_balanced.py | Implements annotation-derived repeat factors and aligned single-process and distributed weighted sampling. |
| libreyolo/training/export_check.py | Adds an opt-in ONNX export check with safe LoRA model swapping and numeric comparison when output layouts match. |
| libreyolo/training/qat_defaults.py | Extends QAT safeguards to disable checkpoint averaging alongside EMA and SyncBatchNorm. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[Train configuration] --> D[Build training dataloader]
  D -->|class_balanced| S[Weighted shared sampler]
  D --> T[Training epochs]
  T -->|export_check before epoch 1| E[ONNX export validation]
  T --> V[Validation metrics]
  V --> A[Top-N averaging pool]
  V --> P{Final epoch or early stop}
  P -->|precise_bn enabled| B[Recompute BN statistics]
  B --> R[Revalidate and update best state]
  R --> K[Save last and best checkpoints]
  K --> H[Refresh historical best checkpoint]
  H --> W[Validate and write average.pt]
```
</details>

<sub>Reviews (9): Last reviewed commit: ["Salvage opt-in training helpers"](https://github.com/libreyolo/libreyolo/commit/0a16e5507e97b8f19051ca365e7a0c3ff2fcc3e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53501957)</sub>

**Context used:**

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
- Knowledge Base — [Data Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/data-pipeline.md)

<!-- /greptile_comment -->