### PR TITLE
Add LibreLLM OpenAI-compatible chat client

### DIFF
--- a/docs/adr/0019-librellm-contract.md
+++ b/docs/adr/0019-librellm-contract.md
@@ -1,0 +1,97 @@
+# ADR 0019: LibreLLM Contract For OpenAI-Compatible Chat
+
+- Status: Accepted
+- Date: 2026-08-15
+- Scope: New sibling client (hosted language and vision chat over
+  OpenAI-compatible HTTP APIs)
+
+## Context
+
+LibreYOLO already has `LibreVLM` (ADR 0002) for generative models used as
+open-vocabulary detectors. That contract is `set_classes` plus `predict` /
+`track` returning `Results`.
+
+Hosted chat models do not fit it. They take text, optionally an image, and
+return a provider response object. There are no boxes and no confidence.
+Forcing them through `LibreVLM` would make `predict()` sometimes mean
+"detect" and sometimes mean "chat".
+
+The de-facto ecosystem already published a small LLM interface for this job.
+The public call shape (constructor arguments, `__call__(source, image=)`,
+`async_call`, native SDK response) is the contract users will expect. This
+ADR records that shape. Implementation talks to the official OpenAI Python
+SDK (Apache-2.0) and to that SDK's documented Responses / Chat Completions
+APIs. No third-party CV library source was read.
+
+## Decision
+
+Add `LibreLLM` as a sibling factory, not a `BaseModel` and not a detector.
+
+- `LibreVLM` stays the detector. Image in, `Results` out.
+- `LibreLLM` is the chat client. Text in, optional image, native SDK
+  response out. Vision is an optional `image=` field on the same object
+  because that is how the wire protocol works.
+
+```python
+from libreyolo import LibreLLM, LibreYOLO
+
+llm = LibreLLM("gpt-5.6-luna")
+print(llm("What is YOLO?").output_text)
+
+response = llm("What is happening in this image?", image="bus.jpg")
+
+llm = LibreLLM("gpt-5.6-luna", api="chat.completions")
+print(llm("What is NMS?").choices[0].message.content)
+
+llm = LibreLLM(
+    "provider-model",
+    api="chat.completions",
+    base_url="https://provider.example/v1",
+    api_key="...",
+)
+```
+
+## Public API
+
+| Argument | Default | Meaning |
+|---|---|---|
+| `model` | `"gpt-5.6-luna"` | Identifier sent to the endpoint |
+| `api` | `"responses"` | `"responses"` or `"chat.completions"` |
+| `base_url` | `None` | OpenAI-compatible host |
+| `api_key` | `None` | Else the SDK reads `OPENAI_API_KEY` |
+| `prompt` | `None` | Sticky instruction prepended to plain text and image requests |
+| `**kwargs` | | Default SDK request arguments; per-call values win |
+
+Call rules:
+
+- `source` is text, a native message list, or an image object.
+- A string such as `"bus.jpg"` is text, not an image.
+- `image=` accepts a path, HTTP URL, data URI, NumPy array (OpenCV BGR), or
+  PIL image. Local files and image objects become JPEG data URIs. HTTP URLs
+  and data URIs pass through (the client does not download them).
+- Native message lists are forwarded unchanged and cannot be combined with
+  `image=`.
+- Calling the instance with only a constructor `prompt` sends that prompt.
+- `stream=True` and other SDK request arguments pass through.
+- `async_call` is the async counterpart.
+- Return value is the SDK object (`output_text` on Responses,
+  `choices[0].message.content` on Chat Completions).
+
+Inference only. `train`, `val`, `export`, `track`, and `benchmark` raise
+`NotImplementedError`. There is no CLI verb.
+
+Install extra: `pip install "libreyolo[llm]"`.
+
+## Out of scope
+
+- Remote detection (`set_classes` + boxes). That remains a `LibreVLM`
+  transport if it lands later.
+- Provider-native Gemini / Anthropic transports.
+- Cost estimation, batch APIs, auto-label.
+
+## Consequences
+
+- Users get one OpenAI-compatible client that reaches any host speaking
+  Responses or Chat Completions, including localhost.
+- The detector contract stays honest.
+- The `openai` package is an optional extra, not a core dependency.

--- a/docs/adr/0019-librellm-contract.md
+++ b/docs/adr/0019-librellm-contract.md
@@ -95,3 +95,18 @@ Install extra: `pip install "libreyolo[llm]"`.
   Responses or Chat Completions, including localhost.
 - The detector contract stays honest.
 - The `openai` package is an optional extra, not a core dependency.
+
+## Amendment (2026-08-15): name routing locked
+
+Locked alongside the remote `LibreVLM` transport (ADR 0020):
+
+- Bare model names stay remote model ids forever. There is no closed
+  allowlist of valid provider ids: it could never be maintained, and it
+  would break every newly shipped remote model until a release.
+- The billing-accident protection is a denylist: a bare name matching a
+  `LibreVLM` local alias raises with a pointer to `LibreVLM`. `base_url=`
+  is the escape hatch (the name becomes opaque and is sent there).
+- Optional known `provider/` prefixes (`openai/`, `openrouter/`) strip and
+  supply the provider's default host and env key. Unknown prefixes leave
+  the whole string as the model id (unchanged behavior). The bare form
+  stays primary.

