### PR TITLE
Hugging Face Hub integration: load user checkpoints, push fine-tuned ones

### DIFF
--- a/docs/hf_hub.md
+++ b/docs/hf_hub.md
@@ -1,0 +1,95 @@
+# Hugging Face Hub integration
+
+LibreYOLO can load checkpoints from any Hugging Face Hub repository and push
+your own fine-tuned checkpoints back, in both cases using the standard
+LibreYOLO metadata schema (v1.0, see `docs/checkpoint_schema.md`).
+
+The integration is optional:
+
+```bash
+pip install libreyolo[hf]
+```
+
+`import libreyolo` never imports `huggingface_hub`; it is only loaded when a
+Hub reference or push is actually used.
+
+## Loading models from the Hub
+
+Any repository that contains a LibreYOLO checkpoint can be loaded directly:
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("someuser/their-finetune")          # bare owner/repo
+model = LibreYOLO("hf://someuser/their-finetune")     # explicit form
+model = LibreYOLO("hf://someuser/repo@main/best.pt")  # pin revision and file
+```
+
+Resolution rules:
+
+- A local file or directory with the same name always wins over the bare
+  `owner/repo` form. Use the `hf://` form to bypass that precedence.
+- The bare form is only treated as a Hub reference when the last segment has
+  no file extension, so paths like `weights/model.pt` keep their meaning.
+- Without an explicit filename, the single `*.pt` (or `*.safetensors`) file
+  in the repo is used. Repos with several checkpoints raise an error listing
+  them; select one with `hf://owner/repo/<filename>`.
+
+Downloads go to the shared `huggingface_hub` cache and are loaded through the
+same safe path as local files: `torch.load(weights_only=True)` plus metadata
+validation. Checkpoints without LibreYOLO metadata fall back to the usual
+legacy or auto-conversion flows with a warning.
+
+Private and gated repos work once you are authenticated (see below).
+
+## Pushing models to the Hub
+
+Any loaded model can be published, together with an auto-generated model card
+derived from its checkpoint metadata (family, size, task, classes, metrics):
+
+```python
+model = LibreYOLO("runs/detect/train/weights/best.pt")
+model.push_to_hub("someuser/my-finetune")                  # public
+model.push_to_hub("someuser/my-finetune", private=True)    # private
+model.push_to_hub("someuser/my-finetune", license="mit",
+                  metrics={"mAP50": 0.62})
+```
+
+The repo is created if missing. The checkpoint is uploaded as `model.pt`, so
+repeated pushes update the same file. Anyone can then load it back with
+`LibreYOLO("someuser/my-finetune")`.
+
+To upload automatically when a training run finishes, use the Hub logger:
+
+```python
+model.train(data="data.yaml", epochs=100, loggers="hf:someuser/my-finetune")
+```
+
+or, with options:
+
+```python
+from libreyolo.training import HuggingFaceHubLogger
+
+model.train(
+    data="data.yaml",
+    loggers=HuggingFaceHubLogger("someuser/my-finetune", private=True),
+)
+```
+
+The logger checks for credentials at construction time, so a missing login
+fails before training starts instead of after hours of training. On train
+end it pushes `weights/best.pt` (falling back to `last.pt`) with the final
+metrics rendered into the model card.
+
+## Authentication
+
+Reading public repos needs no login. Private repos, gated repos, and all
+pushes need a Hugging Face token, resolved the standard way:
+
+1. Run `hf auth login` once (stores a token on the machine), or
+2. set the `HF_TOKEN` environment variable, or
+3. pass `token="hf_..."` to `push_to_hub` / `HuggingFaceHubLogger`.
+
+Pushing requires a token with write scope; create one at
+<https://huggingface.co/settings/tokens>. Error messages repeat these steps
+whenever authentication is the likely cause.

--- a/docs/hf_hub.md
+++ b/docs/hf_hub.md
@@ -35,10 +35,19 @@ Resolution rules:
   in the repo is used. Repos with several checkpoints raise an error listing
   them; select one with `hf://owner/repo/<filename>`.
 
+- A revision passed as `@revision` must not contain `/`; use a commit SHA or a
+  slash-free branch name.
+
 Downloads go to the shared `huggingface_hub` cache and are loaded through the
 same safe path as local files: `torch.load(weights_only=True)` plus metadata
-validation. Checkpoints without LibreYOLO metadata fall back to the usual
-legacy or auto-conversion flows with a warning.
+validation.
+
+Hub checkpoints are identified by their LibreYOLO metadata. Recognized
+upstream checkpoints are still auto-converted, but a file with no metadata
+that cannot be converted is rejected rather than guessed at, because raw
+tensor keys from an arbitrary Hub repo can match an unrelated family and fail
+much later with a confusing error. To load such a file anyway, download it and
+pass a local path, which re-enables legacy architecture detection.
 
 Private and gated repos work once you are authenticated (see below).
 
@@ -76,10 +85,11 @@ model.train(
 )
 ```
 
-The logger checks for credentials at construction time, so a missing login
-fails before training starts instead of after hours of training. On train
-end it pushes `weights/best.pt` (falling back to `last.pt`) with the final
-metrics rendered into the model card.
+The logger verifies write access at construction time, which also creates the
+target repository up front, so a credential or repository-name problem fails
+before training starts instead of discarding hours of work at the end. On
+train end it pushes `weights/best.pt` (falling back to `last.pt`) with the
+final metrics rendered into the model card.
 
 Note the differing defaults: `push_to_hub` creates a public repo (you are
 explicitly publishing), while the logger creates a private one, because it

--- a/docs/hf_hub.md
+++ b/docs/hf_hub.md
@@ -72,7 +72,7 @@ from libreyolo.training import HuggingFaceHubLogger
 
 model.train(
     data="data.yaml",
-    loggers=HuggingFaceHubLogger("someuser/my-finetune", private=True),
+    loggers=HuggingFaceHubLogger("someuser/my-finetune", private=False),
 )
 ```
 
@@ -80,6 +80,12 @@ The logger checks for credentials at construction time, so a missing login
 fails before training starts instead of after hours of training. On train
 end it pushes `weights/best.pt` (falling back to `last.pt`) with the final
 metrics rendered into the model card.
