### PR TITLE
Add in-tree Triton MSDA fallback for CUDA inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- **In-tree Triton multi-scale deformable attention.** The `ms_deform_attn`
+  slot now has a `triton` provider that needs no `kernels` extra: CUDA
+  fp32/fp16/bf16 inference, same bilinear equation as the portable
+  `grid_sample` path. Inputs that require grad fall through, so training
+  keeps a backward. Hub stays preferred when `libreyolo[hub-kernels]` is
+  installed. Opt out with `LIBREYOLO_TRITON_MSDA=0`. On an RTX 5070 Ti
+  the kernel is ~4x the portable core on RF-DETR-s shapes and ~12x on
+  Deformable-DETR / RT-DETR multi-level shapes; RF-DETR-n end-to-end
+  moves about 7% because the windowed DINOv2 backbone dominates.
+
 - **`min_samples` epoch-length floor for tiny datasets.** New opt-in training
   knob (`model.train(..., min_samples=640)` /
   `libreyolo train --min-samples 640`, issue #768): when the training dataset

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -56,14 +56,20 @@ audited commit revision in its provider module — a moved branch on the Hub
 can never change the binary that runs in-process. Bumping a pin requires a
 GPU parity run of the provider's `*_matches_portable_on_cuda` test.
 
-Current hub-backed slot:
+Current `ms_deform_attn` providers, newest-first:
 
-- `ms_deform_attn` <- [`kernels-community/deformable-detr`](https://huggingface.co/kernels-community/deformable-detr)
+- `hub` <- [`kernels-community/deformable-detr`](https://huggingface.co/kernels-community/deformable-detr)
   (Apache-2.0): the compiled CUDA multi-scale deformable attention
-  forward/backward from Deformable DETR. Eligible inputs are CUDA fp32 in
-  eager mode. Training is accelerated too (the compiled backward registers
+  forward/backward from Deformable DETR. Eligible inputs are CUDA
+  fp32/fp16/bf16 in eager mode (half inputs are upcast at the call
+  boundary). Training is accelerated too (the compiled backward registers
   through an autograd bridge). Active whenever the `kernels` package is
   installed, unless `LIBREYOLO_HUB_KERNELS=0`.
+- `triton` (in-tree): same equation, no extra package. CUDA fp32/fp16/bf16
+  inference; inputs that require grad fall through so training keeps a
+  backward. On by default when Triton imports and CUDA is visible;
+  `LIBREYOLO_TRITON_MSDA=0` disables it. Hub stays preferred when both
+  are eligible.
 
   Wired into every Deformable-DETR-lineage family: RF-DETR,
   LibreDeformableDETR, LibreDINO-DETR, LW-DETR, Grounding DINO, RT-DETR,

--- a/libreyolo/kernels/__init__.py
+++ b/libreyolo/kernels/__init__.py
@@ -102,7 +102,7 @@ _INTREE_ATTEMPTED = False
 # the attention provider self-register on import; each group fails
 # independently so a missing optional dependency never hides the others.
 _LAZY_PROVIDERS = (
-    # Triton fake-quant kernels (need triton; absent on Windows).
+    # Triton fake-quant kernels (need triton).
     ".quant.simulate",
     # Triton finalized-path kernels.
     ".quant.execute.fp8_fusion",
@@ -118,7 +118,7 @@ def _ensure_intree_loaded():
 
     Lazy so `import libreyolo` never pays the triton import cost, and
     skipped entirely when the env forces the reference implementations.
-    Absence of triton (e.g. Windows) is the normal fallback case.
+    Absence of triton is the normal fallback case.
     """
     global _INTREE_ATTEMPTED
     if _INTREE_ATTEMPTED or _forced() in ("off", "reference"):

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -13,9 +13,13 @@ Like the GEMM slots, no reference implementation is registered: every model
 family keeps its own upstream-parity ``grid_sample`` port as the default and
 only consults this slot through :func:`maybe_ms_deform_attn`.
 
-The in-tree provider loads the compiled CUDA kernel published at
+Two accelerated providers share the slot. The in-tree Triton kernel
+(``ms_deform_attn_triton``) needs no extra package and covers CUDA
+fp32/fp16/bf16 inference; it registers first. The Hub provider loads the
+compiled CUDA kernel published at
 ``kernels-community/deformable-detr`` on the Hugging Face Hub (Apache-2.0)
-via the optional ``kernels`` package. Nothing is vendored: the artifact is
+via the optional ``kernels`` package and registers on top, so it wins
+when the extra is installed. Nothing is vendored: the artifact is
 fetched at runtime, pinned to the audited revision in ``_HUB_REVISION`` so
 a moved branch can never swap the binary that runs in-process. When the
 installed ``kernels`` release cannot resolve the pin (its resolver rejects
@@ -417,6 +421,13 @@ def maybe_ms_deform_attn_v2(
         attention_weights.unflatten(3, (levels, points)),
     )
 
+
+# Triton registers first (older); Hub stays preferred when its extra is
+# installed. A missing Triton install must not hide the Hub provider.
+try:
+    from .ms_deform_attn_triton import triton_ms_deform_attn  # noqa: F401
+except Exception as exc:
+    logger.debug("Triton ms_deform_attn unavailable: %s", exc)
 
 register("ms_deform_attn", hub_ms_deform_attn, name="hub", predicate=_eligible)
 

--- a/libreyolo/kernels/attention/ms_deform_attn_triton.py
+++ b/libreyolo/kernels/attention/ms_deform_attn_triton.py
@@ -1,0 +1,340 @@
+"""Triton multi-scale deformable attention (``ms_deform_attn`` / ``triton``).
+
+Implements the published Deformable DETR sampling equation (Zhu et al.,
+ICLR 2021): for each query, head, level and point, bilinear-sample the
+value map at ``sampling_locations`` (``align_corners=False``, zeros
+padding) and reduce with ``attention_weights``. Written from that
+equation; not derived from any compiled CUDA or third-party Triton kernel.
+
+Inference only. Inputs that require grad return ``None`` so the caller
+keeps its portable ``grid_sample`` path (and the Hub kernel, when that
+provider is the one ``resolve`` selected). Accumulates in fp32 so fp16
+and bf16 match the portable core to the usual half-precision tolerance.
+
+Eligible inputs are CUDA fp32 / fp16 / bf16. The provider is on whenever
+Triton imports and CUDA is visible; ``LIBREYOLO_TRITON_MSDA=0`` disables
+it. Hub stays preferred: this module registers first, the Hub provider
+registers on top.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import Optional
+
+import torch
+
+from .. import register
+
+
+_SLOT_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
+
+def _env_enabled() -> bool:
+    return os.environ.get("LIBREYOLO_TRITON_MSDA", "").strip().lower() not in (
+        "0",
+        "false",
+        "off",
+        "no",
+    )
+
+
+def _eligible() -> bool:
+    return (
+        _env_enabled()
+        and importlib.util.find_spec("triton") is not None
+        and torch.cuda.is_available()
+    )
+
+
+def _supported_inputs(
+    value: torch.Tensor,
+    spatial_shapes,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+) -> bool:
+    if not isinstance(spatial_shapes, torch.Tensor):
+        return False
+    if value.requires_grad or sampling_locations.requires_grad or attention_weights.requires_grad:
+        return False
+    if not (
+        value.is_cuda
+        and sampling_locations.is_cuda
+        and attention_weights.is_cuda
+        and spatial_shapes.is_cuda
+    ):
+        return False
+    if not (
+        value.dtype in _SLOT_DTYPES
+        and sampling_locations.dtype in _SLOT_DTYPES
+        and attention_weights.dtype in _SLOT_DTYPES
+    ):
+        return False
+    if value.dim() != 4 or sampling_locations.dim() != 6 or attention_weights.dim() != 5:
+        return False
+    if spatial_shapes.dim() != 2 or spatial_shapes.shape[1] != 2:
+        return False
+    batch, len_in, n_heads, channels = value.shape
+    n_queries = sampling_locations.shape[1]
+    n_levels = sampling_locations.shape[3]
+    n_points = sampling_locations.shape[4]
+    if batch == 0 or n_queries == 0:
+        return False
+    if sampling_locations.shape[5] != 2:
+        return False
+    if (
+        sampling_locations.shape[0] != batch
+        or attention_weights.shape[0] != batch
+        or sampling_locations.shape[2] != n_heads
+        or attention_weights.shape[2] != n_heads
+        or attention_weights.shape[1] != n_queries
+        or spatial_shapes.shape[0] != n_levels
+        or attention_weights.shape[3] != n_levels
+        or attention_weights.shape[4] != n_points
+    ):
+        return False
+    if not (0 < channels <= 128):
+        return False
+    # Area must match Len_in or the kernel indexes off the value buffer.
+    # spatial_shapes is a few (H, W) pairs; the readback is cheaper than an
+    # illegal CUDA access on a mismatched caller.
+    areas = spatial_shapes[:, 0] * spatial_shapes[:, 1]
+    if int(areas.sum().item()) != int(len_in):
+        return False
+    if bool((spatial_shapes <= 0).any().item()):
+        return False
+    return True
+
+
+def _next_power_of_2(n: int) -> int:
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+def _level_starts(shapes: torch.Tensor) -> torch.Tensor:
+    areas = shapes[:, 0] * shapes[:, 1]
+    return torch.cat([areas.new_zeros(1), areas.cumsum(0)[:-1]]).contiguous()
+
+
+def _msda_kernel():
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _msda_fwd(
+        value_ptr,
+        loc_ptr,
+        attn_ptr,
+        shapes_ptr,
+        starts_ptr,
+        out_ptr,
+        batch,
+        n_queries,
+        n_heads,
+        n_channels,
+        n_levels,
+        n_points,
+        stride_vb,
+        stride_vs,
+        stride_vh,
+        stride_vc,
+        stride_lb,
+        stride_lq,
+        stride_lh,
+        stride_ll,
+        stride_lp,
+        stride_ab,
+        stride_aq,
+        stride_ah,
+        stride_al,
+        stride_ap,
+        stride_ob,
+        stride_oq,
+        BLOCK_C: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        n_head_query = n_heads * n_queries
+        batch_idx = pid // n_head_query
+        rem = pid - batch_idx * n_head_query
+        query_idx = rem // n_heads
+        head_idx = rem - query_idx * n_heads
+        if batch_idx >= batch:
+            return
+
+        offs_c = tl.arange(0, BLOCK_C)
+        mask_c = offs_c < n_channels
+        acc = tl.zeros((BLOCK_C,), dtype=tl.float32)
+
+        for level in range(n_levels):
+            height = tl.load(shapes_ptr + level * 2 + 0)
+            width = tl.load(shapes_ptr + level * 2 + 1)
+            start = tl.load(starts_ptr + level)
+            height_f = height.to(tl.float32)
+            width_f = width.to(tl.float32)
+            for point in range(n_points):
+                loc_off = (
+                    batch_idx * stride_lb
+                    + query_idx * stride_lq
+                    + head_idx * stride_lh
+                    + level * stride_ll
+                    + point * stride_lp
+                )
+                loc_x = tl.load(loc_ptr + loc_off + 0).to(tl.float32)
+                loc_y = tl.load(loc_ptr + loc_off + 1).to(tl.float32)
+                weight = tl.load(
+                    attn_ptr
+                    + batch_idx * stride_ab
+                    + query_idx * stride_aq
+                    + head_idx * stride_ah
+                    + level * stride_al
+                    + point * stride_ap
+                ).to(tl.float32)
+
+                # grid_sample, align_corners=False, locations in [0, 1].
+                sample_x = loc_x * width_f - 0.5
+                sample_y = loc_y * height_f - 0.5
+                x0 = tl.floor(sample_x)
+                y0 = tl.floor(sample_y)
+                wx = sample_x - x0
+                wy = sample_y - y0
+                ix0 = x0.to(tl.int64)
+                iy0 = y0.to(tl.int64)
+                ix1 = ix0 + 1
+                iy1 = iy0 + 1
+                in00 = (iy0 >= 0) & (iy0 < height) & (ix0 >= 0) & (ix0 < width)
+                in01 = (iy0 >= 0) & (iy0 < height) & (ix1 >= 0) & (ix1 < width)
+                in10 = (iy1 >= 0) & (iy1 < height) & (ix0 >= 0) & (ix0 < width)
+                in11 = (iy1 >= 0) & (iy1 < height) & (ix1 >= 0) & (ix1 < width)
+                iy0c = tl.minimum(tl.maximum(iy0, 0), height - 1)
+                ix0c = tl.minimum(tl.maximum(ix0, 0), width - 1)
+                iy1c = tl.minimum(tl.maximum(iy1, 0), height - 1)
+                ix1c = tl.minimum(tl.maximum(ix1, 0), width - 1)
+                base = value_ptr + batch_idx * stride_vb + head_idx * stride_vh
+                acc += (
+                    tl.load(
+                        base + (start + iy0c * width + ix0c) * stride_vs + offs_c * stride_vc,
+                        mask=mask_c & in00,
+                        other=0.0,
+                    ).to(tl.float32)
+                    * ((1.0 - wy) * (1.0 - wx) * weight)
+                )
+                acc += (
+                    tl.load(
+                        base + (start + iy0c * width + ix1c) * stride_vs + offs_c * stride_vc,
+                        mask=mask_c & in01,
+                        other=0.0,
+                    ).to(tl.float32)
+                    * ((1.0 - wy) * wx * weight)
+                )
+                acc += (
+                    tl.load(
+                        base + (start + iy1c * width + ix0c) * stride_vs + offs_c * stride_vc,
+                        mask=mask_c & in10,
+                        other=0.0,
+                    ).to(tl.float32)
+                    * (wy * (1.0 - wx) * weight)
+                )
+                acc += (
+                    tl.load(
+                        base + (start + iy1c * width + ix1c) * stride_vs + offs_c * stride_vc,
+                        mask=mask_c & in11,
+                        other=0.0,
+                    ).to(tl.float32)
+                    * (wy * wx * weight)
+                )
+
+        out_off = (
+            batch_idx * stride_ob
+            + query_idx * stride_oq
+            + head_idx * n_channels
+            + offs_c
+        )
+        tl.store(out_ptr + out_off, acc, mask=mask_c)
+
+    return _msda_fwd
+
+
+_KERNEL = None
+
+
+def _kernel():
+    global _KERNEL
+    if _KERNEL is None:
+        _KERNEL = _msda_kernel()
+    return _KERNEL
+
+
+def triton_ms_deform_attn(
+    value: torch.Tensor,
+    spatial_shapes: torch.Tensor,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+) -> Optional[torch.Tensor]:
+    """Run MSDA on the in-tree Triton kernel, or return None to fall back."""
+    if not _supported_inputs(
+        value, spatial_shapes, sampling_locations, attention_weights
+    ):
+        return None
+    try:
+        import triton  # noqa: F401
+    except Exception:
+        return None
+
+    value = value.contiguous()
+    sampling_locations = sampling_locations.contiguous()
+    attention_weights = attention_weights.contiguous()
+    shapes = spatial_shapes.to(dtype=torch.int64, device=value.device).contiguous()
+    starts = _level_starts(shapes)
+
+    batch, _, n_heads, n_channels = value.shape
+    _, n_queries, _, n_levels, n_points, _ = sampling_locations.shape
+    output = torch.empty(
+        batch, n_queries, n_heads * n_channels, device=value.device, dtype=torch.float32
+    )
+    block_c = _next_power_of_2(int(n_channels))
+    grid = (batch * n_queries * n_heads,)
+    try:
+        _kernel()[grid](
+            value,
+            sampling_locations,
+            attention_weights,
+            shapes,
+            starts,
+            output,
+            batch,
+            n_queries,
+            n_heads,
+            n_channels,
+            n_levels,
+            n_points,
+            value.stride(0),
+            value.stride(1),
+            value.stride(2),
+            value.stride(3),
+            sampling_locations.stride(0),
+            sampling_locations.stride(1),
+            sampling_locations.stride(2),
+            sampling_locations.stride(3),
+            sampling_locations.stride(4),
+            attention_weights.stride(0),
+            attention_weights.stride(1),
+            attention_weights.stride(2),
+            attention_weights.stride(3),
+            attention_weights.stride(4),
+            output.stride(0),
+            output.stride(1),
+            BLOCK_C=block_c,
+        )
+    except Exception:
+        return None
+    if value.dtype != torch.float32:
+        return output.to(dtype=value.dtype)
+    return output
+
+
+register("ms_deform_attn", triton_ms_deform_attn, name="triton", predicate=_eligible)
+
+
+__all__ = ["triton_ms_deform_attn"]

--- a/tests/unit/kernels/test_ms_deform_attn.py
+++ b/tests/unit/kernels/test_ms_deform_attn.py
@@ -35,9 +35,10 @@ LEN_IN = sum(h * w for h, w in SHAPES)
 def _clean_registry_env(monkeypatch):
     monkeypatch.delenv("LIBREYOLO_KERNELS", raising=False)
     monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
-    # Hub kernels are on by default when the `kernels` package is installed;
-    # pin them off so these tests behave the same on any machine.
+    # Accelerated providers are on by default when their extras/runtime
+    # exist; pin them off so these tests behave the same on any machine.
     monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", "0")
+    monkeypatch.setenv("LIBREYOLO_TRITON_MSDA", "0")
     kernels.clear_cache()
     yield
     kernels.unregister("ms_deform_attn", "mock")
@@ -420,3 +421,141 @@ def test_load_hub_kernel_disables_when_both_paths_fail(monkeypatch):
     monkeypatch.setattr(module, "_load_pinned_snapshot", no_snapshot)
     assert module._load_hub_kernel() is None
     assert module._hub_failed is True
+
+
+# =============================================================================
+# In-tree Triton provider
+# =============================================================================
+
+
+def test_triton_selected_when_hub_disabled(monkeypatch):
+    """No hub extra: resolve should land on Triton when CUDA+Triton exist."""
+    if not torch.cuda.is_available() or importlib.util.find_spec("triton") is None:
+        pytest.skip("needs CUDA and Triton")
+    monkeypatch.delenv("LIBREYOLO_TRITON_MSDA", raising=False)
+    monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", "0")
+    kernels.clear_cache()
+    # Force the lazy providers to load against the new env.
+    importlib.import_module("libreyolo.kernels.attention.ms_deform_attn_triton")
+    assert kernels.active().get("ms_deform_attn") == "triton"
+
+
+def test_triton_default_on_and_env_opt_out(monkeypatch):
+    from libreyolo.kernels.attention import ms_deform_attn_triton as module
+
+    monkeypatch.delenv("LIBREYOLO_TRITON_MSDA", raising=False)
+    assert module._env_enabled()
+    for value in ("0", "false", "off", "no"):
+        monkeypatch.setenv("LIBREYOLO_TRITON_MSDA", value)
+        assert not module._env_enabled()
+
+
+def test_triton_impl_rejects_cpu_inputs():
+    from libreyolo.kernels.attention.ms_deform_attn_triton import triton_ms_deform_attn
+
+    value, shapes, locations, weights = _classic_inputs()
+    assert triton_ms_deform_attn(value, shapes, locations, weights) is None
+
+
+def test_triton_impl_rejects_mismatched_metadata():
+    from libreyolo.kernels.attention.ms_deform_attn_triton import triton_ms_deform_attn
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+    value, shapes, locations, weights = _classic_inputs()
+    value = value.cuda()
+    shapes = shapes.cuda()
+    locations = locations.cuda()
+    weights = weights.cuda()
+    # Len_in does not match the spatial areas: must not launch.
+    bad_value = value[:, :-1]
+    assert triton_ms_deform_attn(bad_value, shapes, locations, weights) is None
+    # Level count disagrees across tensors.
+    assert triton_ms_deform_attn(value, shapes[:1], locations, weights) is None
+
+
+def test_triton_impl_rejects_grad_inputs():
+    from libreyolo.kernels.attention.ms_deform_attn_triton import triton_ms_deform_attn
+
+    value, shapes, locations, weights = _classic_inputs()
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+    value = value.cuda().requires_grad_(True)
+    shapes = shapes.cuda()
+    locations = locations.cuda()
+    weights = weights.cuda()
+    assert triton_ms_deform_attn(value, shapes, locations, weights) is None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or importlib.util.find_spec("triton") is None,
+    reason="needs CUDA and Triton",
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_triton_matches_portable_on_cuda(dtype):
+    """Forward parity of the in-tree Triton kernel vs the portable core."""
+    from libreyolo.kernels.attention.ms_deform_attn_triton import triton_ms_deform_attn
+
+    value, shapes, locations, weights = _classic_inputs()
+    value = value.cuda().to(dtype)
+    shapes = shapes.cuda()
+    locations = locations.cuda().to(
+        dtype if dtype == torch.float32 else torch.float32
+    )
+    weights = weights.cuda().to(dtype if dtype == torch.float32 else torch.float32)
+    if dtype != torch.float32:
+        value = value.to(dtype)
+
+    out = triton_ms_deform_attn(value, shapes, locations, weights)
+    assert out is not None
+    assert out.dtype == value.dtype
+
+    ref = rfdetr_core(
+        value.float().permute(0, 2, 3, 1).contiguous(),
+        shapes,
+        locations.float(),
+        weights.float().flatten(-2),
+    )
+    rtol, atol = (1e-4, 1e-5) if dtype == torch.float32 else (2e-3, 2e-3)
+    torch.testing.assert_close(out.float(), ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or importlib.util.find_spec("triton") is None,
+    reason="needs CUDA and Triton",
+)
+def test_triton_rfdetr_shapes_on_cuda():
+    """RF-DETR detect is 1 level, 2 points, 16-wide heads, 300 queries."""
+    from libreyolo.kernels.attention.ms_deform_attn_triton import triton_ms_deform_attn
+
+    generator = torch.Generator(device="cuda").manual_seed(2)
+    batch, queries, heads, channels, levels, points = 1, 300, 16, 16, 1, 2
+    height = width = 24
+    value = torch.randn(
+        batch, height * width, heads, channels, generator=generator, device="cuda"
+    )
+    shapes = torch.tensor([(height, width)], dtype=torch.int64, device="cuda")
+    locations = torch.rand(
+        batch,
+        queries,
+        heads,
+        levels,
+        points,
+        2,
+        generator=generator,
+        device="cuda",
+    )
+    weights = torch.rand(
+        batch, queries, heads, levels, points, generator=generator, device="cuda"
+    )
+    weights = weights / weights.sum(dim=(-2, -1), keepdim=True)
+
+    out = triton_ms_deform_attn(value, shapes, locations, weights)
+    assert out is not None
+    ref = rfdetr_core(
+        value.permute(0, 2, 3, 1).contiguous(),
+        shapes,
+        locations,
+        weights.flatten(-2),
+    )
+    torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-5)

--- a/tests/unit/kernels/test_ms_deform_attn_families.py
+++ b/tests/unit/kernels/test_ms_deform_attn_families.py
@@ -67,9 +67,10 @@ MOCK_OUTPUT = torch.full((BATCH, LEN_Q, HEADS * CHANNELS), 7.0)
 def _clean_registry_env(monkeypatch):
     monkeypatch.delenv("LIBREYOLO_KERNELS", raising=False)
     monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
-    # Hub kernels are on by default when the `kernels` package is installed;
-    # pin them off so these tests behave the same on any machine.
+    # Accelerated providers are on by default when their extras/runtime
+    # exist; pin them off so these tests behave the same on any machine.
     monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", "0")
+    monkeypatch.setenv("LIBREYOLO_TRITON_MSDA", "0")
     kernels.clear_cache()
     yield
     kernels.unregister("ms_deform_attn", "mock")


### PR DESCRIPTION
- In-tree Triton `ms_deform_attn` provider for CUDA fp32/fp16/bf16 inference.
- No `kernels` extra. Hub stays preferred when `libreyolo[hub-kernels]` is installed.
- Inputs that require grad return None so training keeps the portable backward.
- Opt out with `LIBREYOLO_TRITON_MSDA=0`.
- Does not change extras: `hub-kernels` stays a Speed extra, not folded into `rfdetr`.

Reviewer: registration order (triton then hub), metadata guard before launch, CUDA parity tests.

Verified: 70 unit tests in `tests/unit/kernels/test_ms_deform_attn*.py` on Windows CUDA (RTX 5070 Ti). Isolated MSDA ~4x on RF-DETR-s shapes, ~12x on multi-level DETR; RF-DETR-n e2e ~7%.

Not verified: Linux Hub+Triton together beyond resolve order; export/TensorRT (portable path); training.

Greptile P1 (unvalidated spatial metadata -> illegal CUDA access): fixed before open.

## Code provenance

Original Triton kernel written for this PR from the published multi-scale deformable attention equation (Zhu et al., Deformable DETR, ICLR 2021): bilinear sample at `sampling_locations` with `align_corners=False` and zeros padding, reduced by `attention_weights`. Not derived from the Deformable DETR CUDA extension, `kernels-community/deformable-detr`, or any third-party Triton kernel. Slot registration and docs are original LibreYOLO wiring around that equation.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an in-tree Triton implementation of multi-scale deformable attention for CUDA inference while retaining Hub preference and portable training/export fallbacks.

- Registers the Triton and Hub implementations in preference order.
- Adds dtype, shape, gradient, and spatial-metadata eligibility checks around the Triton kernel.
- Adds CUDA parity, provider-selection, fallback, and family-adapter tests.
- Documents runtime selection, opt-out behavior, and supported precision modes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking provider-chain issue that can unnecessarily bypass the new Triton acceleration when Hub is installed but unusable for a call.

The accelerated result remains correct because every affected call falls back to the portable implementation, but provider resolution does not realize the documented fallback opportunity between Hub and Triton.

**Files Needing Attention:** libreyolo/kernels/attention/ms_deform_attn.py, libreyolo/kernels/__init__.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/kernels/attention/ms_deform_attn_triton.py | Adds the inference-only Triton MSDA kernel, input validation, fp32 accumulation, and graceful portable fallback behavior. |
| libreyolo/kernels/attention/ms_deform_attn.py | Registers Triton beneath Hub, but the single-provider adapter cannot use Triton when the preferred Hub implementation rejects a call. |
| libreyolo/kernels/__init__.py | Keeps the existing cached single-provider resolution model, which limits fallback between the newly coexisting MSDA providers. |
| tests/unit/kernels/test_ms_deform_attn.py | Adds useful CUDA parity and eligibility tests but does not cover call-time fallback from Hub to Triton. |
| tests/unit/kernels/test_ms_deform_attn_families.py | Updates family-adapter tests to isolate both accelerated providers and preserve deterministic portable-path coverage. |
| docs/kernels.md | Documents provider order, supported dtypes, inference-only Triton behavior, and environment controls. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[DETR-family MSDA call] --> B{Export, tracing, or unavailable?}
  B -->|Yes| P[Portable grid_sample path]
  B -->|No| R[Resolve cached provider]
  R --> H{Hub eligible?}
  H -->|Yes| HC[Invoke Hub only]
  H -->|No| T{Triton eligible?}
  T -->|Yes| TC[Invoke Triton]
  T -->|No| P
  HC -->|Tensor result| O[Return accelerated output]
  HC -->|None or failure| P
  TC -->|Tensor result| O
  TC -->|None or failure| P
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20libreyolo%2Flibreyolo%20PR%20%23784%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=784&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fkernels%2Fattention%2Fms_deform_attn.py%3A425-432%0A**Provider%20fallback%20stops%20at%20Hub**%0A%0AWhen%20both%20providers%20are%20eligible%20but%20Hub%20rejects%20an%20input%20or%20disables%20itself%20after%20a%20launch%20failure%2C%20%60maybe_ms_deform_attn%60%20returns%20Hub's%20%60None%60%20without%20trying%20Triton%2C%20so%20supported%20calls%20unnecessarily%20fall%20back%20to%20the%20slower%20portable%20path%20and%20subsequent%20calls%20continue%20bypassing%20Triton.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=784&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22feat%2Frfdetr-msda-triton%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frfdetr-msda-triton%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fkernels%2Fattention%2Fms_deform_attn.py%3A425-432%0A**Provider%20fallback%20stops%20at%20Hub**%0A%0AWhen%20both%20providers%20are%20eligible%20but%20Hub%20rejects%20an%20input%20or%20disables%20itself%20after%20a%20launch%20failure%2C%20%60maybe_ms_deform_attn%60%20returns%20Hub's%20%60None%60%20without%20trying%20Triton%2C%20so%20supported%20calls%20unnecessarily%20fall%20back%20to%20the%20slower%20portable%20path%20and%20subsequent%20calls%20continue%20bypassing%20Triton.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=784&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add in-tree Triton MSDA fallback for CUD..."](https://github.com/libreyolo/libreyolo/commit/6e666607404d09a6c255bd72efc308de8ca2b556) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53504529)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Kernel and quantization runtime](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/kernel-and-quantization.md)

<!-- /greptile_comment -->