--- a/docs/librellm.md
+++ b/docs/librellm.md
@@ -1,0 +1,137 @@
+# LibreLLM
+
+`LibreLLM` is a small client for language and vision models behind an
+OpenAI-compatible API. It prepares text or image input, forwards request
+arguments to the official OpenAI Python SDK, and returns the SDK's native
+response object.
+
+It is not a detector. For open-vocabulary boxes use `LibreVLM`. For a
+trained detector use `LibreYOLO`.
+
+The default API is `responses`. Use `api="chat.completions"` for providers
+that implement only Chat Completions.
+
+## Install
+
+```bash
+pip install "libreyolo[llm]"
+export OPENAI_API_KEY="your-api-key"
+```
+
+## Responses API
+
+```python
+from libreyolo import LibreLLM
+
+llm = LibreLLM("gpt-5.6-luna")
+response = llm("What is YOLO?")
+print(response.output_text)
+```
+
+### Multimodal input
+
+Pass a path, HTTP URL, data URI, NumPy array, or PIL image through `image`:
+
+```python
+from libreyolo import LibreLLM
+
+llm = LibreLLM("gpt-5.6-luna")
+response = llm("What is happening in this image?", image="bus.jpg")
+print(response.output_text)
+```
+
+A string passed as `source`, such as `llm("bus.jpg")`, is treated as text.
+Use the `image` argument to send an image.
+
+Local files and image objects are encoded as JPEG data URIs. NumPy arrays
+use OpenCV's BGR channel order. HTTP URLs and data URIs are forwarded as-is.
+
+Use `prompt` for an instruction shared by every request:
+
+```python
+llm = LibreLLM("gpt-5.6-luna", prompt="Answer in one sentence.")
+response = llm("Describe this image.", image="bus.jpg")
+```
+
+## Chat Completions
+
+```python
+from libreyolo import LibreLLM
+
+llm = LibreLLM("gpt-5.6-luna", api="chat.completions")
+response = llm("What is non-maximum suppression?")
+print(response.choices[0].message.content)
+```
+
+Pass native message objects when you need conversation history. They are
+forwarded unchanged.
+
+## Streaming and async
+
+```python
+llm = LibreLLM("gpt-5.6-luna")
+for event in llm("Explain object detection.", stream=True):
+    if event.type == "response.output_text.delta":
+        print(event.delta, end="", flush=True)
+```
+
+```python
+import asyncio
+from libreyolo import LibreLLM
+
+llm = LibreLLM("gpt-5.6-luna")
+
+async def main():
+    response = await llm.async_call("What is YOLO?")
+    print(response.output_text)
+
+asyncio.run(main())
+```
+
+## Other OpenAI-compatible hosts
+
+```python
+from libreyolo import LibreLLM
+
+llm = LibreLLM(
+    "provider-model",
+    api="chat.completions",
+    base_url="https://provider.example/v1",
+    api_key="your-api-key",
+)
+response = llm("What tasks does YOLO support?")
+print(response.choices[0].message.content)
+```
+
+The same configuration works with compatible local servers.
+
+## Combine a detector and an LLM
+
+```python
+from libreyolo import LibreLLM, LibreYOLO
+
+yolo = LibreYOLO("LibreYOLO9t.pt")
+llm = LibreLLM("gpt-5.6-luna")
+image = "bus.jpg"
+
+result = yolo(image)
+if any(result.names[int(cls)] == "person" for cls in result.boxes.cls):
+    response = llm("Describe the scene.", image=image)
+    print(response.output_text)
+```
+
+## Constructor
+
+| Argument | Default | Description |
+|---|---|---|
+| `model` | `"gpt-5.6-luna"` | Model identifier sent to the selected endpoint |
+| `api` | `"responses"` | `"responses"` or `"chat.completions"` |
+| `base_url` | `None` | Optional OpenAI-compatible endpoint |
+| `api_key` | `None` | API key; otherwise the SDK reads `OPENAI_API_KEY` |
+| `prompt` | `None` | Instruction prepended to plain text and image requests |
+| `**kwargs` | | Default SDK request arguments; per-call arguments override matching constructor values |
+
+`LibreLLM` is inference-only and is not exposed through the `libreyolo` CLI.
+`train`, `val`, `export`, `track`, and `benchmark` raise.
+
+See [`adr/0019-librellm-contract.md`](adr/0019-librellm-contract.md).

--- a/docs/librellm.md
+++ b/docs/librellm.md
@@ -105,6 +105,34 @@ print(response.choices[0].message.content)
 
 The same configuration works with compatible local servers.
 