+
+Note the differing defaults: `push_to_hub` creates a public repo (you are
+explicitly publishing), while the logger creates a private one, because it
+uploads unattended and a model trained on proprietary data must not become
+public by surprise. Pass `private=False` to publish from training. Repos that
+already exist keep their current visibility either way.
 
 ## Authentication
 

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -312,7 +312,10 @@ def LibreYOLO(
     Args:
         model_path: Path to weights (.pt), ONNX (.onnx), ExecuTorch (.pte),
                     MNN (.mnn), TensorRT (.engine), OpenVINO/Paddle/ncnn
-                    directory, or a Triton HTTP(S) model URL.
+                    directory, a Triton HTTP(S) model URL, or a Hugging Face
+                    Hub reference: "owner/repo" or
+                    "hf://owner/repo[@revision][/file.pt]" (requires the
+                    optional huggingface_hub package).
         size: Model size variant (auto-detected from weights if omitted).
         reg_max: Regression max for DFL (YOLOv9 only, default: 16).
         nb_classes: Number of classes (auto-detected if omitted).
@@ -336,6 +339,15 @@ def LibreYOLO(
         from ..backends.triton import TritonBackend
 
         return TritonBackend(model_path, device=device, task=task)
+
+    # Hugging Face Hub references ("owner/repo" or "hf://owner/repo") resolve
+    # to a checkpoint in the shared huggingface_hub cache, then flow through
+    # the exact same safe-load + metadata-validation path as a local file.
+    from ..utils.hf_hub import maybe_resolve_hub_reference
+
+    hub_checkpoint = maybe_resolve_hub_reference(model_path)
+    if hub_checkpoint is not None:
+        model_path = hub_checkpoint
 
     model_path = _resolve_weights_path(model_path)
 
@@ -479,10 +491,22 @@ def LibreYOLO(
                 except ModuleNotFoundError:
                     pass
             if size is None:
+                from ..utils.hf_hub import looks_like_repo_id
+
+                hub_hint = ""
+                if looks_like_repo_id(model_path):
+                    # A same-named local file or directory shadowed the bare
+                    # owner/repo form (local always wins), so point at the
+                    # explicit Hub syntax that bypasses that precedence.
+                    hub_hint = (
+                        f"\nIf you meant a Hugging Face Hub model, use the "
+                        f"explicit form: LibreYOLO('hf://{model_path}')."
+                    )
                 raise ValueError(
                     f"Model weights file not found: {model_path}\n"
                     f"Cannot auto-download: unable to determine size from filename.\n"
-                    f"Please specify size explicitly or provide a valid weights file path."
+                    f"Please specify size explicitly or provide a valid weights "
+                    f"file path.{hub_hint}"
                 )
 
         try:

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -345,8 +345,10 @@ def LibreYOLO(
     # the exact same safe-load + metadata-validation path as a local file.
     from ..utils.hf_hub import maybe_resolve_hub_reference
 
+    hub_source = None
     hub_checkpoint = maybe_resolve_hub_reference(model_path)
     if hub_checkpoint is not None:
+        hub_source = model_path
         model_path = hub_checkpoint
 
     model_path = _resolve_weights_path(model_path)
@@ -593,6 +595,22 @@ def LibreYOLO(
                 model_path,
                 "; ".join(metadata_errors),
                 _METADATA_CONVERSION_HELP,
+            )
+        elif hub_source is not None:
+            # Guessing a family from raw tensor keys is a coin flip for a file
+            # pulled off the open Hub: an unrelated model can satisfy some
+            # family's can_load() and then fail with a nonsense error about
+            # that family. Metadata is the contract for Hub loads, so refuse
+            # here and name the repo instead.
+            raise ValueError(
+                f"'{hub_source}' does not contain a LibreYOLO checkpoint.\n"
+                f"Hugging Face models are loaded by their LibreYOLO metadata "
+                f"(schema v1.0), and this file has none, so its architecture "
+                f"cannot be identified.\n"
+                f"If it is an upstream checkpoint LibreYOLO can convert, "
+                f"download it and load it from a local path, which enables "
+                f"the legacy architecture-detection path.\n"
+                f"{_METADATA_CONVERSION_HELP}"
             )
         else:
             logger.warning(

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1809,6 +1809,54 @@ class BaseModel(ABC):
         logger.info("Saved checkpoint to %s", out)
         return str(out)
 
+    def push_to_hub(
+        self,
+        repo_id: str,
+        *,
+        private: bool = False,
+        token: Optional[str] = None,
+        commit_message: Optional[str] = None,
+        license: Optional[str] = None,
+        metrics: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Upload this model to a Hugging Face Hub repository.
+
+        Saves the model as a schema v1.0 checkpoint (``model.pt``) and pushes
+        it together with an auto-generated model card. The repo is created if
+        it does not exist. Anyone can then load it back with
+        ``LibreYOLO("owner/repo")``.
+
+        Requires the optional huggingface_hub package
+        (``pip install libreyolo[hf]``) and Hub authentication with write
+        scope (``hf auth login`` or the ``HF_TOKEN`` environment variable, or
+        pass ``token=``).
+
+        Args:
+            repo_id: Target repository as ``"owner/name"``.
+            private: Create the repo as private (existing repos keep their
+                visibility).
+            token: Hub token overriding the ambient login.
+            commit_message: Custom commit message for the checkpoint upload.
+            license: License identifier for the model card front matter
+                (e.g. ``"mit"``). Omitted from the card when None.
+            metrics: Optional metric name -> value mapping rendered into the
+                model card.
+
+        Returns:
+            The repository URL.
+        """
+        from libreyolo.utils.hf_hub import push_model_to_hub
+
+        return push_model_to_hub(
+            self,
+            repo_id,
+            private=private,
+            token=token,
+            commit_message=commit_message,
+            license_id=license,
+            metrics=metrics,
+        )
+
     def export(self, format: str = "onnx", **kwargs) -> str:
         """Export model to deployment format.
 

--- a/libreyolo/training/__init__.py
+++ b/libreyolo/training/__init__.py
@@ -23,6 +23,7 @@ from .loggers import (
     ClearMLLogger as ClearMLLogger,
     CometLogger as CometLogger,
     DVCLiveLogger as DVCLiveLogger,
+    HuggingFaceHubLogger as HuggingFaceHubLogger,
     MLflowLogger as MLflowLogger,
     NeptuneLogger as NeptuneLogger,
     TensorBoardLogger as TensorBoardLogger,

--- a/libreyolo/training/loggers/__init__.py
+++ b/libreyolo/training/loggers/__init__.py
@@ -20,6 +20,7 @@ from .base import BaseLogger as BaseLogger
 from .clearml_logger import ClearMLLogger as ClearMLLogger
 from .comet_logger import CometLogger as CometLogger
 from .dvclive_logger import DVCLiveLogger as DVCLiveLogger
+from .hf_hub_logger import HuggingFaceHubLogger as HuggingFaceHubLogger
 from .mlflow_logger import MLflowLogger as MLflowLogger
 from .neptune_logger import NeptuneLogger as NeptuneLogger
 from .tensorboard_logger import TensorBoardLogger as TensorBoardLogger
@@ -35,6 +36,10 @@ _LOGGER_FACTORIES = {
     "mlflow": MLflowLogger,
     "wandb": WandbLogger,
 }
+
+# The Hub logger needs a target repo, so its string form carries it inline:
+# loggers="hf:owner/repo" (also accepted: "huggingface:owner/repo").
+_HF_LOGGER_PREFIXES = ("hf:", "huggingface:")
 
 
 def resolve_loggers(loggers: Any) -> list[Any]:
@@ -52,11 +57,22 @@ def resolve_loggers(loggers: Any) -> list[Any]:
     for item in loggers:
         if isinstance(item, str):
             key = item.strip().lower()
-            if key not in _LOGGER_FACTORIES:
+            if key.startswith(_HF_LOGGER_PREFIXES):
+                repo_id = item.strip().partition(":")[2]
+                resolved.append(HuggingFaceHubLogger(repo_id))
+            elif key in ("hf", "huggingface"):
                 raise ValueError(
-                    f"Unknown logger {item!r}. Valid names: {sorted(_LOGGER_FACTORIES)}"
+                    "The Hugging Face Hub logger needs a target repository: "
+                    "use loggers='hf:owner/repo', or pass a configured "
+                    "HuggingFaceHubLogger instance."
                 )
-            resolved.append(_LOGGER_FACTORIES[key]())
+            elif key not in _LOGGER_FACTORIES:
+                raise ValueError(
+                    f"Unknown logger {item!r}. Valid names: "
+                    f"{sorted(_LOGGER_FACTORIES) + ['hf:owner/repo']}"
+                )
+            else:
+                resolved.append(_LOGGER_FACTORIES[key]())
         else:
             resolved.append(item)
     return resolved

--- a/libreyolo/training/loggers/hf_hub_logger.py
+++ b/libreyolo/training/loggers/hf_hub_logger.py
@@ -20,12 +20,13 @@ class HuggingFaceHubLogger(BaseLogger):
         model.train(data="data.yaml", loggers="hf:someuser/my-finetune")
 
     Authentication is resolved the standard huggingface_hub way (``hf auth
-    login`` or ``HF_TOKEN``); a missing login fails at construction time so a
-    long run never trains for hours and then silently fails to upload.
+    login`` or ``HF_TOKEN``). Write access is verified at construction time,
+    which also creates the target repository, so a credential problem surfaces
+    before the run instead of discarding hours of training at the end.
 
     Args:
-        repo_id: Target repository as ``"owner/name"``. Created on first push
-            if it does not exist.
+        repo_id: Target repository as ``"owner/name"``. Created immediately
+            when the logger is constructed.
         private: Create the repo as private. Defaults to True, unlike the
             explicit :meth:`~libreyolo.models.base.BaseModel.push_to_hub`:
             this upload happens unattended at the end of a run, so a model
@@ -45,19 +46,11 @@ class HuggingFaceHubLogger(BaseLogger):
         license: str | None = None,
     ):
         super().__init__()
-        from libreyolo.utils.hf_hub import (
-            _auth_help,
-            _require_hub,
-            _validate_push_repo_id,
-        )
+        from libreyolo.utils.hf_hub import assert_can_push
 
-        hub = _require_hub()
-        _validate_push_repo_id(repo_id)
-        if token is None and hub.get_token() is None:
-            raise ValueError(
-                "HuggingFaceHubLogger needs Hub credentials before training "
-                "starts.\n" + _auth_help(repo_id, write=True)
-            )
+        # Proves write access now rather than after the run, which also
+        # creates the target repo up front.
+        assert_can_push(repo_id, private=private, token=token)
         self.repo_id = repo_id
         self.private = private
         self.token = token

--- a/libreyolo/training/loggers/hf_hub_logger.py
+++ b/libreyolo/training/loggers/hf_hub_logger.py
@@ -26,7 +26,12 @@ class HuggingFaceHubLogger(BaseLogger):
     Args:
         repo_id: Target repository as ``"owner/name"``. Created on first push
             if it does not exist.
-        private: Create the repo as private.
+        private: Create the repo as private. Defaults to True, unlike the
+            explicit :meth:`~libreyolo.models.base.BaseModel.push_to_hub`:
+            this upload happens unattended at the end of a run, so a model
+            trained on proprietary data must never become public by surprise.
+            Pass ``private=False`` to publish. Existing repos keep whatever
+            visibility they already have.
         token: Hub token overriding the ambient login (must have write scope).
         license: License identifier for the generated model card.
     """
@@ -35,7 +40,7 @@ class HuggingFaceHubLogger(BaseLogger):
         self,
         repo_id: str,
         *,
-        private: bool = False,
+        private: bool = True,
         token: str | None = None,
         license: str | None = None,
     ):

--- a/libreyolo/training/loggers/hf_hub_logger.py
+++ b/libreyolo/training/loggers/hf_hub_logger.py
@@ -1,0 +1,95 @@
+"""Push the best checkpoint of a training run to the Hugging Face Hub."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ..callbacks import TrainEndEvent
+from .base import BaseLogger
+
+logger = logging.getLogger("libreyolo")
+
+
+class HuggingFaceHubLogger(BaseLogger):
+    """Upload ``weights/best.pt`` to a Hub repository when training ends.
+
+    Enable it with a configured instance or the ``"hf:owner/repo"`` string
+    form::
+
+        model.train(data="data.yaml", loggers="hf:someuser/my-finetune")
+
+    Authentication is resolved the standard huggingface_hub way (``hf auth
+    login`` or ``HF_TOKEN``); a missing login fails at construction time so a
+    long run never trains for hours and then silently fails to upload.
+
+    Args:
+        repo_id: Target repository as ``"owner/name"``. Created on first push
+            if it does not exist.
+        private: Create the repo as private.
+        token: Hub token overriding the ambient login (must have write scope).
+        license: License identifier for the generated model card.
+    """
+
+    def __init__(
+        self,
+        repo_id: str,
+        *,
+        private: bool = False,
+        token: str | None = None,
+        license: str | None = None,
+    ):
+        super().__init__()
+        from libreyolo.utils.hf_hub import (
+            _auth_help,
+            _require_hub,
+            _validate_push_repo_id,
+        )
+
+        hub = _require_hub()
+        _validate_push_repo_id(repo_id)
+        if token is None and hub.get_token() is None:
+            raise ValueError(
+                "HuggingFaceHubLogger needs Hub credentials before training "
+                "starts.\n" + _auth_help(repo_id, write=True)
+            )
+        self.repo_id = repo_id
+        self.private = private
+        self.token = token
+        self.license = license
+
+    def _handle_end(self, event: TrainEndEvent) -> None:
+        from libreyolo.utils.hf_hub import push_checkpoint_to_hub
+
+        weights_dir = Path(event.save_dir) / "weights"
+        checkpoint = None
+        for candidate in ("best.pt", "last.pt"):
+            if (weights_dir / candidate).is_file():
+                checkpoint = weights_dir / candidate
+                break
+        if checkpoint is None:
+            logger.warning(
+                "HuggingFaceHubLogger: no best.pt or last.pt under %s; "
+                "nothing to push.",
+                weights_dir,
+            )
+            return
+
+        metrics = {
+            key: value
+            for key, value in event.results.items()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        }
+        url = push_checkpoint_to_hub(
+            checkpoint,
+            self.repo_id,
+            private=self.private,
+            token=self.token,
+            license_id=self.license,
+            metrics=metrics or None,
+            commit_message=(
+                f"Upload {event.model_family}{event.model_size or ''} "
+                f"{event.task} training result ({event.completed_epochs} epochs)"
+            ),
+        )
+        logger.info("Training checkpoint pushed to %s", url)

--- a/libreyolo/utils/hf_hub.py
+++ b/libreyolo/utils/hf_hub.py
@@ -224,12 +224,13 @@ def resolve_hub_checkpoint(ref: HubRef, *, token: str | None = None) -> str:
         EntryNotFoundError,
         GatedRepoError,
         HfHubHTTPError,
+        LocalEntryNotFoundError,
         RepositoryNotFoundError,
         RevisionNotFoundError,
     )
 
+    filename = ref.filename
     try:
-        filename = ref.filename
         if filename is None:
             api = hub.HfApi(token=token)
             repo_files = api.list_repo_files(ref.repo_id, revision=ref.revision)
@@ -256,9 +257,19 @@ def resolve_hub_checkpoint(ref: HubRef, *, token: str | None = None) -> str:
             f"Revision '{ref.revision}' does not exist in Hugging Face repo "
             f"'{ref.repo_id}'."
         ) from exc
+    except LocalEntryNotFoundError as exc:
+        # Subclass of EntryNotFoundError, so it must be caught first. It means
+        # "could not reach the Hub and it is not cached", which has nothing to
+        # do with the file being absent from the repo.
+        raise ConnectionError(
+            f"Could not download '{filename or ref.repo_id}' from the Hugging "
+            f"Face Hub and it is not in the local cache. Check your network "
+            f"connection, or unset HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE if you "
+            f"are in offline mode."
+        ) from exc
     except EntryNotFoundError as exc:
         raise FileNotFoundError(
-            f"File '{ref.filename}' does not exist in Hugging Face repo "
+            f"File '{filename}' does not exist in Hugging Face repo "
             f"'{ref.repo_id}'."
         ) from exc
     except HfHubHTTPError as exc:
@@ -297,6 +308,42 @@ def _format_metric(value: Any) -> str:
     return str(value)
 
 
+def _card_names(names: Any) -> list[str]:
+    """Return class names in class-index order.
+
+    The checkpoint schema accepts ``names`` as a list or as a dict whose keys
+    may be ints or their string forms, so normalize all three here. Sorting
+    raw dict keys would order string keys lexicographically ("10" before
+    "2") and indexing a list with them would raise.
+    """
+    if isinstance(names, (list, tuple)):
+        return [str(value) for value in names]
+    if not isinstance(names, dict):
+        return []
+    try:
+        ordered = sorted(names.items(), key=lambda item: int(item[0]))
+    except (TypeError, ValueError):
+        ordered = list(names.items())
+    return [str(value) for _, value in ordered]
+
+
+def _yaml_scalar(value: Any) -> str:
+    """Render a checkpoint-derived value as a safe single-line YAML scalar.
+
+    Checkpoint metadata is attacker-controlled for any file you did not write
+    yourself, and it is rendered into the card's front matter. Without this, a
+    ``model_family`` carrying a newline could inject its own keys (forging,
+    say, a permissive ``license:`` on non-permissive weights).
+    """
+    text = str(value)
+    if _REPO_SEGMENT_RE.match(text):
+        # Plain token (the normal case): emit it bare so cards stay readable.
+        return text
+    for char in ("\r", "\n", "\t"):
+        text = text.replace(char, " ")
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"').strip() + '"'
+
+
 def build_model_card(
     metadata: dict[str, Any],
     repo_id: str,
@@ -318,10 +365,10 @@ def build_model_card(
     if pipeline_tag:
         front.append(f"pipeline_tag: {pipeline_tag}")
     if license_id:
-        front.append(f"license: {license_id}")
+        front.append(f"license: {_yaml_scalar(license_id)}")
     front.append("tags:")
     for tag in ("libreyolo", family, task):
-        front.append(f"- {tag}")
+        front.append(f"- {_yaml_scalar(tag)}")
     front.append("---")
 
     body: list[str] = [
@@ -351,9 +398,10 @@ def build_model_card(
     if metadata.get("quant"):
         body.append("| Quantized | yes |")
 
-    if names:
-        shown = [str(names[k]) for k in sorted(names)[:50]]
-        suffix = ", ..." if len(names) > 50 else ""
+    ordered_names = _card_names(names)
+    if ordered_names:
+        shown = ordered_names[:50]
+        suffix = ", ..." if len(ordered_names) > 50 else ""
         body += [
             "",
             "## Classes",
@@ -383,6 +431,57 @@ def _validate_push_repo_id(repo_id: str) -> None:
             f"Invalid Hugging Face repository id {repo_id!r}. Expected "
             "'owner/name', e.g. 'someuser/my-yolo9-finetune'."
         )
+
+
+def assert_can_push(repo_id: str, *, private: bool = True, token: str | None = None):
+    """Verify now that a later push to ``repo_id`` can succeed.
+
+    Checking that *a* token exists proves nothing: a token scoped to another
+    namespace passes that test and then fails after the run it was supposed to
+    protect. So this resolves the identity behind the token, refuses a
+    namespace the user cannot write to, and finally creates the repo, which is
+    the only real proof of write access. The repo is therefore created up
+    front rather than at the end of training.
+    """
+    hub = _require_hub()
+    from huggingface_hub.errors import HfHubHTTPError
+
+    _validate_push_repo_id(repo_id)
+    api = hub.HfApi(token=token)
+    try:
+        identity = api.whoami()
+    except Exception as exc:
+        raise PermissionError(
+            f"Could not verify Hugging Face credentials for '{repo_id}'.\n"
+            + _auth_help(repo_id, write=True)
+        ) from exc
+
+    owner = repo_id.split("/")[0]
+    namespaces = {identity.get("name")}
+    namespaces.update(
+        org.get("name") for org in identity.get("orgs", []) or [] if org
+    )
+    namespaces.discard(None)
+    if owner not in namespaces:
+        raise PermissionError(
+            f"You cannot push to '{repo_id}': you are signed in as "
+            f"'{identity.get('name')}' and '{owner}' is not your username or "
+            f"one of your organizations ({sorted(namespaces)}).\n"
+            f"{_auth_help(repo_id, write=True)}"
+        )
+
+    try:
+        api.create_repo(repo_id, private=private, exist_ok=True, repo_type="model")
+    except HfHubHTTPError as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status in (401, 403):
+            raise PermissionError(
+                f"Your token cannot write to '{repo_id}' (HTTP {status}). A "
+                f"fine-grained token must grant write access to this "
+                f"repository.\n{_auth_help(repo_id, write=True)}"
+            ) from exc
+        raise
+    return api
 
 
 def push_checkpoint_to_hub(

--- a/libreyolo/utils/hf_hub.py
+++ b/libreyolo/utils/hf_hub.py
@@ -1,0 +1,499 @@
+"""Hugging Face Hub integration: load checkpoints from any repo, push your own.
+
+Two directions, both optional (``pip install libreyolo[hf]``):
+
+- Loading: ``LibreYOLO("owner/repo")`` or ``LibreYOLO("hf://owner/repo")``
+  downloads a LibreYOLO checkpoint from any Hub repository into the shared
+  huggingface_hub cache and loads it through the normal metadata-validated
+  path. ``hf://owner/repo@revision/file.pt`` pins a revision and file.
+- Pushing: :func:`push_model_to_hub` / :func:`push_checkpoint_to_hub` upload a
+  schema v1.0 checkpoint as ``model.pt`` plus an auto-generated model card
+  derived from the checkpoint metadata.
+
+``huggingface_hub`` is imported lazily so ``import libreyolo`` never pays for
+it and torch-free deployments are unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("libreyolo")
+
+HF_URI_PREFIX = "hf://"
+
+# The canonical checkpoint filename inside a pushed repo. Loading does not
+# depend on it (any single .pt in a repo is picked up), but a fixed name keeps
+# repeated pushes to the same repo as updates rather than accumulating files.
+HUB_CHECKPOINT_FILENAME = "model.pt"
+
+_REPO_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# A bare ``owner/name`` string whose last segment ends in a local artifact
+# extension keeps its historical meaning: a (possibly missing) local path that
+# the legacy auto-download flow may create. Only extension-less names can be
+# claimed as Hub repo ids without changing existing behavior.
+_LOCAL_ARTIFACT_SUFFIXES = (
+    ".pt",
+    ".pth",
+    ".safetensors",
+    ".onnx",
+    ".torchscript",
+    ".pte",
+    ".tflite",
+    ".mnn",
+    ".engine",
+    ".tensorrt",
+    ".mlpackage",
+    ".xml",
+    ".bin",
+    ".param",
+    ".yaml",
+    ".yml",
+    ".json",
+)
+
+# File types inside a Hub repo that LibreYOLO(...) can load directly.
+_WEIGHT_CANDIDATE_SUFFIXES = (".pt", ".safetensors")
+
+# Canonical LibreYOLO task -> Hub pipeline_tag. Tasks without a good Hub
+# equivalent are simply omitted from the card front matter.
+_PIPELINE_TAGS = {
+    "detect": "object-detection",
+    "obb": "object-detection",
+    "point": "object-detection",
+    "segment": "image-segmentation",
+    "semantic": "image-segmentation",
+    "panoptic": "image-segmentation",
+    "pose": "keypoint-detection",
+    "classify": "image-classification",
+    "depth": "depth-estimation",
+    "edge": "image-to-image",
+    "normal": "image-to-image",
+    "restore": "image-to-image",
+    "matte": "image-to-image",
+    "ocr": "image-to-text",
+    "embed": "image-feature-extraction",
+}
+
+
+@dataclass(frozen=True)
+class HubRef:
+    """A parsed Hugging Face Hub model reference."""
+
+    repo_id: str
+    filename: str | None = None
+    revision: str | None = None
+
+
+def _require_hub():
+    try:
+        import huggingface_hub
+    except ImportError as exc:
+        raise ImportError(
+            "This model reference points to the Hugging Face Hub, which "
+            "requires the optional huggingface_hub package. Install it with: "
+            "pip install libreyolo[hf]"
+        ) from exc
+    return huggingface_hub
+
+
+def _is_valid_repo_id(repo_id: str) -> bool:
+    parts = repo_id.split("/")
+    return len(parts) == 2 and all(_REPO_SEGMENT_RE.match(part) for part in parts)
+
+
+def parse_hub_reference(model_path: str) -> HubRef | None:
+    """Parse a model path into a :class:`HubRef`, or None for local paths.
+
+    Recognized forms:
+
+    - ``hf://owner/repo`` (optionally ``@revision``, optionally a trailing
+      ``/path/to/file`` inside the repo)
+    - bare ``owner/repo`` when it cannot be a local path: exactly one forward
+      slash, valid Hub characters, no local artifact extension, and nothing
+      with that name on disk.
+    """
+    if not isinstance(model_path, str) or not model_path:
+        return None
+
+    if model_path.startswith(HF_URI_PREFIX):
+        remainder = model_path[len(HF_URI_PREFIX) :].strip("/")
+        parts = remainder.split("/")
+        if len(parts) < 2:
+            raise ValueError(
+                f"Invalid Hugging Face reference {model_path!r}. Expected "
+                "hf://owner/repo, hf://owner/repo@revision, or "
+                "hf://owner/repo/path/to/file.pt."
+            )
+        owner, name = parts[0], parts[1]
+        revision = None
+        if "@" in name:
+            name, _, revision = name.partition("@")
+            if not revision:
+                raise ValueError(
+                    f"Invalid Hugging Face reference {model_path!r}: empty "
+                    "revision after '@'."
+                )
+        repo_id = f"{owner}/{name}"
+        if not _is_valid_repo_id(repo_id):
+            raise ValueError(
+                f"Invalid Hugging Face repository id {repo_id!r} in "
+                f"{model_path!r}."
+            )
+        filename = "/".join(parts[2:]) or None
+        return HubRef(repo_id=repo_id, filename=filename, revision=revision)
+
+    # Bare owner/repo form: conservative, never claims anything that could be
+    # (or become) a local path.
+    if "\\" in model_path or model_path.count("/") != 1:
+        return None
+    if model_path.startswith((".", "~", "/")) or ":" in model_path:
+        return None
+    if model_path.lower().endswith(_LOCAL_ARTIFACT_SUFFIXES):
+        return None
+    if not _is_valid_repo_id(model_path):
+        return None
+    if Path(model_path).exists() or Path(model_path.split("/")[0]).is_dir():
+        return None
+    return HubRef(repo_id=model_path)
+
+
+def looks_like_repo_id(model_path: str) -> bool:
+    """Pure-syntax check: could this string name a Hub repo (``owner/name``)?
+
+    Unlike :func:`parse_hub_reference` this never consults the filesystem, so
+    it can explain a failed local load that shadowed a plausible Hub id.
+    """
+    return (
+        isinstance(model_path, str)
+        and model_path.count("/") == 1
+        and "\\" not in model_path
+        and ":" not in model_path
+        and not model_path.lower().endswith(_LOCAL_ARTIFACT_SUFFIXES)
+        and _is_valid_repo_id(model_path)
+    )
+
+
+def _auth_help(repo_id: str, *, write: bool = False) -> str:
+    lines = [
+        "Authenticate with the Hugging Face Hub in one of these ways:",
+        "  1. Run `hf auth login` once (stores a token on this machine).",
+        "  2. Set the HF_TOKEN environment variable to a token.",
+        "  3. Pass token='hf_...' to this call.",
+        "Create tokens at https://huggingface.co/settings/tokens.",
+    ]
+    if write:
+        lines.append(
+            f"Pushing to '{repo_id}' needs a token with WRITE scope "
+            "(fine-grained tokens must include this repository)."
+        )
+    return "\n".join(lines)
+
+
+def _select_repo_weight_file(repo_files: list[str], repo_id: str) -> str:
+    candidates = [
+        f for f in repo_files if f.lower().endswith(_WEIGHT_CANDIDATE_SUFFIXES)
+    ]
+    if not candidates:
+        raise FileNotFoundError(
+            f"No loadable checkpoint (*.pt or *.safetensors) found in Hugging "
+            f"Face repo '{repo_id}'. Files present: {sorted(repo_files)}"
+        )
+    if len(candidates) == 1:
+        return candidates[0]
+    pt_files = [f for f in candidates if f.lower().endswith(".pt")]
+    if len(pt_files) == 1:
+        return pt_files[0]
+    raise ValueError(
+        f"Hugging Face repo '{repo_id}' contains multiple checkpoints: "
+        f"{sorted(candidates)}. Select one explicitly with "
+        f"LibreYOLO('hf://{repo_id}/<filename>')."
+    )
+
+
+def resolve_hub_checkpoint(ref: HubRef, *, token: str | None = None) -> str:
+    """Download the checkpoint for ``ref`` and return its local cache path."""
+    hub = _require_hub()
+    from huggingface_hub.errors import (
+        EntryNotFoundError,
+        GatedRepoError,
+        HfHubHTTPError,
+        RepositoryNotFoundError,
+        RevisionNotFoundError,
+    )
+
+    try:
+        filename = ref.filename
+        if filename is None:
+            api = hub.HfApi(token=token)
+            repo_files = api.list_repo_files(ref.repo_id, revision=ref.revision)
+            filename = _select_repo_weight_file(list(repo_files), ref.repo_id)
+        local_path = hub.hf_hub_download(
+            repo_id=ref.repo_id,
+            filename=filename,
+            revision=ref.revision,
+            token=token,
+        )
+    except GatedRepoError as exc:
+        raise PermissionError(
+            f"Hugging Face repo '{ref.repo_id}' is gated: request access on "
+            f"its model page, then authenticate.\n{_auth_help(ref.repo_id)}"
+        ) from exc
+    except RepositoryNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Hugging Face repo '{ref.repo_id}' was not found. Either the id "
+            "is wrong, or the repo is private and you are not authenticated.\n"
+            + _auth_help(ref.repo_id)
+        ) from exc
+    except RevisionNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Revision '{ref.revision}' does not exist in Hugging Face repo "
+            f"'{ref.repo_id}'."
+        ) from exc
+    except EntryNotFoundError as exc:
+        raise FileNotFoundError(
+            f"File '{ref.filename}' does not exist in Hugging Face repo "
+            f"'{ref.repo_id}'."
+        ) from exc
+    except HfHubHTTPError as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status in (401, 403):
+            raise PermissionError(
+                f"Access to Hugging Face repo '{ref.repo_id}' was denied "
+                f"(HTTP {status}).\n" + _auth_help(ref.repo_id)
+            ) from exc
+        raise
+
+    logger.info(
+        "Resolved Hugging Face model '%s' to %s", ref.repo_id, local_path
+    )
+    return local_path
+
+
+def maybe_resolve_hub_reference(
+    model_path: str, *, token: str | None = None
+) -> str | None:
+    """Return a local checkpoint path if ``model_path`` is a Hub reference."""
+    ref = parse_hub_reference(model_path)
+    if ref is None:
+        return None
+    return resolve_hub_checkpoint(ref, token=token)
+
+
+# =============================================================================
+# Pushing
+# =============================================================================
+
+
+def _format_metric(value: Any) -> str:
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+def build_model_card(
+    metadata: dict[str, Any],
+    repo_id: str,
+    *,
+    license_id: str | None = None,
+    metrics: dict[str, Any] | None = None,
+) -> str:
+    """Render a model card (README.md) from LibreYOLO checkpoint metadata."""
+    family = str(metadata.get("model_family", "unknown"))
+    size = str(metadata.get("size", ""))
+    task = str(metadata.get("task", "detect"))
+    nc = metadata.get("nc")
+    imgsz = metadata.get("imgsz")
+    names = metadata.get("names") or {}
+    version = metadata.get("libreyolo_version", "unknown")
+
+    front: list[str] = ["---", "library_name: libreyolo"]
+    pipeline_tag = _PIPELINE_TAGS.get(task)
+    if pipeline_tag:
+        front.append(f"pipeline_tag: {pipeline_tag}")
+    if license_id:
+        front.append(f"license: {license_id}")
+    front.append("tags:")
+    for tag in ("libreyolo", family, task):
+        front.append(f"- {tag}")
+    front.append("---")
+
+    body: list[str] = [
+        "",
+        f"# {family}{size} ({task})",
+        "",
+        "LibreYOLO checkpoint (metadata schema v1.0). Load it directly:",
+        "",
+        "```python",
+        "from libreyolo import LibreYOLO",
+        "",
+        f'model = LibreYOLO("{repo_id}")',
+        'results = model.predict("image.jpg")',
+        "```",
+        "",
+        "## Model details",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Family | `{family}` |",
+        f"| Size | `{size}` |",
+        f"| Task | `{task}` |",
+        f"| Classes (nc) | {nc} |",
+        f"| Input size (imgsz) | {imgsz} |",
+        f"| LibreYOLO version | `{version}` |",
+    ]
+    if metadata.get("quant"):
+        body.append("| Quantized | yes |")
+
+    if names:
+        shown = [str(names[k]) for k in sorted(names)[:50]]
+        suffix = ", ..." if len(names) > 50 else ""
+        body += [
+            "",
+            "## Classes",
+            "",
+            ", ".join(shown) + suffix,
+        ]
+
+    if metrics:
+        body += ["", "## Metrics", "", "| Metric | Value |", "| --- | --- |"]
+        for key in sorted(metrics):
+            body.append(f"| {key} | {_format_metric(metrics[key])} |")
+
+    body += [
+        "",
+        "---",
+        "",
+        "Trained and published with [LibreYOLO]"
+        "(https://github.com/LibreYOLO/libreyolo).",
+        "",
+    ]
+    return "\n".join(front + body)
+
+
+def _validate_push_repo_id(repo_id: str) -> None:
+    if not isinstance(repo_id, str) or not _is_valid_repo_id(repo_id):
+        raise ValueError(
+            f"Invalid Hugging Face repository id {repo_id!r}. Expected "
+            "'owner/name', e.g. 'someuser/my-yolo9-finetune'."
+        )
+
+
+def push_checkpoint_to_hub(
+    checkpoint_path: str | Path,
+    repo_id: str,
+    *,
+    private: bool = False,
+    token: str | None = None,
+    commit_message: str | None = None,
+    license_id: str | None = None,
+    metrics: dict[str, Any] | None = None,
+) -> str:
+    """Upload a LibreYOLO checkpoint file plus a generated model card.
+
+    The checkpoint must carry schema v1.0 metadata (anything written by
+    ``model.save`` or the trainer qualifies). Returns the repo URL.
+    """
+    from .serialization import (
+        load_untrusted_torch_file,
+        validate_checkpoint_metadata,
+    )
+
+    _validate_push_repo_id(repo_id)
+    checkpoint_path = Path(checkpoint_path)
+    if not checkpoint_path.is_file():
+        raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
+
+    loaded = load_untrusted_torch_file(
+        checkpoint_path, map_location="cpu", context="hub upload inspection"
+    )
+    errors = validate_checkpoint_metadata(loaded, strict=False)
+    if errors:
+        raise ValueError(
+            f"Refusing to push '{checkpoint_path}': it is not a LibreYOLO "
+            "schema v1.0 checkpoint (" + "; ".join(errors) + "). Load it and "
+            "re-save with model.save() first."
+        )
+    metadata = {k: v for k, v in loaded.items() if k != "model"}
+
+    hub = _require_hub()
+    from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError
+
+    card = build_model_card(
+        metadata, repo_id, license_id=license_id, metrics=metrics
+    )
+    if commit_message is None:
+        commit_message = (
+            f"Upload {metadata.get('model_family', 'model')}"
+            f"{metadata.get('size', '')} {metadata.get('task', '')} "
+            "checkpoint with LibreYOLO"
+        )
+
+    try:
+        api = hub.HfApi(token=token)
+        repo_url = api.create_repo(
+            repo_id, private=private, exist_ok=True, repo_type="model"
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(card, encoding="utf-8")
+            api.upload_file(
+                path_or_fileobj=str(checkpoint_path),
+                path_in_repo=HUB_CHECKPOINT_FILENAME,
+                repo_id=repo_id,
+                commit_message=commit_message,
+            )
+            api.upload_file(
+                path_or_fileobj=str(readme_path),
+                path_in_repo="README.md",
+                repo_id=repo_id,
+                commit_message="Update model card",
+            )
+    except RepositoryNotFoundError as exc:
+        raise PermissionError(
+            f"Could not access Hugging Face repo '{repo_id}'.\n"
+            + _auth_help(repo_id, write=True)
+        ) from exc
+    except HfHubHTTPError as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status in (401, 403):
+            raise PermissionError(
+                f"Pushing to Hugging Face repo '{repo_id}' was denied "
+                f"(HTTP {status}).\n" + _auth_help(repo_id, write=True)
+            ) from exc
+        raise
+
+    url = str(getattr(repo_url, "url", None) or repo_url)
+    logger.info("Pushed checkpoint to %s", url)
+    return url
+
+
+def push_model_to_hub(
+    model,
+    repo_id: str,
+    *,
+    private: bool = False,
+    token: str | None = None,
+    commit_message: str | None = None,
+    license_id: str | None = None,
+    metrics: dict[str, Any] | None = None,
+) -> str:
+    """Save ``model`` as a v1.0 checkpoint and upload it to the Hub."""
+    _validate_push_repo_id(repo_id)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        checkpoint_path = model.save(str(Path(tmp_dir) / HUB_CHECKPOINT_FILENAME))
+        return push_checkpoint_to_hub(
+            checkpoint_path,
+            repo_id,
+            private=private,
+            token=token,
+            commit_message=commit_message,
+            license_id=license_id,
+            metrics=metrics,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,6 +273,10 @@ dvclive = [
 dvc = [
     "libreyolo[dvclive]",
 ]
+hf = [
+    # Hugging Face Hub loading (LibreYOLO("owner/repo")) and push_to_hub.
+    "huggingface_hub>=0.34.0",
+]
 all = [
     "libreyolo[stream]",
     "libreyolo[onnx]",
@@ -306,6 +310,7 @@ all = [
     "libreyolo[comet]",
     "libreyolo[clearml]",
     "libreyolo[dvclive]",
+    "libreyolo[hf]",
     # Keep Neptune separate: stable neptune-scale requires protobuf<7 while
     # the TFLite/onnx2tf extra included above requires protobuf 7.
 ]

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -395,6 +395,28 @@ def test_hf_logger_pushes_best_checkpoint(tmp_path, monkeypatch):
     assert pushed["metrics"] == {"best_mAP50": 0.5, "final_loss": 1.0}
 
 
+def test_hf_logger_defaults_to_private(tmp_path, monkeypatch):
+    """Unattended uploads must not publish by surprise (push_to_hub differs)."""
+    from libreyolo.training.loggers import HuggingFaceHubLogger
+
+    _patch_ambient_token(monkeypatch)
+    weights_dir = tmp_path / "weights"
+    weights_dir.mkdir()
+    _make_yolo9_checkpoint(weights_dir / "best.pt")
+
+    seen = {}
+    monkeypatch.setattr(
+        hf_hub,
+        "push_checkpoint_to_hub",
+        lambda path, repo_id, **kwargs: seen.update(kwargs) or "url",
+    )
+
+    HuggingFaceHubLogger("someuser/finetune").on_train_end(
+        _train_end_event(tmp_path)
+    )
+    assert seen["private"] is True
+
+
 def test_hf_logger_no_checkpoint_is_a_noop(tmp_path, monkeypatch, caplog):
     from libreyolo.training.loggers import HuggingFaceHubLogger
 

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -1,0 +1,434 @@
+"""Unit tests for the Hugging Face Hub integration (issue #786)."""
+
+from __future__ import annotations
+
+import sys
+from types import MappingProxyType
+
+import pytest
+import torch
+
+from libreyolo.models import LibreYOLO
+from libreyolo.models.yolo9.nn import LibreYOLO9Model
+from libreyolo.utils import hf_hub
+from libreyolo.utils.hf_hub import (
+    HubRef,
+    build_model_card,
+    parse_hub_reference,
+    push_checkpoint_to_hub,
+    push_model_to_hub,
+    _select_repo_weight_file,
+)
+from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Reference parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bare_repo_id():
+    ref = parse_hub_reference("someuser/my-finetune")
+    assert ref == HubRef(repo_id="someuser/my-finetune")
+
+
+def test_parse_hf_uri_forms():
+    assert parse_hub_reference("hf://u/r") == HubRef("u/r")
+    assert parse_hub_reference("hf://u/r@abc123") == HubRef("u/r", None, "abc123")
+    assert parse_hub_reference("hf://u/r/sub/file.pt") == HubRef(
+        "u/r", "sub/file.pt", None
+    )
+    assert parse_hub_reference("hf://u/r@v2/best.pt") == HubRef(
+        "u/r", "best.pt", "v2"
+    )
+
+
+@pytest.mark.parametrize(
+    "bad", ["hf://only-owner", "hf://u/r@", "hf://u/bad*name"]
+)
+def test_parse_invalid_hf_uri_raises(bad):
+    with pytest.raises(ValueError):
+        parse_hub_reference(bad)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "libreyolo9s.pt",  # no slash: plain filename
+        "weights/libreyolo9s.pt",  # local artifact extension keeps old flow
+        "some/dir/file.pt",  # more than one slash
+        "./relative/name",
+        "~/home/name",
+        "/abs/name",
+        "C:/drive/name",
+        "dir\\name",
+        "owner/data.yaml",
+        "http://example.com/x",
+    ],
+)
+def test_parse_rejects_local_and_url_paths(path):
+    assert parse_hub_reference(path) is None
+
+
+def test_parse_rejects_existing_local_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "owner").mkdir()
+    (tmp_path / "owner" / "repo").write_text("x")
+    assert parse_hub_reference("owner/repo") is None
+
+
+def test_parse_rejects_when_owner_is_local_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "runs").mkdir()
+    assert parse_hub_reference("runs/exp1") is None
+
+
+# ---------------------------------------------------------------------------
+# Repo file selection
+# ---------------------------------------------------------------------------
+
+
+def test_select_single_pt():
+    assert _select_repo_weight_file(["README.md", "model.pt"], "u/r") == "model.pt"
+
+
+def test_select_prefers_single_pt_over_safetensors():
+    files = ["model.safetensors", "model.pt", "README.md"]
+    assert _select_repo_weight_file(files, "u/r") == "model.pt"
+
+
+def test_select_multiple_pt_raises_with_hf_syntax():
+    with pytest.raises(ValueError, match="hf://u/r/"):
+        _select_repo_weight_file(["a.pt", "b.pt"], "u/r")
+
+
+def test_select_no_weights_raises():
+    with pytest.raises(FileNotFoundError):
+        _select_repo_weight_file(["README.md"], "u/r")
+
+
+# ---------------------------------------------------------------------------
+# Missing optional dependency
+# ---------------------------------------------------------------------------
+
+
+def test_missing_hub_package_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+    with pytest.raises(ImportError, match=r"libreyolo\[hf\]"):
+        hf_hub.resolve_hub_checkpoint(HubRef("u/r"))
+
+
+# ---------------------------------------------------------------------------
+# Resolution against a faked huggingface_hub
+# ---------------------------------------------------------------------------
+
+
+def _make_yolo9_checkpoint(path, names=None):
+    model = LibreYOLO9Model(config="t", nb_classes=80)
+    torch.save(
+        wrap_libreyolo_checkpoint(
+            model.state_dict(),
+            model_family="yolo9",
+            size="t",
+            task="detect",
+            nc=80,
+            names=names,
+            imgsz=640,
+        ),
+        path,
+    )
+    return path
+
+
+def test_resolve_hub_checkpoint_downloads_selected_file(tmp_path, monkeypatch):
+    hub = pytest.importorskip("huggingface_hub")
+    ckpt = _make_yolo9_checkpoint(tmp_path / "model.pt")
+
+    class FakeApi:
+        def __init__(self, token=None):
+            self.token = token
+
+        def list_repo_files(self, repo_id, revision=None):
+            assert repo_id == "someuser/finetune"
+            return ["README.md", "model.pt"]
+
+    calls = {}
+
+    def fake_download(repo_id, filename, revision=None, token=None):
+        calls["args"] = (repo_id, filename, revision)
+        return str(ckpt)
+
+    monkeypatch.setattr(hub, "HfApi", FakeApi)
+    monkeypatch.setattr(hub, "hf_hub_download", fake_download)
+
+    local = hf_hub.resolve_hub_checkpoint(HubRef("someuser/finetune"))
+    assert local == str(ckpt)
+    assert calls["args"] == ("someuser/finetune", "model.pt", None)
+
+
+def test_resolve_repo_not_found_teaches_auth(monkeypatch):
+    hub = pytest.importorskip("huggingface_hub")
+    from huggingface_hub.errors import RepositoryNotFoundError
+
+    class _FakeResponse:
+        status_code = 404
+        headers = {}
+        url = "https://huggingface.co/api/models/ghost/repo"
+        text = ""
+        request = None
+
+    class FakeApi:
+        def __init__(self, token=None):
+            pass
+
+        def list_repo_files(self, repo_id, revision=None):
+            raise RepositoryNotFoundError("nope", response=_FakeResponse())
+
+    monkeypatch.setattr(hub, "HfApi", FakeApi)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        hf_hub.resolve_hub_checkpoint(HubRef("ghost/repo"))
+    message = str(excinfo.value)
+    assert "hf auth login" in message
+    assert "HF_TOKEN" in message
+
+
+def test_factory_loads_bare_repo_reference(tmp_path, monkeypatch):
+    ckpt = _make_yolo9_checkpoint(
+        tmp_path / "model.pt", names={i: f"c{i}" for i in range(80)}
+    )
+    monkeypatch.setattr(
+        hf_hub, "maybe_resolve_hub_reference", lambda p, **kw: str(ckpt)
+    )
+
+    loaded = LibreYOLO("someuser/finetune", device="cpu")
+
+    assert loaded.nb_classes == 80
+    assert loaded.names[0] == "c0"
+
+
+# ---------------------------------------------------------------------------
+# Model card
+# ---------------------------------------------------------------------------
+
+
+def _metadata(**overrides):
+    metadata = {
+        "schema_version": "1.0",
+        "libreyolo_version": "1.5.0",
+        "model_family": "yolo9",
+        "size": "t",
+        "task": "detect",
+        "nc": 2,
+        "names": {0: "red", 1: "white"},
+        "imgsz": 640,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def test_model_card_front_matter_and_body():
+    card = build_model_card(
+        _metadata(), "someuser/finetune", license_id="mit", metrics={"mAP50": 0.5}
+    )
+    front = card.split("---")[1]
+    assert "library_name: libreyolo" in front
+    assert "pipeline_tag: object-detection" in front
+    assert "license: mit" in front
+    assert "- yolo9" in front
+    assert 'LibreYOLO("someuser/finetune")' in card
+    assert "| mAP50 | 0.5000 |" in card
+    assert "red, white" in card
+
+
+def test_model_card_unknown_task_omits_pipeline_tag():
+    card = build_model_card(_metadata(task="gaze"), "u/r")
+    assert "pipeline_tag" not in card
+    assert "license:" not in card
+
+
+def test_model_card_truncates_many_names():
+    names = {i: f"class_{i}" for i in range(120)}
+    card = build_model_card(_metadata(nc=120, names=names), "u/r")
+    assert "class_49" in card
+    assert "class_50, " not in card
+    assert "..." in card
+
+
+# ---------------------------------------------------------------------------
+# Pushing
+# ---------------------------------------------------------------------------
+
+
+class _RecordingApi:
+    instances = []
+
+    def __init__(self, token=None):
+        self.token = token
+        self.created = []
+        self.uploads = []
+        _RecordingApi.instances.append(self)
+
+    def create_repo(self, repo_id, private=False, exist_ok=False, repo_type=None):
+        self.created.append((repo_id, private))
+        return f"https://huggingface.co/{repo_id}"
+
+    def upload_file(
+        self, path_or_fileobj, path_in_repo, repo_id, commit_message=None
+    ):
+        content = None
+        if path_in_repo == "README.md":
+            with open(path_or_fileobj, encoding="utf-8") as fh:
+                content = fh.read()
+        self.uploads.append((path_in_repo, repo_id, content))
+
+
+@pytest.fixture
+def recording_api(monkeypatch):
+    hub = pytest.importorskip("huggingface_hub")
+    _RecordingApi.instances = []
+    monkeypatch.setattr(hub, "HfApi", _RecordingApi)
+    return _RecordingApi
+
+
+def test_push_checkpoint_uploads_weights_and_card(tmp_path, recording_api):
+    ckpt = _make_yolo9_checkpoint(tmp_path / "best.pt")
+
+    url = push_checkpoint_to_hub(ckpt, "someuser/finetune", private=True)
+
+    assert url == "https://huggingface.co/someuser/finetune"
+    api = recording_api.instances[-1]
+    assert api.created == [("someuser/finetune", True)]
+    names = [upload[0] for upload in api.uploads]
+    assert names == ["model.pt", "README.md"]
+    readme = api.uploads[1][2]
+    assert "library_name: libreyolo" in readme
+
+
+def test_push_rejects_metadata_less_checkpoint(tmp_path, recording_api):
+    bad = tmp_path / "raw.pt"
+    torch.save({"conv.weight": torch.zeros(1)}, bad)
+    with pytest.raises(ValueError, match="schema v1.0"):
+        push_checkpoint_to_hub(bad, "someuser/finetune")
+    assert recording_api.instances == []
+
+
+@pytest.mark.parametrize("bad_repo", ["norepo", "a/b/c", "bad*chars/x", ""])
+def test_push_rejects_invalid_repo_id(tmp_path, bad_repo):
+    with pytest.raises(ValueError, match="owner/name"):
+        push_checkpoint_to_hub(tmp_path / "x.pt", bad_repo)
+
+
+def test_push_model_saves_then_uploads(tmp_path, recording_api):
+    class DummyModel:
+        def save(self, path):
+            return str(_make_yolo9_checkpoint(path))
+
+    url = push_model_to_hub(DummyModel(), "someuser/finetune")
+    assert url == "https://huggingface.co/someuser/finetune"
+    assert recording_api.instances[-1].uploads[0][0] == "model.pt"
+
+
+# ---------------------------------------------------------------------------
+# Training logger
+# ---------------------------------------------------------------------------
+
+
+def _train_end_event(save_dir):
+    from libreyolo.training.callbacks import TrainEndEvent
+
+    return TrainEndEvent(
+        total_epochs=2,
+        completed_epochs=2,
+        model_family="yolo9",
+        model_size="t",
+        task="detect",
+        save_dir=str(save_dir),
+        final_loss=1.0,
+        best_metric=0.5,
+        best_epoch=1,
+        total_seconds=12.0,
+        results=MappingProxyType(
+            {"best_mAP50": 0.5, "final_loss": 1.0, "note": "text", "flag": True}
+        ),
+    )
+
+
+def _patch_ambient_token(monkeypatch, token="hf_dummy"):
+    hub = pytest.importorskip("huggingface_hub")
+    monkeypatch.setattr(hub, "get_token", lambda: token)
+
+
+def test_hf_logger_requires_credentials(monkeypatch):
+    from libreyolo.training.loggers import HuggingFaceHubLogger
+
+    _patch_ambient_token(monkeypatch, token=None)
+    with pytest.raises(ValueError, match="hf auth login"):
+        HuggingFaceHubLogger("someuser/finetune")
+
+
+def test_hf_logger_pushes_best_checkpoint(tmp_path, monkeypatch):
+    from libreyolo.training.loggers import HuggingFaceHubLogger
+
+    _patch_ambient_token(monkeypatch)
+    weights_dir = tmp_path / "weights"
+    weights_dir.mkdir()
+    _make_yolo9_checkpoint(weights_dir / "best.pt")
+
+    pushed = {}
+
+    def fake_push(path, repo_id, **kwargs):
+        pushed["path"] = str(path)
+        pushed["repo_id"] = repo_id
+        pushed["metrics"] = kwargs["metrics"]
+        return "https://huggingface.co/someuser/finetune"
+
+    monkeypatch.setattr(hf_hub, "push_checkpoint_to_hub", fake_push)
+
+    hub_logger = HuggingFaceHubLogger("someuser/finetune")
+    hub_logger.on_train_end(_train_end_event(tmp_path))
+
+    assert pushed["repo_id"] == "someuser/finetune"
+    assert pushed["path"].endswith("best.pt")
+    # Non-numeric and boolean result values never reach the model card.
+    assert pushed["metrics"] == {"best_mAP50": 0.5, "final_loss": 1.0}
+
+
+def test_hf_logger_no_checkpoint_is_a_noop(tmp_path, monkeypatch, caplog):
+    from libreyolo.training.loggers import HuggingFaceHubLogger
+
+    _patch_ambient_token(monkeypatch)
+    called = []
+    monkeypatch.setattr(
+        hf_hub, "push_checkpoint_to_hub", lambda *a, **k: called.append(a)
+    )
+
+    hub_logger = HuggingFaceHubLogger("someuser/finetune")
+    with caplog.at_level("WARNING", logger="libreyolo"):
+        hub_logger.on_train_end(_train_end_event(tmp_path))
+
+    assert called == []
+    assert not hub_logger._disabled
+
+
+# ---------------------------------------------------------------------------
+# resolve_loggers string form
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_loggers_hf_string(monkeypatch):
+    from libreyolo.training.loggers import HuggingFaceHubLogger, resolve_loggers
+
+    _patch_ambient_token(monkeypatch)
+    resolved = resolve_loggers("hf:someuser/finetune")
+    assert len(resolved) == 1
+    assert isinstance(resolved[0], HuggingFaceHubLogger)
+    assert resolved[0].repo_id == "someuser/finetune"
+
+
+def test_resolve_loggers_bare_hf_name_errors():
+    from libreyolo.training.loggers import resolve_loggers
+
+    with pytest.raises(ValueError, match="hf:owner/repo"):
+        resolve_loggers("hf")

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -194,6 +194,54 @@ def test_resolve_repo_not_found_teaches_auth(monkeypatch):
     assert "HF_TOKEN" in message
 
 
+def test_resolve_reports_offline_instead_of_missing_file(monkeypatch):
+    """No network is not the same failure as the file being absent."""
+    hub = pytest.importorskip("huggingface_hub")
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    def offline(**kwargs):
+        raise LocalEntryNotFoundError("no internet and no cache")
+
+    monkeypatch.setattr(hub, "hf_hub_download", offline)
+    with pytest.raises(ConnectionError, match="network connection"):
+        hf_hub.resolve_hub_checkpoint(HubRef("u/r", "model.pt"))
+
+
+def test_resolve_missing_entry_names_the_resolved_file(monkeypatch):
+    """The message must name the auto-selected file, not 'None'."""
+    hub = pytest.importorskip("huggingface_hub")
+    from huggingface_hub.errors import EntryNotFoundError
+
+    class FakeApi:
+        def __init__(self, token=None):
+            pass
+
+        def list_repo_files(self, repo_id, revision=None):
+            return ["README.md", "model.pt"]
+
+    def missing(**kwargs):
+        raise EntryNotFoundError("gone")
+
+    monkeypatch.setattr(hub, "HfApi", FakeApi)
+    monkeypatch.setattr(hub, "hf_hub_download", missing)
+    with pytest.raises(FileNotFoundError, match="'model.pt'"):
+        hf_hub.resolve_hub_checkpoint(HubRef("u/r"))
+
+
+def test_factory_refuses_metadata_less_hub_checkpoint(tmp_path, monkeypatch):
+    """Guessing a family from raw keys misroutes arbitrary Hub files."""
+    import torch as _torch
+
+    foreign = tmp_path / "model.pt"
+    _torch.save({"transformer.h.0.attn.weight": _torch.zeros(4, 4)}, foreign)
+    monkeypatch.setattr(
+        hf_hub, "maybe_resolve_hub_reference", lambda p, **kw: str(foreign)
+    )
+
+    with pytest.raises(ValueError, match="does not contain a LibreYOLO checkpoint"):
+        LibreYOLO("someuser/not-a-libreyolo-model", device="cpu")
+
+
 def test_factory_loads_bare_repo_reference(tmp_path, monkeypatch):
     ckpt = _make_yolo9_checkpoint(
         tmp_path / "model.pt", names={i: f"c{i}" for i in range(80)}
@@ -246,6 +294,29 @@ def test_model_card_unknown_task_omits_pipeline_tag():
     card = build_model_card(_metadata(task="gaze"), "u/r")
     assert "pipeline_tag" not in card
     assert "license:" not in card
+
+
+def test_model_card_accepts_names_as_list():
+    """A list is valid per the checkpoint schema and must not crash the card."""
+    card = build_model_card(_metadata(names=["red", "white"]), "u/r")
+    assert "red, white" in card
+
+
+def test_model_card_orders_string_keyed_names_numerically():
+    names = {str(i): f"c{i}" for i in range(12)}
+    card = build_model_card(_metadata(nc=12, names=names), "u/r")
+    assert "c0, c1, c2, c3" in card
+    assert "c1, c10, c11, c2" not in card
+
+
+def test_model_card_front_matter_resists_metadata_injection():
+    """Checkpoint metadata is untrusted: it must not forge front-matter keys."""
+    card = build_model_card(
+        _metadata(model_family="x\nlicense: proprietary"), "u/r"
+    )
+    front = card.split("---")[1]
+    assert "\nlicense: proprietary" not in front
+    assert '- "x license: proprietary"' in front
 
 
 def test_model_card_truncates_many_names():
@@ -355,17 +426,61 @@ def _train_end_event(save_dir):
     )
 
 
-def _patch_ambient_token(monkeypatch, token="hf_dummy"):
-    hub = pytest.importorskip("huggingface_hub")
-    monkeypatch.setattr(hub, "get_token", lambda: token)
+def _patch_ambient_token(monkeypatch, allowed=True):
+    """Stub the write preflight the logger runs at construction time."""
+    pytest.importorskip("huggingface_hub")
+    seen: list[tuple[str, bool]] = []
+
+    def fake_preflight(repo_id, *, private=True, token=None):
+        seen.append((repo_id, private))
+        if not allowed:
+            raise PermissionError("cannot write; run `hf auth login`")
+        return None
+
+    monkeypatch.setattr(hf_hub, "assert_can_push", fake_preflight)
+    return seen
 
 
-def test_hf_logger_requires_credentials(monkeypatch):
+def test_hf_logger_fails_fast_without_write_access(monkeypatch):
+    """A credential problem must surface before training, not after it."""
     from libreyolo.training.loggers import HuggingFaceHubLogger
 
-    _patch_ambient_token(monkeypatch, token=None)
-    with pytest.raises(ValueError, match="hf auth login"):
+    _patch_ambient_token(monkeypatch, allowed=False)
+    with pytest.raises(PermissionError, match="hf auth login"):
         HuggingFaceHubLogger("someuser/finetune")
+
+
+def test_hf_logger_preflights_target_repo(monkeypatch):
+    from libreyolo.training.loggers import HuggingFaceHubLogger
+
+    seen = _patch_ambient_token(monkeypatch)
+    HuggingFaceHubLogger("someuser/finetune")
+    assert seen == [("someuser/finetune", True)]
+
+
+def test_assert_can_push_rejects_foreign_namespace(monkeypatch):
+    """A token that exists proves nothing about where it may write."""
+    hub = pytest.importorskip("huggingface_hub")
+
+    class FakeApi:
+        def __init__(self, token=None):
+            pass
+
+        def whoami(self):
+            return {"name": "someuser", "orgs": [{"name": "someorg"}]}
+
+        def create_repo(self, *args, **kwargs):
+            raise AssertionError("must be rejected before touching the Hub")
+
+    monkeypatch.setattr(hub, "HfApi", FakeApi)
+    with pytest.raises(PermissionError, match="not your username"):
+        hf_hub.assert_can_push("google/not-mine")
+
+    # Own namespace and orgs are allowed through to repo creation.
+    created = []
+    FakeApi.create_repo = lambda self, repo_id, **kw: created.append(repo_id)
+    hf_hub.assert_can_push("someorg/model")
+    assert created == ["someorg/model"]
 
 
 def test_hf_logger_pushes_best_checkpoint(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #786 (phases 1 and 2).

## What

- `LibreYOLO("owner/repo")` and `LibreYOLO("hf://owner/repo[@rev][/file.pt]")` load checkpoints from any Hub repo. Download goes through the huggingface_hub cache (auth, resume, private repos for free), then the normal safe-load + metadata-validation path.
- `model.push_to_hub("owner/repo")` uploads a v1.0 checkpoint as `model.pt` plus an auto-generated model card (`library_name: libreyolo`, pipeline_tag, tags, classes, optional license + metrics).
- `HuggingFaceHubLogger` / `loggers="hf:owner/repo"` pushes `weights/best.pt` when training ends. Credentials checked at construction so a missing login fails before training, not after.
- Auth errors teach the three fixes: `hf auth login`, `HF_TOKEN`, `token=`.
- Optional extra `libreyolo[hf]`. `import libreyolo` never imports huggingface_hub.

## Rules

- Local paths always win over bare `owner/repo`. Bare form only claimed when extension-less, valid Hub id, nothing on disk. Shadowed refs get an error hint pointing at `hf://`.
- Repo with several checkpoints errors and lists them; pick with `hf://owner/repo/<file>`.
- Non-v1.0 checkpoints are refused on push with instructions to re-save.

## Tested

- 40 new unit tests (parsing, selection, card, push mocking, logger, resolve_loggers).
- Regressions: test_model_factory, test_training_loggers(_extended), test_serialization, test_download all pass.
- Live smoke on Windows: `hf://LibreYOLO/LibreYOLO9t/LibreYOLO9t.pt` downloads and loads (yolo9 t detect 80).

## Not in this PR

- Phase 3 (porting the 12 weights/ upload scripts onto push_to_hub).
- Docs website page (docs/hf_hub.md added in-repo).

## Code provenance

All code in this PR is original, written for this change. No third-party code was copied. huggingface_hub is used through its public API only.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds optional Hugging Face Hub checkpoint loading and publishing, including automatic publication of training results.
- Resolves bare and explicit Hub references through the Hugging Face cache before normal checkpoint validation.
- Adds model and checkpoint upload APIs with generated model cards.
- Adds a training logger that uploads the best available checkpoint at training completion.
- Adds the optional `hf` dependency group, documentation, and unit coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/utils/hf_hub.py | Implements Hub-reference parsing, checkpoint resolution, metadata-safe model-card generation, authentication guidance, and checkpoint publication; the prior list-form class-name failure is fixed. |
| libreyolo/models/__init__.py | Routes recognized Hub references through the existing safe checkpoint-loading path while preserving local-path precedence. |
| libreyolo/models/base/model.py | Exposes model publication through the BaseModel API. |
| libreyolo/training/loggers/hf_hub_logger.py | Adds an end-of-training logger that verifies access early and uploads the best available checkpoint. |
| libreyolo/training/loggers/__init__.py | Registers and resolves configured Hugging Face logger instances and prefixed logger strings. |
| tests/unit/test_hf_hub.py | Covers reference parsing, resolution, model cards, publishing, authentication failures, logger behavior, and the corrected list-form class-name path. |
| pyproject.toml | Adds huggingface_hub as an optional dependency through the `hf` and aggregate extras. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  HubRef["owner/repo or hf:// reference"] --> Resolve["Resolve through huggingface_hub cache"]
  Resolve --> Factory["LibreYOLO factory"]
  Factory --> Validate["Safe load and metadata validation"]
  Validate --> Model["LibreYOLO model"]
  Model --> Save["Save schema-v1.0 checkpoint"]
  Save --> Card["Generate model card"]
  Card --> Upload["Upload model.pt and README.md"]
  Training["Training completion"] --> Logger["HuggingFaceHubLogger"]
  Logger --> Best["Select best.pt or last.pt"]
  Best --> Card
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix edge cases found by adversarial test..."](https://github.com/libreyolo/libreyolo/commit/19b54cd99339161032dbbb2d415dc295661ce7fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53519532)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)

<!-- /greptile_comment -->