### PR TITLE
Wire EC pose MSDA onto the shared attention slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- **EC pose on the `ms_deform_attn` slot.** The pose decoder's pre-split
+  `(bs*heads, c, hw)` value tuple now adapts onto the classic slot layout
+  used by detect EC and the other DETR-lineage families. Export and any
+  shape that cannot reshape keep the portable `grid_sample` path.
+
 - **In-tree Triton multi-scale deformable attention.** The `ms_deform_attn`
   slot now has a `triton` provider that needs no `kernels` extra: CUDA
   fp32/fp16/bf16 inference, same bilinear equation as the portable

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -79,7 +79,9 @@ Current `ms_deform_attn` providers, newest-first:
   through to the portable path instead. Two cases do that today: a
   `num_points_list` with a different point count per level, and the
   `method='discrete'` integer-index sampling, which is a different equation.
-  The EC pose variant keeps its own contract and is not wired.
+  The EC pose core (`MSDeformAttnPose`) adapts its pre-split
+  `(bs*heads, c, hw)` levels onto the slot layout and falls through when
+  that reshape is impossible.
 
 Out-of-tree compiled kernels can also ship as a `libreyolo_kernels` package,
 which self-registers on import (e.g. a future CUTLASS NVFP4 GEMM for the

--- a/libreyolo/models/ec/decoder.py
+++ b/libreyolo/models/ec/decoder.py
@@ -26,6 +26,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.init as init
 
+from ...kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
 from ..dfine.decoder import EVAL_CONSTANT_CACHE_LIMIT
 from ..dfine.denoising import get_contrastive_denoising_training_group
 from .utils import (
@@ -1299,6 +1304,30 @@ class SegmentationHead(nn.Module):
 # ===========================================================================
 
 
+def _pose_value_to_slot(value, sampling_locations):
+    """Pose ``(bs*heads, c, hw)`` levels -> slot ``(bs, Len_in, heads, c)``.
+
+    Returns None when the tuple cannot express the slot layout, so the
+    caller keeps the portable ``grid_sample`` path unchanged.
+    """
+    if not isinstance(value, (tuple, list)) or not value:
+        return None
+    if sampling_locations.dim() != 6:
+        return None
+    batch, _, n_heads, n_levels, _, xy = sampling_locations.shape
+    if xy != 2 or n_levels != len(value):
+        return None
+    head_dim = value[0].shape[1]
+    expected_rows = batch * n_heads
+    parts = []
+    for feat in value:
+        if feat.dim() != 3 or feat.shape[0] != expected_rows or feat.shape[1] != head_dim:
+            return None
+        hw = feat.shape[2]
+        parts.append(feat.reshape(batch, n_heads, head_dim, hw).permute(0, 3, 1, 2))
+    return torch.cat(parts, dim=1)
+
+
 def _ms_deform_attn_core_pytorch_pose(
     value, value_spatial_shapes, sampling_locations, attention_weights
 ):
@@ -1306,8 +1335,22 @@ def _ms_deform_attn_core_pytorch_pose(
 
     Mirrors super-gradients/DETRPose's ``ms_deform_attn_core_pytorch``: ``value``
     is a tuple of pre-split per-level tensors of shape
-    ``(bs * n_heads, head_dim, h * w)``.
+    ``(bs * n_heads, head_dim, h * w)``. The accelerated ``ms_deform_attn``
+    slot is consulted when that tuple reshapes onto the classic layout;
+    export and any shape that cannot adapt keep the ``grid_sample`` path.
     """
+    if ms_deform_attn_available():
+        flat = _pose_value_to_slot(value, sampling_locations)
+        if flat is not None:
+            accelerated = maybe_ms_deform_attn(
+                flat,
+                spatial_shapes_tensor(value_spatial_shapes, flat.device),
+                sampling_locations,
+                attention_weights,
+            )
+            if accelerated is not None:
+                return accelerated
+
     _, head_dim, _ = value[0].shape
     bs, num_query, num_heads, num_levels, num_points, _ = sampling_locations.shape
 

--- a/tests/unit/kernels/test_ms_deform_attn_families.py
+++ b/tests/unit/kernels/test_ms_deform_attn_families.py
@@ -33,6 +33,9 @@ from libreyolo.models.deim.ms_deform import (
 from libreyolo.models.dfine.ms_deform import (
     deformable_attention_core_func_v2 as dfine_core,
 )
+from libreyolo.models.ec.decoder import (
+    _ms_deform_attn_core_pytorch_pose as ec_pose_core,
+)
 from libreyolo.models.ec.utils import deformable_attention_core_func_v2 as ec_core
 from libreyolo.models.grounding_dino.nn import _msda as gdino_core
 from libreyolo.models.lwdetr.nn import ms_deform_attn_core_pytorch as lwdetr_core
@@ -222,6 +225,19 @@ def _call_ovdeim(value, locations, weights):
     )
 
 
+def _pose_split_value(value):
+    """Classic layout -> pose ``(bs * heads, c, hw)`` per level."""
+    return tuple(
+        value.permute(0, 2, 3, 1)
+        .flatten(0, 1)
+        .split([height * width for height, width in SHAPES], dim=-1)
+    )
+
+
+def _call_ec_pose(value, locations, weights):
+    return ec_pose_core(_pose_split_value(value), SHAPES, locations, weights)
+
+
 FAMILY_CORES = {
     "lwdetr": _call_lwdetr,
     "grounding_dino": _call_gdino,
@@ -231,6 +247,7 @@ FAMILY_CORES = {
     "deim": _call_deim,
     "ec": _call_ec,
     "ec_reshape": _call_ec_reshape,
+    "ec_pose": _call_ec_pose,
     "ovdeim": _call_ovdeim,
 }
 
@@ -353,6 +370,15 @@ def test_dfine_forced_manual_grid_sample_never_reaches_slot(recorded, monkeypatc
         dfine_core(*args)
     finally:
         ms_deform._FORCE_MANUAL_GRID_SAMPLE.reset(token)
+    assert recorded == []
+
+
+def test_ec_pose_malformed_value_does_not_adapt(recorded):
+    """A value tuple that cannot reshape onto the slot must not be offered."""
+    from libreyolo.models.ec.decoder import _pose_value_to_slot
+
+    value, locations, _weights = _classic_inputs()
+    assert _pose_value_to_slot(_pose_split_value(value)[:1], locations) is None
     assert recorded == []
 
 


### PR DESCRIPTION
- Wire EC pose MSDA (`_ms_deform_attn_core_pytorch_pose`) onto the shared `ms_deform_attn` slot.
- Adapt pre-split `(bs*heads, c, hw)` levels to the classic `(bs, Len_in, heads, c)` layout.
- Fall through to the existing `grid_sample` path when the slot is off, export is on, or the tuple cannot reshape.
- `LQEPose` is unchanged (single-map keypoint sample, not MSDA).
- No extras change.

Reviewer: adapter None-on-mismatch, export still skips the slot, family tests for `ec_pose`.

Verified: 77 unit tests (`test_ms_deform_attn_families.py` + `test_ec_pose.py`).

Not verified: full EC pose e2e / CUDA graph + hub kernel together.

## Code provenance

Original adapter written for this PR. The pose core and `grid_sample` path are existing LibreYOLO code (EC / DETRPose port, Apache-2.0 via EdgeCrafter / SuperGradients). The slot contract is the existing classic Deformable-DETR layout. No third-party kernel was copied.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adapts EC pose decoder values to the shared multi-scale deformable-attention slot while preserving the portable path for export, unavailable kernels, and incompatible layouts.
- Adds the pose tuple-to-classic-layout adapter and shared-slot dispatch.
- Extends family-level routing, fallback, and parity tests for `ec_pose`.
- Updates kernel documentation and the changelog.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security failures identified.

The adapter reconstructs the shared slot’s expected value layout, preserves the pose core’s output contract, and retains the existing portable path whenever export gating, availability, shape adaptation, or provider eligibility prevents acceleration.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/ec/decoder.py | Adds a guarded layout adapter and shared-slot dispatch whose output contract and fallback behavior align with the existing pose core. |
| tests/unit/kernels/test_ms_deform_attn_families.py | Enrolls EC pose in shared routing, fallback, export-skip, and numerical-parity coverage and adds a malformed-layout check. |
| docs/kernels.md | Documents that EC pose now adapts onto the shared slot and falls back when reshaping is impossible. |
| CHANGELOG.md | Records the new EC pose shared-slot integration and its fallback conditions. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[EC pose pre-split value levels] --> B{Shared MSDA available?}
  B -- No --> F[Portable grid_sample path]
  B -- Yes --> C{Tuple adapts to classic layout?}
  C -- No --> F
  C -- Yes --> D[Shared ms_deform_attn slot]
  D -- Provider returns output --> E[Pose attention output]
  D -- Provider declines input --> F
  F --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Wire EC pose MSDA onto the shared attent..."](https://github.com/libreyolo/libreyolo/commit/f4e0c8adbb464a1ecfb2647534f5ac41dadb3225) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53513223)</sub>

**Context used:**

- Knowledge Base — [Kernel and quantization runtime](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/kernel-and-quantization.md)

<!-- /greptile_comment -->