+## Provider prefixes and model-name routing
+
+Bare model names are remote model ids, sent to the configured (or default
+OpenAI) host. That namespace stays open on purpose: a model that ships
+tomorrow works today, with no libreyolo release in between.
+
+Two refinements on top of the bare form:
+
+- An optional `provider/` prefix supplies that provider's default host and
+  env key, for symmetry with `LibreVLM`. Known prefixes: `openai/` (strip,
+  default host, `OPENAI_API_KEY`) and `openrouter/` (strip,
+  `https://openrouter.ai/api/v1`, `OPENROUTER_API_KEY`). An unknown prefix
+  is not an error; the whole string stays the model id (OpenRouter slugs
+  like `"qwen/qwen3-max"` keep working against an explicit `base_url=`).
+
+```python
+LibreLLM("gpt-5.6-luna")                 # bare form, primary
+LibreLLM("openai/gpt-5.6-luna")          # synonym for the line above
+LibreLLM("openrouter/qwen/qwen3-max")    # host + key from the prefix
+```
+
+- A bare name that matches a `LibreVLM` local alias (e.g.
+  `"qwen3-vl-4b"`) raises instead of silently billing the default host for
+  a 404: that string names a local detector, not a hosted chat model. Pass
+  `base_url=` if you really run a hosted model under that exact id. This is
+  a denylist against the (small, disjoint) VLM alias table, not an
+  allowlist of valid provider ids.
+
 ## Combine a detector and an LLM
 
 ```python

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -172,6 +172,11 @@ These models are discriminative text-conditioned detectors with calibrated
 scores; they are not VLMs. Upstream brand casing is intentionally preserved.
 See [`openvocab_design.md`](openvocab_design.md).
 
+`LibreLLM` is a fourth sibling: an OpenAI-compatible chat client with no
+weights, no `FILENAME_PREFIX`, and no `Results`. It is not registered in the
+detector factory. See [`librellm.md`](librellm.md) and
+[`adr/0019-librellm-contract.md`](adr/0019-librellm-contract.md).
+
 ## Size codes
 
 Sizes are family-specific. The table below records what each family currently

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -186,6 +186,7 @@ def __getattr__(name):
         "TrackConfig": (".tracking", "TrackConfig"),
         "OCSortTracker": (".tracking", "OCSortTracker"),
         "OCSortConfig": (".tracking", "OCSortConfig"),
+        "LibreLLM": (".models.llm", "LibreLLM"),
         "LibreVLM": (".models.vlm", "LibreVLM"),
         "LibreLFM2VL": (".models.vlm", "LibreLFM2VL"),
         "LibreQwen3VL": (".models.vlm", "LibreQwen3VL"),
@@ -326,6 +327,8 @@ __all__ = [
     "LibreNorthMicroVision",
     "LibreMODUS",
     "LibreModus",
+    # OpenAI-compatible LLM client (optional, requires libreyolo[llm])
+    "LibreLLM",
     # Promptable-segmentation tier (optional, requires libreyolo[sam])
     "LibreSAM",
     "LibreSAM1",

--- a/libreyolo/models/llm/__init__.py
+++ b/libreyolo/models/llm/__init__.py
@@ -1,0 +1,17 @@
+"""LibreLLM: OpenAI-compatible language and vision chat client.
+
+This is not a detector. It forwards text (and optional images) to an
+OpenAI-compatible Responses or Chat Completions endpoint and returns the
+SDK's native response object. Detection stays on ``LibreVLM`` / ``LibreYOLO``.
+
+    from libreyolo import LibreLLM
+
+    llm = LibreLLM("gpt-5.6-luna")
+    print(llm("What is YOLO?").output_text)
+
+See ``docs/librellm.md`` and ``docs/adr/0019-librellm-contract.md``.
+"""
+
+from .client import LibreLLM
+
+__all__ = ["LibreLLM"]

--- a/libreyolo/models/llm/client.py
+++ b/libreyolo/models/llm/client.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import base64
 import io
+import os
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -30,6 +31,48 @@ _UNSUPPORTED = (
 )
 _DATA_URI_PREFIX = "data:"
 _HTTP_PREFIXES = ("http://", "https://")
+
+# Optional ``provider/`` prefixes, for symmetry with ``LibreVLM``. The bare
+# form (``LibreLLM("gpt-5.6-luna")``) stays primary and is never deprecated.
+# A known prefix is stripped and supplies the provider's default host and env
+# key; anything else is an opaque model id sent to the configured host.
+_KNOWN_PROVIDERS: dict[str, tuple[Optional[str], str]] = {
+    # prefix -> (default base_url, env key)
+    "openai": (None, "OPENAI_API_KEY"),
+    "openrouter": ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"),
+}
+
+
+def _resolve_provider(model: str) -> tuple[str, Optional[str], Optional[str]]:
+    """Strip a known ``provider/`` prefix from *model*.
+
+    Returns ``(model_id, default_base_url, env_key)``. Splits on the first
+    slash only, before lowercasing, so case-sensitive provider model ids
+    survive. An unknown prefix leaves the whole string as the model id
+    (current behavior; OpenRouter slugs like ``qwen/qwen3-max`` keep working
+    against an explicit ``base_url=``).
+    """
+    if "/" in model:
+        prefix, rest = model.split("/", 1)
+        known = _KNOWN_PROVIDERS.get(prefix.lower())
+        if known is not None:
+            return rest, known[0], known[1]
+    return model, None, None
+
+
+def _is_vlm_alias(model: str) -> bool:
+    """True when *model* is a ``LibreVLM`` local alias (detector, not chat).
+
+    The bare-name namespace stays open (a hosted model that ships tomorrow
+    must work today), so protection against billing accidents is this small
+    denylist against the disjoint VLM alias table, never a closed allowlist.
+    """
+    try:
+        from ..vlm import _ALIASES, _LAZY_ALIASES, _MODUS_ALIASES
+    except Exception:  # pragma: no cover - torch-less or partial installs
+        return False
+    key = model.strip().lower()
+    return key in _ALIASES or key in _LAZY_ALIASES or key in _MODUS_ALIASES
 
 
 def _load_openai():
@@ -138,7 +181,28 @@ class LibreLLM:
             raise ValueError(
                 f"api must be one of {_SUPPORTED_APIS}, got {api!r}"
             )
-        self.model = str(model)
+        model_id, provider_base_url, provider_env_key = _resolve_provider(str(model))
+        if base_url is None and "/" not in str(model) and _is_vlm_alias(model_id):
+            raise ValueError(
+                f"{model_id!r} is a LibreVLM local alias (a detector), not a "
+                "hosted model id.\n"
+                f"  detector: LibreVLM({model_id!r})\n"
+                "  really a hosted model with this exact id: pass base_url= "
+                "to send it there"
+            )
+        if base_url is None:
+            base_url = provider_base_url
+        if api_key is None and provider_env_key is not None:
+            # Resolved explicitly so a non-OpenAI prefix never silently bills
+            # whatever OPENAI_API_KEY happens to point at.
+            api_key = os.environ.get(provider_env_key)
+            if api_key is None and provider_env_key != "OPENAI_API_KEY":
+                raise ValueError(
+                    f"Model {model!r} uses a provider prefix whose key is "
+                    f"read from {provider_env_key}, which is not set. Set it "
+                    "or pass api_key=."
+                )
+        self.model = model_id
         self.api = api
         self.base_url = base_url
         self.api_key = api_key

--- a/libreyolo/models/llm/client.py
+++ b/libreyolo/models/llm/client.py
@@ -1,0 +1,284 @@
+"""OpenAI-compatible LibreLLM client.
+
+Implements the de-facto ecosystem LLM call shape from public documentation:
+constructor ``(model, api=, base_url=, api_key=, prompt=, **kwargs)``,
+``__call__(source, image=)``, ``async_call``, native SDK response out.
+
+The official OpenAI Python SDK is Apache-2.0. This module talks to that
+public API. It does not wrap provider-specific response types.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import numpy as np
+from PIL import Image, ImageOps
+
+_DEFAULT_MODEL = "gpt-5.6-luna"
+_SUPPORTED_APIS = ("responses", "chat.completions")
+_INSTALL_HINT = (
+    "LibreLLM requires the 'llm' extra. Install with:\n"
+    "    pip install 'libreyolo[llm]'"
+)
+_UNSUPPORTED = (
+    "LibreLLM is inference-only. Use LibreYOLO for train, val, export, "
+    "track, and benchmark."
+)
+_DATA_URI_PREFIX = "data:"
+_HTTP_PREFIXES = ("http://", "https://")
+
+
+def _load_openai():
+    try:
+        import openai
+    except ImportError as exc:
+        raise ImportError(_INSTALL_HINT) from exc
+    return openai
+
+
+def _data_uri(jpeg_bytes: bytes) -> str:
+    encoded = base64.standard_b64encode(jpeg_bytes).decode("ascii")
+    return f"data:image/jpeg;base64,{encoded}"
+
+
+def _encode_pil(img: Image.Image) -> str:
+    transposed = ImageOps.exif_transpose(img)
+    if transposed is not None:
+        img = transposed
+    if img.mode != "RGB":
+        img = img.convert("RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=95)
+    return _data_uri(buf.getvalue())
+
+
+def _encode_path(path: str) -> str:
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise FileNotFoundError(f"Image file not found: {path}")
+    with Image.open(file_path) as img:
+        return _encode_pil(img)
+
+
+def _encode_bgr_numpy(arr: np.ndarray) -> str:
+    """Encode an OpenCV-style BGR (or gray) array as a JPEG data URI."""
+    import cv2
+
+    image = np.ascontiguousarray(arr)
+    if image.ndim == 3 and image.shape[0] in (1, 3, 4) and image.shape[0] < image.shape[2]:
+        image = np.transpose(image, (1, 2, 0))
+    if image.dtype != np.uint8:
+        if np.issubdtype(image.dtype, np.floating) and float(np.max(image)) <= 1.0:
+            image = (image * 255.0).clip(0, 255).astype(np.uint8)
+        else:
+            image = image.clip(0, 255).astype(np.uint8)
+    ok, buf = cv2.imencode(".jpg", image)
+    if not ok:
+        raise ValueError("Failed to encode NumPy image as JPEG")
+    return _data_uri(buf.tobytes())
+
+
+def _is_image_object(value: Any) -> bool:
+    return isinstance(value, (Image.Image, np.ndarray, Path))
+
+
+def _as_image_url(value: Any) -> str:
+    if isinstance(value, str):
+        if value.startswith(_HTTP_PREFIXES) or value.startswith(_DATA_URI_PREFIX):
+            return value
+        return _encode_path(value)
+    if isinstance(value, Path):
+        return _encode_path(str(value))
+    if isinstance(value, Image.Image):
+        return _encode_pil(value)
+    if isinstance(value, np.ndarray):
+        return _encode_bgr_numpy(value)
+    raise TypeError(
+        "image must be a path, HTTP URL, data URI, NumPy array, or PIL image, "
+        f"got {type(value).__name__}"
+    )
+
+
+def _compose_text(prompt: Optional[str], source_text: Optional[str]) -> Optional[str]:
+    if prompt and source_text:
+        return f"{prompt}\n{source_text}"
+    return source_text or prompt
+
+
+class LibreLLM:
+    """OpenAI-compatible language and vision chat client.
+
+    Args:
+        model: Model identifier sent to the selected endpoint.
+        api: ``"responses"`` (default) or ``"chat.completions"``.
+        base_url: Optional OpenAI-compatible endpoint.
+        api_key: API key; otherwise the SDK reads ``OPENAI_API_KEY``.
+        prompt: Instruction prepended to plain text and image requests.
+        **kwargs: Default SDK request arguments. Per-call arguments override
+            matching constructor values.
+    """
+
+    def __init__(
+        self,
+        model: str = _DEFAULT_MODEL,
+        *,
+        api: str = "responses",
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        prompt: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        if not str(model).strip():
+            raise ValueError("model must be a non-empty string")
+        if api not in _SUPPORTED_APIS:
+            raise ValueError(
+                f"api must be one of {_SUPPORTED_APIS}, got {api!r}"
+            )
+        self.model = str(model)
+        self.api = api
+        self.base_url = base_url
+        self.api_key = api_key
+        self.prompt = prompt
+        self.defaults = dict(kwargs)
+        self._sync = None
+        self._async = None
+
+    def _client_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        if self.api_key is not None:
+            kwargs["api_key"] = self.api_key
+        if self.base_url is not None:
+            kwargs["base_url"] = self.base_url
+        return kwargs
+
+    def _make_sync_client(self):
+        return _load_openai().OpenAI(**self._client_kwargs())
+
+    def _make_async_client(self):
+        return _load_openai().AsyncOpenAI(**self._client_kwargs())
+
+    def _sync_client(self):
+        if self._sync is None:
+            self._sync = self._make_sync_client()
+        return self._sync
+
+    def _async_client(self):
+        if self._async is None:
+            self._async = self._make_async_client()
+        return self._async
+
+    def _prepare(
+        self,
+        source: Any,
+        image: Any,
+    ) -> Union[str, list]:
+        if isinstance(source, list):
+            if image is not None:
+                raise ValueError(
+                    "image= cannot be combined with a native message list; "
+                    "put the image in the messages or pass text as source"
+                )
+            return source
+
+        image_url = None
+        source_text: Optional[str] = None
+
+        if _is_image_object(source):
+            if image is not None:
+                raise ValueError(
+                    "pass the image as source or as image=, not both"
+                )
+            image_url = _as_image_url(source)
+        elif source is None:
+            pass
+        elif isinstance(source, str):
+            source_text = source
+        else:
+            raise TypeError(
+                "source must be text, a native message list, or an image "
+                f"object, got {type(source).__name__}"
+            )
+
+        if image is not None:
+            image_url = _as_image_url(image)
+
+        text = _compose_text(self.prompt, source_text)
+        if text is None and image_url is None:
+            raise ValueError(
+                "LibreLLM() needs a source, image, or a constructor prompt"
+            )
+        return self._build_payload(text, image_url)
+
+    def _build_payload(
+        self, text: Optional[str], image_url: Optional[str]
+    ) -> Union[str, list]:
+        if self.api == "responses":
+            if image_url is None:
+                return text
+            content: list[dict[str, Any]] = []
+            if text:
+                content.append({"type": "input_text", "text": text})
+            content.append({"type": "input_image", "image_url": image_url})
+            return [{"role": "user", "content": content}]
+
+        if image_url is None:
+            return [{"role": "user", "content": text}]
+        content = []
+        if text:
+            content.append({"type": "text", "text": text})
+        content.append(
+            {"type": "image_url", "image_url": {"url": image_url}}
+        )
+        return [{"role": "user", "content": content}]
+
+    def _request_body(self, prepared: Union[str, list], kwargs: dict[str, Any]) -> dict[str, Any]:
+        body = {**self.defaults, **kwargs}
+        body["model"] = self.model
+        if self.api == "responses":
+            body["input"] = prepared
+        else:
+            body["messages"] = prepared
+        return body
+
+    def __call__(self, source: Any = None, /, *, image: Any = None, **kwargs: Any):
+        """Send one request. ``source`` is text, a message list, or an image.
+
+        A string such as ``"bus.jpg"`` is treated as text. Pass the image
+        through ``image=``. Returns the SDK's native response object.
+        """
+        prepared = self._prepare(source, image)
+        body = self._request_body(prepared, kwargs)
+        client = self._sync_client()
+        if self.api == "responses":
+            return client.responses.create(**body)
+        return client.chat.completions.create(**body)
+
+    async def async_call(
+        self, source: Any = None, /, *, image: Any = None, **kwargs: Any
+    ):
+        """Async counterpart of ``__call__``."""
+        prepared = self._prepare(source, image)
+        body = self._request_body(prepared, kwargs)
+        client = self._async_client()
+        if self.api == "responses":
+            return await client.responses.create(**body)
+        return await client.chat.completions.create(**body)
+
+    def train(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(_UNSUPPORTED)
+
+    def val(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(_UNSUPPORTED)
+
+    def export(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(_UNSUPPORTED)
+
+    def track(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(_UNSUPPORTED)
+
+    def benchmark(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(_UNSUPPORTED)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ fast-eval = [
     # platform without one must not be able to break a plain `pip install`.
     "faster-coco-eval>=1.7.0",
 ]
+llm = [
+    # LibreLLM talks to OpenAI-compatible Responses / Chat Completions
+    # endpoints through the official Apache-2.0 OpenAI Python SDK.
+    "openai>=1.66.0",
+]
 vlm = [
     # VLM-as-detector families load through transformers.
     # huggingface_hub (used for snapshot download) ships with transformers.
@@ -295,6 +300,7 @@ all = [
     "libreyolo[siglip2]",
     "libreyolo[coreml]",
     "libreyolo[vlm]",
+    "libreyolo[llm]",
     "libreyolo[sam]",
     "libreyolo[label]",
     "libreyolo[openvocab]",
@@ -507,6 +513,7 @@ markers = [
     "alexnet: tests covering the LibreAlexNet image-classification family",
     "vgg: tests covering the LibreVGG classification family",
     "vlm: tests covering the LibreVLM (VLM-as-detector) tier",
+    "llm: tests covering the LibreLLM OpenAI-compatible client",
     "sam: tests covering the LibreSAM (promptable-segmentation) tier",
     "openvocab: tests covering the LibreOpenVocab detector tier",
     "sensenova: tests covering the LibreSenseNovaVision unified multimodal family",

--- a/tests/smoke/install_surface.py
+++ b/tests/smoke/install_surface.py
@@ -122,6 +122,14 @@ def _check_import_surface(expect_source: str, source_root: Path | None) -> None:
     if LibreModus is not LibreMODUS:
         raise AssertionError("LibreModus compatibility alias did not resolve correctly")
 
+    # LibreLLM is a lazy extra: importing the class must not require openai.
+    from libreyolo import LibreLLM
+
+    if not isinstance(LibreLLM, type):
+        raise AssertionError(
+            f"LibreLLM import did not resolve to a class: {LibreLLM!r}"
+        )
+
     # The open-vocabulary detector tier follows the same lazy-import rule.
     from libreyolo import (
         LibreGroundingDINO,

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,0 +1,338 @@
+"""Unit tests for LibreLLM (offline; the OpenAI SDK is never called)."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from libreyolo.models.llm.client import LibreLLM, _load_openai
+
+pytestmark = [pytest.mark.unit, pytest.mark.llm]
+
+
+class FakeResponses:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if kwargs.get("stream"):
+            return iter(
+                [
+                    SimpleNamespace(
+                        type="response.output_text.delta",
+                        delta="Hello",
+                    )
+                ]
+            )
+        return SimpleNamespace(output_text="ok")
+
+
+class FakeCompletions:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="chat-ok"))]
+        )
+
+
+class FakeClient:
+    def __init__(self):
+        self.responses = FakeResponses()
+        self.chat = SimpleNamespace(completions=FakeCompletions())
+
+
+class FakeAsyncResponses:
+    def __init__(self):
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(output_text="async-ok")
+
+
+class FakeAsyncCompletions:
+    def __init__(self):
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="async-chat"))]
+        )
+
+
+class FakeAsyncClient:
+    def __init__(self):
+        self.responses = FakeAsyncResponses()
+        self.chat = SimpleNamespace(completions=FakeAsyncCompletions())
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(LibreLLM, "_make_sync_client", lambda self: client)
+    return client
+
+
+@pytest.fixture
+def rgb_jpeg(tmp_path):
+    path = tmp_path / "red.jpg"
+    Image.new("RGB", (4, 4), color=(255, 0, 0)).save(path, format="JPEG")
+    return path
+
+
+def test_default_model_and_api(fake_client):
+    llm = LibreLLM()
+    response = llm("What is YOLO?")
+    assert response.output_text == "ok"
+    call = fake_client.responses.calls[0]
+    assert call["model"] == "gpt-5.6-luna"
+    assert call["input"] == "What is YOLO?"
+
+
+def test_chat_completions_text(fake_client):
+    llm = LibreLLM("gpt-5.6-luna", api="chat.completions")
+    response = llm("What is non-maximum suppression?")
+    assert response.choices[0].message.content == "chat-ok"
+    call = fake_client.chat.completions.calls[0]
+    assert call["messages"] == [
+        {"role": "user", "content": "What is non-maximum suppression?"}
+    ]
+    assert fake_client.responses.calls == []
+
+
+def test_string_source_is_text_not_image(fake_client):
+    llm = LibreLLM()
+    llm("bus.jpg")
+    assert fake_client.responses.calls[0]["input"] == "bus.jpg"
+
+
+def test_constructor_prompt_prepended(fake_client):
+    llm = LibreLLM(prompt="Answer in one sentence.")
+    llm("Describe this image.")
+    assert fake_client.responses.calls[0]["input"] == (
+        "Answer in one sentence.\nDescribe this image."
+    )
+
+
+def test_prompt_only_call(fake_client):
+    llm = LibreLLM(prompt="Answer in one sentence.")
+    llm()
+    assert fake_client.responses.calls[0]["input"] == "Answer in one sentence."
+
+
+def test_empty_call_without_prompt_raises(fake_client):
+    llm = LibreLLM()
+    with pytest.raises(ValueError, match="source, image, or a constructor prompt"):
+        llm()
+
+
+def test_unknown_api_raises():
+    with pytest.raises(ValueError, match="api must be"):
+        LibreLLM(api="legacy")
+
+
+def test_empty_model_raises():
+    with pytest.raises(ValueError, match="non-empty"):
+        LibreLLM("   ")
+
+
+def test_http_image_is_passed_through(fake_client):
+    url = "https://example.com/bus.jpg"
+    llm = LibreLLM()
+    llm("What is happening in this image?", image=url)
+    payload = fake_client.responses.calls[0]["input"]
+    assert payload[0]["role"] == "user"
+    content = payload[0]["content"]
+    assert content[0] == {
+        "type": "input_text",
+        "text": "What is happening in this image?",
+    }
+    assert content[1] == {"type": "input_image", "image_url": url}
+
+
+def test_data_uri_image_is_passed_through(fake_client):
+    uri = "data:image/jpeg;base64,AAAA"
+    llm = LibreLLM()
+    llm("look", image=uri)
+    content = fake_client.responses.calls[0]["input"][0]["content"]
+    assert content[1]["image_url"] == uri
+
+
+def test_local_file_becomes_jpeg_data_uri(fake_client, rgb_jpeg):
+    llm = LibreLLM()
+    llm("Describe this image.", image=str(rgb_jpeg))
+    content = fake_client.responses.calls[0]["input"][0]["content"]
+    image_url = content[1]["image_url"]
+    assert image_url.startswith("data:image/jpeg;base64,")
+    raw = base64.standard_b64decode(image_url.split(",", 1)[1])
+    assert raw[:2] == b"\xff\xd8"
+
+
+def test_pil_image_as_source(fake_client):
+    llm = LibreLLM(prompt="Caption.")
+    llm(Image.new("RGB", (2, 2), color=(0, 255, 0)))
+    content = fake_client.responses.calls[0]["input"][0]["content"]
+    assert content[0]["text"] == "Caption."
+    assert content[1]["type"] == "input_image"
+    assert content[1]["image_url"].startswith("data:image/jpeg;base64,")
+
+
+def test_numpy_bgr_encodes_as_jpeg(fake_client):
+    # OpenCV order: blue square.
+    arr = np.zeros((3, 3, 3), dtype=np.uint8)
+    arr[..., 0] = 255
+    llm = LibreLLM()
+    llm("color?", image=arr)
+    image_url = fake_client.responses.calls[0]["input"][0]["content"][1]["image_url"]
+    assert image_url.startswith("data:image/jpeg;base64,")
+
+
+def test_chat_completions_image_shape(fake_client, rgb_jpeg):
+    llm = LibreLLM(api="chat.completions")
+    llm("Describe this image.", image=str(rgb_jpeg))
+    messages = fake_client.chat.completions.calls[0]["messages"]
+    content = messages[0]["content"]
+    assert content[0] == {"type": "text", "text": "Describe this image."}
+    assert content[1]["type"] == "image_url"
+    assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_native_messages_pass_through(fake_client):
+    messages = [
+        {"role": "system", "content": "Be brief."},
+        {"role": "user", "content": "What tasks does YOLO support?"},
+    ]
+    llm = LibreLLM()
+    llm(messages)
+    assert fake_client.responses.calls[0]["input"] is messages
+
+
+def test_native_messages_reject_image_kwarg(fake_client):
+    llm = LibreLLM()
+    with pytest.raises(ValueError, match="native message list"):
+        llm([{"role": "user", "content": "hi"}], image="bus.jpg")
+
+
+def test_kwargs_merge_per_call_wins(fake_client):
+    llm = LibreLLM(temperature=0.1, max_output_tokens=16)
+    llm("hi", temperature=0.7)
+    call = fake_client.responses.calls[0]
+    assert call["temperature"] == 0.7
+    assert call["max_output_tokens"] == 16
+    assert call["model"] == "gpt-5.6-luna"
+
+
+def test_stream_passthrough(fake_client):
+    llm = LibreLLM()
+    events = list(llm("Explain object detection.", stream=True))
+    assert events[0].type == "response.output_text.delta"
+    assert events[0].delta == "Hello"
+    assert fake_client.responses.calls[0]["stream"] is True
+
+
+def test_async_call(monkeypatch):
+    client = FakeAsyncClient()
+    monkeypatch.setattr(LibreLLM, "_make_async_client", lambda self: client)
+    llm = LibreLLM()
+
+    async def run():
+        return await llm.async_call("What is YOLO?")
+
+    response = asyncio.run(run())
+    assert response.output_text == "async-ok"
+    assert client.responses.calls[0]["input"] == "What is YOLO?"
+
+
+def test_async_chat_completions(monkeypatch):
+    client = FakeAsyncClient()
+    monkeypatch.setattr(LibreLLM, "_make_async_client", lambda self: client)
+    llm = LibreLLM(api="chat.completions")
+
+    async def run():
+        return await llm.async_call("hi")
+
+    response = asyncio.run(run())
+    assert response.choices[0].message.content == "async-chat"
+
+
+def test_client_kwargs_include_base_url_and_key(monkeypatch):
+    seen = {}
+
+    class Recording:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+            self.responses = FakeResponses()
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(
+        "libreyolo.models.llm.client._load_openai",
+        lambda: SimpleNamespace(OpenAI=Recording, AsyncOpenAI=Recording),
+    )
+    llm = LibreLLM(
+        "provider-model",
+        api="chat.completions",
+        base_url="https://provider.example/v1",
+        api_key="secret",
+    )
+    llm("What tasks does YOLO support?")
+    assert seen == {
+        "api_key": "secret",
+        "base_url": "https://provider.example/v1",
+    }
+
+
+def test_missing_extra_hint(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name == "openai" or name.startswith("openai."):
+            raise ImportError("forced")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+    with pytest.raises(ImportError, match="libreyolo\\[llm\\]"):
+        _load_openai()
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["train", "val", "export", "track", "benchmark"],
+)
+def test_cv_verbs_raise(method):
+    llm = LibreLLM()
+    with pytest.raises(NotImplementedError, match="inference-only"):
+        getattr(llm, method)()
+
+
+def test_public_import_does_not_need_openai():
+    from libreyolo import LibreLLM as Exported
+
+    assert Exported is LibreLLM
+    instance = Exported("gpt-5.6-luna")
+    assert instance.api == "responses"
+
+
+def test_missing_local_image_raises(fake_client, tmp_path):
+    llm = LibreLLM()
+    missing = tmp_path / "nope.jpg"
+    with pytest.raises(FileNotFoundError):
+        llm("look", image=str(missing))
+
+
+def test_source_and_image_objects_conflict(fake_client, rgb_jpeg):
+    llm = LibreLLM()
+    with pytest.raises(ValueError, match="not both"):
+        llm(Path(rgb_jpeg), image=str(rgb_jpeg))

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -325,6 +325,55 @@ def test_public_import_does_not_need_openai():
     assert instance.api == "responses"
 
 
+def test_vlm_alias_denylist_raises():
+    with pytest.raises(ValueError, match="LibreVLM local alias"):
+        LibreLLM("qwen3-vl-4b")
+
+
+def test_vlm_alias_allowed_with_base_url(fake_client):
+    llm = LibreLLM("qwen3-vl-4b", base_url="http://localhost:8000/v1")
+    assert llm.model == "qwen3-vl-4b"
+    assert llm.base_url == "http://localhost:8000/v1"
+
+
+def test_openai_prefix_strips_to_bare_model(fake_client):
+    llm = LibreLLM("openai/gpt-5.6-luna")
+    llm("hi")
+    assert fake_client.responses.calls[0]["model"] == "gpt-5.6-luna"
+    assert llm.base_url is None
+
+
+def test_openrouter_prefix_sets_host_and_env_key(monkeypatch, fake_client):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    llm = LibreLLM("openrouter/qwen/qwen3-max")
+    assert llm.model == "qwen/qwen3-max"
+    assert llm.base_url == "https://openrouter.ai/api/v1"
+    assert llm.api_key == "or-key"
+
+
+def test_openrouter_prefix_without_key_raises(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+        LibreLLM("openrouter/qwen/qwen3-max")
+
+
+def test_unknown_prefix_stays_whole_model_id(fake_client):
+    llm = LibreLLM("qwen/qwen3-max", base_url="https://openrouter.ai/api/v1")
+    llm("hi")
+    assert fake_client.responses.calls[0]["model"] == "qwen/qwen3-max"
+
+
+def test_explicit_base_url_wins_over_prefix_default(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    llm = LibreLLM("openrouter/qwen/qwen3-max", base_url="http://proxy.local/v1")
+    assert llm.base_url == "http://proxy.local/v1"
+
+
+def test_prefix_model_id_case_preserved(fake_client):
+    llm = LibreLLM("openai/GPT-5.6-Luna")
+    assert llm.model == "GPT-5.6-Luna"
+
+
 def test_missing_local_image_raises(fake_client, tmp_path):
     llm = LibreLLM()
     missing = tmp_path / "nope.jpg"


### PR DESCRIPTION
## What

- New `LibreLLM` factory: thin OpenAI-compatible chat client (ADR 0019)
- `responses` (default) + `chat.completions`, any `base_url`, native SDK objects out
- `image=` path/URL/data-URI/NumPy/PIL -> JPEG data URI; string source is text, not a file
- `stream=True` + `async_call`; `train/val/export/track/benchmark` raise; no CLI
- New extra `libreyolo[llm]`; import stays lazy, openai loads on first call
- Name routing: optional `openai/` + `openrouter/` prefixes set host + env key; bare names stay remote ids; bare name matching a LibreVLM alias raises (denylist, `base_url=` escape hatch)
- 38 offline unit tests at the SDK boundary; docs page + ADR 0019

## Not in this PR

- Remote LibreVLM detect: stacked on top in the `librevlm-remote` branch PR
- Live smoke against a real key: manual step before merge, one call

## Code provenance

Written from scratch for this PR. Talks to the official OpenAI Python SDK (Apache-2.0) as an optional dependency; no SDK or third-party code copied. The constructor/call shape follows publicly documented ecosystem conventions, implemented independently.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

LibreLLM adds a lazily imported, OpenAI-compatible client for text and vision requests without integrating it into the detector or CLI lifecycle.
- Supports Responses and Chat Completions, synchronous and asynchronous calls, streaming passthrough, native message lists, and image conversion.
- Adds provider-prefix routing, LibreVLM-alias protection, an optional `llm` dependency extra, public documentation, an ADR, and offline SDK-boundary tests.
- Preserves the OpenAI SDK’s native response objects and delegates optional request controls through constructor and per-call keyword arguments.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no concrete changed-code failure remains after evaluating the reachable request, credential-routing, and optional-dependency paths.

The new client consistently implements its documented thin-transport contract, keeps the OpenAI dependency lazy, preserves explicit host and provider routing, and exercises the principal payload and lifecycle paths with offline tests.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/llm/client.py | Implements provider routing, lazy SDK clients, text/image payload construction, synchronous and asynchronous requests, and inference-only lifecycle guards; no actionable defect was established. |
| libreyolo/__init__.py | Adds LibreLLM to the package’s lazy public import surface without eagerly importing the optional OpenAI SDK. |
| pyproject.toml | Adds the OpenAI SDK as an optional `llm` extra and includes it in the aggregate installation extra. |
| tests/unit/test_llm.py | Provides broad offline coverage for request shapes, image encoding, async and streaming behavior, provider routing, lazy dependency loading, and unsupported operations. |
| docs/librellm.md | Documents installation, both supported API styles, multimodal inputs, streaming, async usage, custom hosts, and model-name routing. |
| docs/adr/0019-librellm-contract.md | Defines LibreLLM as a chat-client sibling rather than a detector and records its public request, routing, and return-value contracts. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    User[Application] --> LibreLLM[LibreLLM]
    LibreLLM --> Prepare{Prepare input}
    Prepare -->|Text or native messages| Payload[Responses or Chat payload]
    Prepare -->|Path, PIL, or NumPy image| Encode[JPEG data URI]
    Prepare -->|HTTP URL or data URI| Payload
    Encode --> Payload
    Payload --> Client{Sync or async SDK client}
    Client --> Responses[responses.create]
    Client --> Chat[chat.completions.create]
    Responses --> Native[Native SDK response or stream]
    Chat --> Native
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Route LibreLLM names: provider prefixes ..."](https://github.com/libreyolo/libreyolo/commit/46648ddf805005c5d01f4a3b15f31bbc9733f93f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53524650)</sub>

<!-- /greptile_comment -->