### PR TITLE
Fix MSDA Hub-to-Triton fallback, graph capture, and device launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ before 1.4.0 are documented in the
 
 ## [Unreleased]
 
+### Fixed
+
+- **MSDA slot follow-ups from #784.** `maybe_ms_deform_attn` walks eligible
+  providers when the preferred Hub kernel returns None, so Triton still
+  runs after a Hub reject or disable. Triton skips the `spatial_shapes`
+  `.item()` checks while CUDA-graph capturing, launches on `value.device`,
+  and disables itself after the first compile/launch failure instead of
+  retrying every call.
+
 ### Added
 
 - **EC pose on the `ms_deform_attn` slot.** The pose decoder's pre-split

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -26,9 +26,11 @@ dependency is never an error, only a fallback.
 
 ## Selection
 
-Implementations are tried newest-first; the first one whose predicate passes
-wins, falling back to the reference. `libreyolo.kernels.active()` reports the
-current selection.
+Implementations are tried newest-first; `resolve()` returns the first whose
+predicate passes. Slots that may return None for a given input
+(`ms_deform_attn`) then walk the remaining eligible providers so a Hub
+reject does not hide Triton. `libreyolo.kernels.active()` reports the
+first eligible name.
 
 - `LIBREYOLO_KERNELS=off|reference` forces the reference implementations;
   any other value selects only implementations registered under that name.

--- a/libreyolo/kernels/__init__.py
+++ b/libreyolo/kernels/__init__.py
@@ -44,7 +44,7 @@ import importlib
 import importlib.util
 import logging
 import os
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 from ..quant import fake_quant as _reference
 
@@ -86,6 +86,39 @@ def unregister(op: str, name: str):
 
 def clear_cache():
     _RESOLVED.clear()
+
+
+def _entry_allowed(entry: dict, forced: str) -> bool:
+    if forced in ("off", "reference") and entry["name"] != "reference":
+        return False
+    if forced and forced not in ("off", "reference") and entry["name"] not in (
+        forced,
+        "reference",
+    ):
+        return False
+    predicate = entry["predicate"]
+    try:
+        return predicate is None or predicate()
+    except Exception as exc:  # a broken predicate must never break inference
+        logger.warning(
+            "Kernel predicate failed for %s: %s", entry["name"], exc
+        )
+        return False
+
+
+def iter_impls(op: str) -> Iterator[Tuple[str, Callable]]:
+    """Yield eligible ``(name, impl)`` pairs newest-first.
+
+    Unlike :func:`resolve`, this does not cache and does not stop at the
+    first eligible provider. Slots that can return None for a given input
+    (attention, GEMM) walk the rest so a rejected newer impl does not hide
+    an older one.
+    """
+    _ensure_intree_loaded()
+    forced = _forced()
+    for entry in _REGISTRY.get(op, ()):
+        if _entry_allowed(entry, forced):
+            yield entry["name"], entry["impl"]
 
 
 def _forced() -> str:
@@ -140,23 +173,9 @@ def resolve(op: str) -> Optional[Callable]:
         return _RESOLVED[cache_key]
 
     impl = None
-    for entry in _REGISTRY.get(op, ()):
-        if forced in ("off", "reference") and entry["name"] != "reference":
-            continue
-        if forced and forced not in ("off", "reference") and entry["name"] not in (
-            forced,
-            "reference",
-        ):
-            continue
-        predicate = entry["predicate"]
-        try:
-            if predicate is None or predicate():
-                impl = entry["impl"]
-                break
-        except Exception as exc:  # a broken predicate must never break inference
-            logger.warning(
-                "Kernel predicate failed for %s/%s: %s", op, entry["name"], exc
-            )
+    for _name, candidate in iter_impls(op):
+        impl = candidate
+        break
     _RESOLVED[cache_key] = impl
     return impl
 

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -47,7 +47,7 @@ from typing import Optional
 
 import torch
 
-from .. import register, resolve
+from .. import clear_cache, iter_impls, register, resolve
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +177,7 @@ def _load_hub_kernel():
             logger.warning("Hub kernel %s unavailable: %s", _HUB_REPO, exc2)
     if _hub_kernel is None:
         _hub_failed = True
+        clear_cache()
     return _hub_kernel
 
 
@@ -315,6 +316,7 @@ def hub_ms_deform_attn(
         # A kernel that loads but rejects this torch/GPU combination must
         # never break inference: disable the provider and fall back.
         _hub_failed = True
+        clear_cache()
         logger.warning("Hub kernel %s failed, falling back: %s", _HUB_REPO, exc)
         return None
 
@@ -384,10 +386,15 @@ def maybe_ms_deform_attn(
     """
     if not ms_deform_attn_available():
         return None
-    impl = resolve("ms_deform_attn")
-    if impl is None:
-        return None
-    return impl(value, spatial_shapes, sampling_locations, attention_weights)
+    # Walk eligible providers. Hub is preferred but may return None for an
+    # input or disable itself after a launch failure; Triton must still run.
+    for _name, impl in iter_impls("ms_deform_attn"):
+        output = impl(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+        if output is not None:
+            return output
+    return None
 
 
 def maybe_ms_deform_attn_v2(

--- a/libreyolo/kernels/attention/ms_deform_attn_triton.py
+++ b/libreyolo/kernels/attention/ms_deform_attn_triton.py
@@ -20,15 +20,19 @@ registers on top.
 from __future__ import annotations
 
 import importlib.util
+import logging
 import os
 from typing import Optional
 
 import torch
 
-from .. import register
+from .. import clear_cache, register
+
+logger = logging.getLogger(__name__)
 
 
 _SLOT_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+_triton_failed = False
 
 
 def _env_enabled() -> bool:
@@ -43,9 +47,20 @@ def _env_enabled() -> bool:
 def _eligible() -> bool:
     return (
         _env_enabled()
+        and not _triton_failed
         and importlib.util.find_spec("triton") is not None
         and torch.cuda.is_available()
     )
+
+
+def _disable(exc: BaseException) -> None:
+    """One-shot disable after a compile/launch failure. Matches the Hub path."""
+    global _triton_failed
+    if _triton_failed:
+        return
+    _triton_failed = True
+    clear_cache()
+    logger.warning("Triton ms_deform_attn failed, falling back: %s", exc)
 
 
 def _supported_inputs(
@@ -58,11 +73,12 @@ def _supported_inputs(
         return False
     if value.requires_grad or sampling_locations.requires_grad or attention_weights.requires_grad:
         return False
+    device = value.device
     if not (
         value.is_cuda
-        and sampling_locations.is_cuda
-        and attention_weights.is_cuda
-        and spatial_shapes.is_cuda
+        and sampling_locations.device == device
+        and attention_weights.device == device
+        and spatial_shapes.device == device
     ):
         return False
     if not (
@@ -97,13 +113,15 @@ def _supported_inputs(
     if not (0 < channels <= 128):
         return False
     # Area must match Len_in or the kernel indexes off the value buffer.
-    # spatial_shapes is a few (H, W) pairs; the readback is cheaper than an
-    # illegal CUDA access on a mismatched caller.
-    areas = spatial_shapes[:, 0] * spatial_shapes[:, 1]
-    if int(areas.sum().item()) != int(len_in):
-        return False
-    if bool((spatial_shapes <= 0).any().item()):
-        return False
+    # Skip the host readback while CUDA-graph capturing: warmup already
+    # validated this shape, and .item() would abort capture.
+    capturing = torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+    if not capturing:
+        areas = spatial_shapes[:, 0] * spatial_shapes[:, 1]
+        if int(areas.sum().item()) != int(len_in):
+            return False
+        if bool((spatial_shapes <= 0).any().item()):
+            return False
     return True
 
 
@@ -273,6 +291,8 @@ def triton_ms_deform_attn(
     attention_weights: torch.Tensor,
 ) -> Optional[torch.Tensor]:
     """Run MSDA on the in-tree Triton kernel, or return None to fall back."""
+    if _triton_failed:
+        return None
     if not _supported_inputs(
         value, spatial_shapes, sampling_locations, attention_weights
     ):
@@ -296,38 +316,40 @@ def triton_ms_deform_attn(
     block_c = _next_power_of_2(int(n_channels))
     grid = (batch * n_queries * n_heads,)
     try:
-        _kernel()[grid](
-            value,
-            sampling_locations,
-            attention_weights,
-            shapes,
-            starts,
-            output,
-            batch,
-            n_queries,
-            n_heads,
-            n_channels,
-            n_levels,
-            n_points,
-            value.stride(0),
-            value.stride(1),
-            value.stride(2),
-            value.stride(3),
-            sampling_locations.stride(0),
-            sampling_locations.stride(1),
-            sampling_locations.stride(2),
-            sampling_locations.stride(3),
-            sampling_locations.stride(4),
-            attention_weights.stride(0),
-            attention_weights.stride(1),
-            attention_weights.stride(2),
-            attention_weights.stride(3),
-            attention_weights.stride(4),
-            output.stride(0),
-            output.stride(1),
-            BLOCK_C=block_c,
-        )
-    except Exception:
+        with torch.cuda.device(value.device):
+            _kernel()[grid](
+                value,
+                sampling_locations,
+                attention_weights,
+                shapes,
+                starts,
+                output,
+                batch,
+                n_queries,
+                n_heads,
+                n_channels,
+                n_levels,
+                n_points,
+                value.stride(0),
+                value.stride(1),
+                value.stride(2),
+                value.stride(3),
+                sampling_locations.stride(0),
+                sampling_locations.stride(1),
+                sampling_locations.stride(2),
+                sampling_locations.stride(3),
+                sampling_locations.stride(4),
+                attention_weights.stride(0),
+                attention_weights.stride(1),
+                attention_weights.stride(2),
+                attention_weights.stride(3),
+                attention_weights.stride(4),
+                output.stride(0),
+                output.stride(1),
+                BLOCK_C=block_c,
+            )
+    except Exception as exc:
+        _disable(exc)
         return None
     if value.dtype != torch.float32:
         return output.to(dtype=value.dtype)

--- a/tests/unit/kernels/test_ms_deform_attn.py
+++ b/tests/unit/kernels/test_ms_deform_attn.py
@@ -559,3 +559,89 @@ def test_triton_rfdetr_shapes_on_cuda():
         weights.flatten(-2),
     )
     torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-5)
+
+
+def test_maybe_walks_next_provider_when_first_returns_none(monkeypatch):
+    """Hub (or any newer impl) returning None must not hide the next provider."""
+    recorded = []
+
+    def first_impl(value, spatial_shapes, sampling_locations, attention_weights):
+        recorded.append("first")
+        return None
+
+    def second_impl(value, spatial_shapes, sampling_locations, attention_weights):
+        recorded.append("second")
+        return torch.full(
+            (value.shape[0], sampling_locations.shape[1], value.shape[2] * value.shape[3]),
+            7.0,
+        )
+
+    kernels.register("ms_deform_attn", second_impl, name="second")
+    kernels.register("ms_deform_attn", first_impl, name="first")
+    kernels.clear_cache()
+    try:
+        value, shapes, locations, weights = _classic_inputs()
+        out = maybe_ms_deform_attn(value, shapes, locations, weights)
+        assert recorded == ["first", "second"]
+        assert torch.equal(out, torch.full((BATCH, LEN_Q, HEADS * CHANNELS), 7.0))
+    finally:
+        kernels.unregister("ms_deform_attn", "first")
+        kernels.unregister("ms_deform_attn", "second")
+        kernels.clear_cache()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_triton_supported_inputs_skips_item_during_capture(monkeypatch):
+    from libreyolo.kernels.attention.ms_deform_attn_triton import _supported_inputs
+
+    value, shapes, locations, weights = _classic_inputs()
+    value = value.cuda()
+    shapes = shapes.cuda()
+    locations = locations.cuda()
+    weights = weights.cuda()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    assert _supported_inputs(value, shapes, locations, weights)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_triton_rejects_mixed_devices():
+    from libreyolo.kernels.attention.ms_deform_attn_triton import (
+        _supported_inputs,
+        triton_ms_deform_attn,
+    )
+
+    value, shapes, locations, weights = _classic_inputs()
+    value = value.cuda()
+    locations = locations.cuda()
+    weights = weights.cuda()
+    # shapes left on CPU: must not launch.
+    assert not _supported_inputs(value, shapes, locations, weights)
+    assert triton_ms_deform_attn(value, shapes, locations, weights) is None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or importlib.util.find_spec("triton") is None,
+    reason="needs CUDA and Triton",
+)
+def test_triton_disables_after_launch_failure(monkeypatch):
+    from libreyolo.kernels.attention import ms_deform_attn_triton as module
+
+    value, shapes, locations, weights = _classic_inputs()
+    value = value.cuda()
+    shapes = shapes.cuda()
+    locations = locations.cuda()
+    weights = weights.cuda()
+
+    monkeypatch.setattr(module, "_triton_failed", False)
+    calls = []
+
+    class _Boom:
+        def __getitem__(self, _grid):
+            calls.append(1)
+            raise RuntimeError("compile failed")
+
+    monkeypatch.setattr(module, "_kernel", lambda: _Boom())
+    assert module.triton_ms_deform_attn(value, shapes, locations, weights) is None
+    assert module._triton_failed
+    assert module.triton_ms_deform_attn(value, shapes, locations, weights) is None
+    assert calls == [1]

--- a/tests/unit/kernels/test_registry.py
+++ b/tests/unit/kernels/test_registry.py
@@ -53,9 +53,9 @@ def test_env_force_reference(monkeypatch):
 
 
 def test_active_lists_attention_slot(monkeypatch):
-    # The attention provider needs no triton, so the slot registers on any
-    # platform; with hub kernels pinned off it must resolve to nothing.
+    # Both accelerated providers pinned off: the slot must report unavailable.
     monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", "0")
+    monkeypatch.setenv("LIBREYOLO_TRITON_MSDA", "0")
     kernels.clear_cache()
     assert kernels.active().get("ms_deform_attn") == "unavailable"
 


### PR DESCRIPTION
Follow-up to #784 review findings.

- Walk eligible `ms_deform_attn` providers when the preferred Hub impl returns None, so Triton still runs after a Hub reject or disable.
- Clear the resolve cache when Hub or Triton disables itself.
- Skip Triton `spatial_shapes` `.item()` checks while CUDA-graph capturing (warmup already validated the shape).
- Launch Triton on `value.device`.
- Disable Triton after the first compile/launch failure instead of retrying every call.

Verified: 84 unit tests in `tests/unit/kernels/test_ms_deform_attn*.py` and `test_registry.py`.

Not verified: real multi-GPU launch; CUDA-graph capture of a DETR family with Triton active.

## Code provenance

Original fixes to LibreYOLO kernel selection and the in-tree Triton MSDA provider. No third-party code.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves MSDA provider fallback and makes the Triton implementation safer around provider failures, CUDA graph capture, and multi-device launch contexts.
- Walks eligible MSDA providers until one accepts the input.
- Invalidates registry resolution when Hub or Triton disables itself.
- Avoids capture-unsafe tensor readbacks and launches under `value.device`.
- Adds regression coverage for fallback ordering, mixed devices, capture, and one-shot disablement.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking defects identified.

The provider walk preserves portable fallback, cache invalidation follows provider disablement, device consistency is enforced before launch, and current graph-capture callers validate and reuse spatial shapes during warmup.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/kernels/__init__.py | Adds a shared eligibility helper and uncached iterator while preserving the existing resolution and forced-provider semantics. |
| libreyolo/kernels/attention/ms_deform_attn.py | Walks nullable MSDA providers and clears cached resolution when the Hub provider disables itself. |
| libreyolo/kernels/attention/ms_deform_attn_triton.py | Adds same-device validation and launch context, capture-aware checks, and permanent graceful disablement after the first Triton failure. |
| tests/unit/kernels/test_ms_deform_attn.py | Covers provider cascading, mixed-device rejection, capture-safe eligibility, and one-shot Triton failure handling. |
| tests/unit/kernels/test_registry.py | Makes the unavailable-slot assertion deterministic by disabling both accelerated MSDA providers. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Call[maybe_ms_deform_attn] --> Available{Any provider eligible?}
  Available -- No --> Portable[Caller uses portable fallback]
  Available -- Yes --> Provider[Invoke next eligible provider]
  Provider --> Result{Returned output?}
  Result -- Yes --> Output[Return accelerated output]
  Result -- No --> Remaining{Another provider eligible?}
  Remaining -- Yes --> Provider
  Remaining -- No --> Portable
  Provider --> Failure{Compile or launch failure?}
  Failure -- Yes --> Disable[Disable provider and clear resolve cache]
  Disable --> Remaining
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix MSDA Hub-to-Triton fallback, graph c..."](https://github.com/libreyolo/libreyolo/commit/7694615c91a5fb3ea6ecbc396b163b8daa475bb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53520572)</sub>

**Context used:**

- Knowledge Base — [Kernel and quantization runtime](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/kernel-and-quantization.md)

<!-- /greptile_comment -->