### PR TITLE
Add remote LibreVLM transport (provider/model-id)

### DIFF
--- a/docs/adr/0002-librevlm-contract.md
+++ b/docs/adr/0002-librevlm-contract.md
@@ -3,6 +3,9 @@
 - Status: Accepted
 - Date: 2026-06-05 (updated 2026-06-06)
 - Scope: New model tier (vision-language models used as open-vocab detectors)
+- Extended by ADR 0020 (2026-08-15): the same contract over an
+  OpenAI-compatible remote transport (`LibreVLM("provider/model-id")`).
+  The contract in this document is unchanged; remote is a new backend.
 
 ## Context
 

--- a/docs/adr/0020-librevlm-remote-transport.md
+++ b/docs/adr/0020-librevlm-remote-transport.md
@@ -1,0 +1,115 @@
+# ADR 0020: Remote transport for LibreVLM
+
+Status: accepted
+Date: 2026-08-15
+
+## Context
+
+`LibreVLM` (ADR 0002) runs local vision-language models as open-vocabulary
+detectors. `LibreLLM` (ADR 0019) is an OpenAI-compatible chat client. Hosted
+vision chat models (OpenAI, OpenRouter, any vLLM/Ollama-style compat host)
+can also emit boxes when prompted, which makes them useful as an explore /
+auto-label ramp before training a real detector.
+
+The question was where hosted detection lives: a third factory
+(`LibreAPI`), a chat method that sometimes returns boxes, or a new
+transport behind the existing detector contract.
+
+## Decision
+
+Factories follow contract, not where the weights live. Detect vs chat is
+the product; local vs API is a backend. Two factories, no third:
+
+- `LibreVLM` gains an OpenAI-compatible remote transport. Same contract as
+  local: sticky `set_classes`, `predict()` returning pixel-xyxy `Results`
+  on images/lists/folders/video files, `chat(image, prompt) -> str` as the
+  raw escape hatch, soft confidence 1.0.
+- `LibreLLM` stays the chat client (native SDK objects, streaming, async).
+  It never grows `predict()`/`set_classes()`; `LibreVLM.chat()` never grows
+  streaming or SDK returns.
+
+### Routing grammar
+
+A slash means remote; a bare alias stays local; no local alias will ever
+contain a slash. Evaluate in order: existing path (checkpoint), path-shaped
+string (never a provider; `FileNotFoundError` with the resolved absolute
+path), first-slash provider split (before lowercasing, so case-sensitive
+model ids survive), bare alias table. The unknown-provider error names the
+known providers, the `openai-compat/` + `base_url=` escape, the local
+aliases (HF repo ids are not accepted), and the resolved path that does not
+exist, because those are the three things a failing string could have meant.
+
+v1 providers: `openai` (SDK default host, `OPENAI_API_KEY`), `openrouter`
+(`https://openrouter.ai/api/v1`, `OPENROUTER_API_KEY`), `openai-compat`
+(required `base_url=`). The model id after the first slash passes through
+verbatim: a model that ships tomorrow works today; the provider's 404 is
+the miss signal, not our alias table.
+
+### Wire API defaults (deliberate asymmetry)
+
+| | default `api` | why |
+|---|---|---|
+| `LibreVLM` remote | `chat.completions` | the format every compat host speaks |
+| `LibreLLM` | `responses` | the ecosystem chat-client shape we copied |
+
+`LibreVLM` also requires the `openai-compat/` prefix for self-hosted
+endpoints where `LibreLLM` keys off `base_url=` alone: `LibreVLM` has a
+closed local alias table to disambiguate against; `LibreLLM` does not.
+
+### An empty result is never ambiguous
+
+Per-image failure never aborts a folder, and every non-clean empty carries
+`result.remote = {"error": "http" | "parse" | "refusal", "detail", "model"}`.
+Auth / bad-model / bad-request errors raise loudly (they would fail on every
+image; converting them to empties would silently zero a run). Multi-image
+runs log a failure summary. A chatty prose answer without boxes counts as a
+parse failure: the model broke the format contract, and the caller deserves
+to know before trusting it as a negative.
+
+### Cost safety (v1 scope; cost accounting is not)
+
+- Live sources (webcam, network streams, screen capture) raise. Every frame
+  is a metered call; there is no opt-in kwarg in v1.
+- Multi-image runs log a one-line metered banner (count, provider, model)
+  before the first request.
+- `batch=` means request concurrency (thread pool over per-image HTTP,
+  default 8), never a stacked tensor.
+- `estimate()` / `budget=` / price tables stay out of v1.
+
+### Detection prompt and parsing
+
+One generic prompt (the existing base `_format_detection_prompt`: JSON
+array of `{"label", "bbox"}` normalized to [0, 1]), no per-vendor dialect
+registry. `parsing.py` is reused unchanged; Qwen-lineage `bbox_2d` 0-1000
+answers are rescaled by heuristic (values above ~1). `prompt=` overrides,
+same as local.
+
+### selftest()
+
+`model.selftest()` sends two metered probes (a red rectangle at a known
+position, then a blank image) and reports pass/fail with IoU and
+false-positive count. It is the honest answer to "does this hosted model
+ground at all" and makes no mAP claim.
+
+### Install
+
+Remote `LibreVLM` requires `libreyolo[llm]` (the OpenAI SDK), not
+`libreyolo[vlm]`: a machine that only does hosted detect must not pull
+transformers. Constructing without the extra raises the pip hint; importing
+libreyolo never imports openai.
+
+## Out of scope (named so they stay decisions)
+
+Native Gemini/Anthropic/Moondream transports; `estimate()`/`budget=`;
+`autolabel()` and provider batch JSONL; CLI; realtime APIs; SDK objects
+from `chat()`; remote models inside `LibreYOLO(...)`; LiteLLM or vendor CV
+SDK dependencies; callable `api_key`.
+
+## Consequences
+
+- The explore-with-hosted-model, train-local workflow is one import.
+- Boxes from hosted chat models are uncalibrated (confidence 1.0, provider
+  resizing, prompt adherence varies); docs steer calibrated use to
+  `LibreYOLO` and gate big runs behind `selftest()`.
+- Remote sends images to a third party; documented, no policy registry in
+  v1.

--- a/docs/adr/0020-librevlm-remote-transport.md
+++ b/docs/adr/0020-librevlm-remote-transport.md
@@ -58,13 +58,27 @@ closed local alias table to disambiguate against; `LibreLLM` does not.
 
 ### An empty result is never ambiguous
 
-Per-image failure never aborts a folder, and every non-clean empty carries
-`result.remote = {"error": "http" | "parse" | "refusal", "detail", "model"}`.
-Auth / bad-model / bad-request errors raise loudly (they would fail on every
-image; converting them to empties would silently zero a run). Multi-image
-runs log a failure summary. A chatty prose answer without boxes counts as a
-parse failure: the model broke the format contract, and the caller deserves
-to know before trusting it as a negative.
+Per-image failure never aborts a folder, and every non-clean result carries
+`result.remote = {"error": kind, "detail", "model"}` with kind one of
+`http`, `parse`, `refusal`, `truncated`. Auth / bad-model / malformed-request
+errors raise loudly (they would fail on every image; converting them to
+empties would silently zero a run). Multi-image runs log a failure summary.
+A chatty prose answer without boxes counts as a parse failure: the model
+broke the format contract, and the caller deserves to know before trusting
+it as a negative.
+
+`truncated` is its own kind because the classification is not obvious.
+First-party OpenAI answers an output-limit overflow with a **400**, not a
+truncated string, and 400s are otherwise fatal. But truncation depends on
+how much the model had to say about *this* image (a crowded frame overflows
+where a sparse one does not), so treating it as fatal would abort a folder
+partway through. It is therefore isolated per image, while a genuinely
+malformed request (same 400 class, identical on every image) still raises;
+the two are told apart by requiring both a length signal and a
+"was reached" signal in the message. Compat hosts instead return 200 with
+`finish_reason="length"` (or `status="incomplete"` on Responses) and partial
+content; there the parsed boxes are kept and the result is still flagged,
+since the list is incomplete by definition.
 
 ### Cost safety (v1 scope; cost accounting is not)
 

--- a/docs/librevlm_design.md
+++ b/docs/librevlm_design.md
@@ -276,6 +276,57 @@ precision tiers, and terms distinction are documented in
 [`libremodus.md`](libremodus.md) and
 [`adr/0016-libremodus-analysis-contract.md`](adr/0016-libremodus-analysis-contract.md).
 
+## Remote models (ADR 0020)
+
+The same factory also runs hosted vision chat models as detectors. A slash
+means remote; a bare alias stays local:
+
+```python
+from libreyolo import LibreVLM
+
+model = LibreVLM("openai/gpt-5.6-luna")           # OPENAI_API_KEY
+model = LibreVLM("openrouter/qwen/qwen3.8-max")   # OPENROUTER_API_KEY
+model = LibreVLM(
+    "openai-compat/qwen3-vl-32b",                 # any vLLM/Ollama-style host
+    base_url="http://localhost:8000/v1",
+    api_key="empty",
+)
+
+model.set_classes(["helmet", "person", "forklift"])
+model.selftest()                       # 2 metered probes: does it ground?
+result = model.predict("frame.jpg")    # same Results, pixel xyxy
+results = model.predict("folder/")     # banner, per-image error isolation
+text = model.chat("frame.jpg", "Anyone missing a helmet?")   # str
+```
+
+What is identical to local: sticky `set_classes`, `predict` on
+image/list/folder/video file, pixel-xyxy `Results`, `chat() -> str`,
+`track()` on video files, soft confidence 1.0.
+
+What is different, loudly:
+
+- **Live sources raise.** Webcam, network streams, and screen capture are
+  unbounded metered calls; pass finite sources. Multi-image runs log a
+  one-line metered banner first.
+- **An empty result is never ambiguous.** HTTP failure, unparseable text,
+  and refusals yield empty boxes plus
+  `result.remote = {"error": "http" | "parse" | "refusal", ...}`, and the
+  run logs a failure summary. A clean "found nothing" has no `.remote`.
+  Auth or bad-model errors raise immediately instead.
+- **`batch=` means request concurrency** (thread pool over per-image HTTP,
+  default 8), not a stacked tensor.
+- `device=`, `tiling=`, `augment=`, `train()`, `val()`, `export()` raise.
+- Requires `pip install "libreyolo[llm]"` (the OpenAI SDK), not
+  `libreyolo[vlm]`; hosted-only machines skip transformers entirely.
+
+Wire API defaults differ on purpose: remote `LibreVLM` speaks
+`chat.completions` (the format every compat host supports; pass
+`api="responses"` for first-party OpenAI), while `LibreLLM` defaults to
+`responses`. Boxes from hosted chat models are uncalibrated; for calibrated
+detection train a `LibreYOLO` model, and treat remote detect as the
+explore / auto-label ramp. Remote sends your images to the provider under
+that provider's terms.
+
 ## Known limitations (v1)
 
 These are deliberate v1 scoping choices, called out so behavior matches expectations:

--- a/docs/librevlm_design.md
+++ b/docs/librevlm_design.md
@@ -308,11 +308,13 @@ What is different, loudly:
 - **Live sources raise.** Webcam, network streams, and screen capture are
   unbounded metered calls; pass finite sources. Multi-image runs log a
   one-line metered banner first.
-- **An empty result is never ambiguous.** HTTP failure, unparseable text,
-  and refusals yield empty boxes plus
-  `result.remote = {"error": "http" | "parse" | "refusal", ...}`, and the
-  run logs a failure summary. A clean "found nothing" has no `.remote`.
-  Auth or bad-model errors raise immediately instead.
+- **An empty result is never ambiguous.** HTTP failures, unparseable text,
+  refusals, and truncated answers set
+  `result.remote = {"error": "http" | "parse" | "refusal" | "truncated", ...}`,
+  and the run logs a failure summary. A clean "found nothing" has no
+  `.remote`. Auth or bad-model errors raise immediately instead. Raising
+  `max_new_tokens=` is the fix for `truncated` (a crowded image needs more
+  output budget than a sparse one).
 - **`batch=` means request concurrency** (thread pool over per-image HTTP,
   default 8), not a stacked tensor.
 - `device=`, `tiling=`, `augment=`, `train()`, `val()`, `export()` raise.

--- a/libreyolo/models/llm/client.py
+++ b/libreyolo/models/llm/client.py
@@ -10,27 +10,26 @@ public API. It does not wrap provider-specific response types.
 
 from __future__ import annotations
 
-import base64
-import io
 import os
-from pathlib import Path
 from typing import Any, Optional, Union
 
-import numpy as np
-from PIL import Image, ImageOps
+# Image encoding, payload building, and SDK loading live in the transport
+# module shared with the remote LibreVLM path. Re-imported here so existing
+# ``client._load_openai`` / ``client._as_image_url`` references keep working.
+from .openai_transport import (
+    SUPPORTED_APIS as _SUPPORTED_APIS,
+    _as_image_url,
+    _is_image_object,
+    _load_openai,
+    build_user_payload,
+    client_kwargs,
+)
 
 _DEFAULT_MODEL = "gpt-5.6-luna"
-_SUPPORTED_APIS = ("responses", "chat.completions")
-_INSTALL_HINT = (
-    "LibreLLM requires the 'llm' extra. Install with:\n"
-    "    pip install 'libreyolo[llm]'"
-)
 _UNSUPPORTED = (
     "LibreLLM is inference-only. Use LibreYOLO for train, val, export, "
     "track, and benchmark."
 )
-_DATA_URI_PREFIX = "data:"
-_HTTP_PREFIXES = ("http://", "https://")
 
 # Optional ``provider/`` prefixes, for symmetry with ``LibreVLM``. The bare
 # form (``LibreLLM("gpt-5.6-luna")``) stays primary and is never deprecated.
@@ -73,77 +72,6 @@ def _is_vlm_alias(model: str) -> bool:
         return False
     key = model.strip().lower()
     return key in _ALIASES or key in _LAZY_ALIASES or key in _MODUS_ALIASES
-
-
-def _load_openai():
-    try:
-        import openai
-    except ImportError as exc:
-        raise ImportError(_INSTALL_HINT) from exc
-    return openai
-
-
-def _data_uri(jpeg_bytes: bytes) -> str:
-    encoded = base64.standard_b64encode(jpeg_bytes).decode("ascii")
-    return f"data:image/jpeg;base64,{encoded}"
-
-
-def _encode_pil(img: Image.Image) -> str:
-    transposed = ImageOps.exif_transpose(img)
-    if transposed is not None:
-        img = transposed
-    if img.mode != "RGB":
-        img = img.convert("RGB")
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=95)
-    return _data_uri(buf.getvalue())
-
-
-def _encode_path(path: str) -> str:
-    file_path = Path(path)
-    if not file_path.is_file():
-        raise FileNotFoundError(f"Image file not found: {path}")
-    with Image.open(file_path) as img:
-        return _encode_pil(img)
-
-
-def _encode_bgr_numpy(arr: np.ndarray) -> str:
-    """Encode an OpenCV-style BGR (or gray) array as a JPEG data URI."""
-    import cv2
-
-    image = np.ascontiguousarray(arr)
-    if image.ndim == 3 and image.shape[0] in (1, 3, 4) and image.shape[0] < image.shape[2]:
-        image = np.transpose(image, (1, 2, 0))
-    if image.dtype != np.uint8:
-        if np.issubdtype(image.dtype, np.floating) and float(np.max(image)) <= 1.0:
-            image = (image * 255.0).clip(0, 255).astype(np.uint8)
-        else:
-            image = image.clip(0, 255).astype(np.uint8)
-    ok, buf = cv2.imencode(".jpg", image)
-    if not ok:
-        raise ValueError("Failed to encode NumPy image as JPEG")
-    return _data_uri(buf.tobytes())
-
-
-def _is_image_object(value: Any) -> bool:
-    return isinstance(value, (Image.Image, np.ndarray, Path))
-
-
-def _as_image_url(value: Any) -> str:
-    if isinstance(value, str):
-        if value.startswith(_HTTP_PREFIXES) or value.startswith(_DATA_URI_PREFIX):
-            return value
-        return _encode_path(value)
-    if isinstance(value, Path):
-        return _encode_path(str(value))
-    if isinstance(value, Image.Image):
-        return _encode_pil(value)
-    if isinstance(value, np.ndarray):
-        return _encode_bgr_numpy(value)
-    raise TypeError(
-        "image must be a path, HTTP URL, data URI, NumPy array, or PIL image, "
-        f"got {type(value).__name__}"
-    )
 
 
 def _compose_text(prompt: Optional[str], source_text: Optional[str]) -> Optional[str]:
@@ -212,12 +140,7 @@ class LibreLLM:
         self._async = None
 
     def _client_kwargs(self) -> dict[str, Any]:
-        kwargs: dict[str, Any] = {}
-        if self.api_key is not None:
-            kwargs["api_key"] = self.api_key
-        if self.base_url is not None:
-            kwargs["base_url"] = self.base_url
-        return kwargs
+        return client_kwargs(self.api_key, self.base_url)
 
     def _make_sync_client(self):
         return _load_openai().OpenAI(**self._client_kwargs())
@@ -280,24 +203,7 @@ class LibreLLM:
     def _build_payload(
         self, text: Optional[str], image_url: Optional[str]
     ) -> Union[str, list]:
-        if self.api == "responses":
-            if image_url is None:
-                return text
-            content: list[dict[str, Any]] = []
-            if text:
-                content.append({"type": "input_text", "text": text})
-            content.append({"type": "input_image", "image_url": image_url})
-            return [{"role": "user", "content": content}]
-
-        if image_url is None:
-            return [{"role": "user", "content": text}]
-        content = []
-        if text:
-            content.append({"type": "text", "text": text})
-        content.append(
-            {"type": "image_url", "image_url": {"url": image_url}}
-        )
-        return [{"role": "user", "content": content}]
+        return build_user_payload(self.api, text, image_url)
 
     def _request_body(self, prepared: Union[str, list], kwargs: dict[str, Any]) -> dict[str, Any]:
         body = {**self.defaults, **kwargs}

--- a/libreyolo/models/llm/openai_transport.py
+++ b/libreyolo/models/llm/openai_transport.py
@@ -1,0 +1,148 @@
+"""Shared OpenAI-compatible transport helpers.
+
+One internal module, two doors: ``LibreLLM`` (chat client, native SDK
+responses out) and the remote ``LibreVLM`` transport (detection over HTTP)
+both encode images, build user payloads, and construct SDK clients through
+these helpers. Everything here is offline-testable; the ``openai`` package
+is imported lazily so importing libreyolo never requires the ``llm`` extra.
+
+The official OpenAI Python SDK is Apache-2.0. This module talks to that
+public API. It does not wrap provider-specific response types.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import numpy as np
+from PIL import Image, ImageOps
+
+SUPPORTED_APIS = ("responses", "chat.completions")
+_INSTALL_HINT = (
+    "This feature requires the 'llm' extra (the official OpenAI SDK). "
+    "Install with:\n"
+    "    pip install 'libreyolo[llm]'"
+)
+_DATA_URI_PREFIX = "data:"
+_HTTP_PREFIXES = ("http://", "https://")
+
+
+def _load_openai():
+    try:
+        import openai
+    except ImportError as exc:
+        raise ImportError(_INSTALL_HINT) from exc
+    return openai
+
+
+def _data_uri(jpeg_bytes: bytes) -> str:
+    encoded = base64.standard_b64encode(jpeg_bytes).decode("ascii")
+    return f"data:image/jpeg;base64,{encoded}"
+
+
+def _encode_pil(img: Image.Image) -> str:
+    transposed = ImageOps.exif_transpose(img)
+    if transposed is not None:
+        img = transposed
+    if img.mode != "RGB":
+        img = img.convert("RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=95)
+    return _data_uri(buf.getvalue())
+
+
+def _encode_path(path: str) -> str:
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise FileNotFoundError(f"Image file not found: {path}")
+    with Image.open(file_path) as img:
+        return _encode_pil(img)
+
+
+def _encode_bgr_numpy(arr: np.ndarray) -> str:
+    """Encode an OpenCV-style BGR (or gray) array as a JPEG data URI."""
+    import cv2
+
+    image = np.ascontiguousarray(arr)
+    if image.ndim == 3 and image.shape[0] in (1, 3, 4) and image.shape[0] < image.shape[2]:
+        image = np.transpose(image, (1, 2, 0))
+    if image.dtype != np.uint8:
+        if np.issubdtype(image.dtype, np.floating) and float(np.max(image)) <= 1.0:
+            image = (image * 255.0).clip(0, 255).astype(np.uint8)
+        else:
+            image = image.clip(0, 255).astype(np.uint8)
+    ok, buf = cv2.imencode(".jpg", image)
+    if not ok:
+        raise ValueError("Failed to encode NumPy image as JPEG")
+    return _data_uri(buf.tobytes())
+
+
+def _is_image_object(value: Any) -> bool:
+    return isinstance(value, (Image.Image, np.ndarray, Path))
+
+
+def _as_image_url(value: Any) -> str:
+    if isinstance(value, str):
+        if value.startswith(_HTTP_PREFIXES) or value.startswith(_DATA_URI_PREFIX):
+            return value
+        return _encode_path(value)
+    if isinstance(value, Path):
+        return _encode_path(str(value))
+    if isinstance(value, Image.Image):
+        return _encode_pil(value)
+    if isinstance(value, np.ndarray):
+        return _encode_bgr_numpy(value)
+    raise TypeError(
+        "image must be a path, HTTP URL, data URI, NumPy array, or PIL image, "
+        f"got {type(value).__name__}"
+    )
+
+
+def build_user_payload(
+    api: str, text: Optional[str], image_url: Optional[str]
+) -> Union[str, list]:
+    """Build the single-turn user payload for the given wire API.
+
+    Returns the value for ``input=`` (responses) or ``messages=``
+    (chat.completions). Text-only responses input stays a bare string, which
+    is the SDK's cheapest accepted shape.
+    """
+    if api == "responses":
+        if image_url is None:
+            return text
+        content: list[dict[str, Any]] = []
+        if text:
+            content.append({"type": "input_text", "text": text})
+        content.append({"type": "input_image", "image_url": image_url})
+        return [{"role": "user", "content": content}]
+
+    if image_url is None:
+        return [{"role": "user", "content": text}]
+    content = []
+    if text:
+        content.append({"type": "text", "text": text})
+    content.append({"type": "image_url", "image_url": {"url": image_url}})
+    return [{"role": "user", "content": content}]
+
+
+def response_text(api: str, response: Any) -> str:
+    """Decode a plain string out of a native SDK response object."""
+    if api == "responses":
+        return getattr(response, "output_text", None) or ""
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        return ""
+    return getattr(choices[0].message, "content", None) or ""
+
+
+def client_kwargs(api_key: Optional[str], base_url: Optional[str]) -> dict[str, Any]:
+    """Constructor kwargs for ``OpenAI`` / ``AsyncOpenAI``, omitting unset."""
+    kwargs: dict[str, Any] = {}
+    if api_key is not None:
+        kwargs["api_key"] = api_key
+    if base_url is not None:
+        kwargs["base_url"] = base_url
+    return kwargs

--- a/libreyolo/models/vlm/__init__.py
+++ b/libreyolo/models/vlm/__init__.py
@@ -17,6 +17,7 @@ See ``docs/librevlm_design.md`` and ``docs/adr/0002-librevlm-contract.md``.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, Tuple, Type
 
 from .base import LibreVLMModel
@@ -78,6 +79,57 @@ _MODUS_ALIASES: Dict[str, str] = {
 
 _DEFAULT_MODEL = "qwen3-vl-4b"
 
+# Remote transport (ADR 0020): a slash means remote, a bare alias stays
+# local. No local alias will ever contain a slash, which keeps the routing
+# unambiguous.
+_REMOTE_PROVIDERS = ("openai", "openrouter", "openai-compat")
+_REMOTE_ONLY_KWARGS = ("base_url", "api_key", "api")
+
+
+def _all_aliases() -> list:
+    return sorted(set(_ALIASES) | set(_LAZY_ALIASES) | set(_MODUS_ALIASES))
+
+
+def _looks_like_path(s: str) -> bool:
+    """Path-shaped strings are never parsed as ``provider/model``."""
+    import re
+
+    if "\\" in s or re.match(r"^[A-Za-z]:[\\/]", s):
+        return True
+    return s.startswith(("/", "./", "../", "~"))
+
+
+def _reject_remote_kwargs(kwargs: dict, model) -> None:
+    offending = [k for k in _REMOTE_ONLY_KWARGS if kwargs.get(k) is not None]
+    if offending:
+        raise ValueError(
+            f"{', '.join(k + '=' for k in offending)} only applies to remote "
+            f"models ('provider/model-id' form). {str(model)!r} resolves to a "
+            "local model. Did you mean LibreVLM('openai-compat/"
+            f"{model}', base_url=...)?"
+        )
+
+
+def _unknown_provider_error(full: str, prefix: str) -> ValueError:
+    try:
+        resolved = Path(full).resolve()
+    except OSError:
+        resolved = full
+    return ValueError(
+        f"Unknown remote provider {prefix!r} in {full!r}.\n"
+        f"  Known providers: {', '.join(_REMOTE_PROVIDERS)} (self-hosted: "
+        "LibreVLM('openai-compat/<model-id>', base_url=...)).\n"
+        "  Hugging Face repo ids are not accepted; local aliases: "
+        f"{', '.join(_all_aliases())}.\n"
+        f"  If you meant a checkpoint path: nothing exists at {resolved}."
+    )
+
+
+def _load_remote(provider: str, model_id: str, **kwargs) -> LibreVLMModel:
+    from .remote import RemoteVLMModel
+
+    return RemoteVLMModel(provider, model_id, **kwargs)
+
 
 def _load_checkpoint(path, **kwargs) -> LibreVLMModel:
     """Load a fine-tune checkpoint directory produced by ``train()``."""
@@ -97,27 +149,70 @@ def _load_checkpoint(path, **kwargs) -> LibreVLMModel:
 
 
 def LibreVLM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreVLMModel:
-    """Load a vision-language detector by name or fine-tune checkpoint path.
+    """Load a vision-language detector: local family, checkpoint, or remote.
 
     Args:
-        model: Model alias (e.g. ``"qwen3-vl-4b"``, ``"lfm2-vl-450m"``), or a
-            path to a fine-tune checkpoint directory produced by ``train()``
-            (it carries ``libreyolo_vlm.json``). Defaults to Qwen3-VL-4B
-            (Apache-2.0).
-        **kwargs: Forwarded to the family constructor: ``device``, ``names``
-            (initial class vocabulary, same as calling ``set_classes`` after
-            load), ``prompt`` (override the detection prompt), ``max_new_tokens``.
-            When loading a checkpoint, ``names`` defaults to the vocabulary the
-            fine-tune was trained on.
+        model: One of:
+
+            - a local model alias (e.g. ``"qwen3-vl-4b"``, ``"lfm2-vl-450m"``;
+              defaults to Qwen3-VL-4B, Apache-2.0),
+            - a path to a fine-tune checkpoint directory produced by
+              ``train()`` (it carries ``libreyolo_vlm.json``),
+            - a remote ``"provider/model-id"`` string (ADR 0020). Known
+              providers: ``openai/``, ``openrouter/``, and
+              ``openai-compat/`` + ``base_url=`` for any self-hosted or
+              gateway endpoint. The model id after the first slash is passed
+              through verbatim, so newly shipped hosted models work without a
+              libreyolo release.
+        **kwargs: Forwarded to the family constructor. Local: ``device``,
+            ``names`` (initial vocabulary, same as ``set_classes`` after
+            load), ``prompt`` (override the detection prompt),
+            ``max_new_tokens``. Remote adds ``base_url``, ``api_key``,
+            ``api`` (``"chat.completions"`` default or ``"responses"``), and
+            ``provider=`` as the kwarg form of the prefix; ``device`` raises.
 
     Returns:
         A ``LibreVLMModel`` instance with the standard predict/track surface.
     """
     from .training.checkpoint import is_vlm_checkpoint
 
+    provider = kwargs.pop("provider", None)
+    if provider is not None:
+        # Kwarg form: LibreVLM(model="gpt-5.6-luna", provider="openai")
+        # normalizes to the string form LibreVLM("openai/gpt-5.6-luna").
+        return _load_remote(str(provider).lower(), str(model), **kwargs)
+
     if is_vlm_checkpoint(model):
+        _reject_remote_kwargs(kwargs, model)
         return _load_checkpoint(model, **kwargs)
-    key = str(model).strip().lower()
+
+    s = str(model)
+    try:
+        path_exists = Path(s).exists()
+    except OSError:
+        path_exists = False
+    if path_exists:
+        raise ValueError(
+            f"{s!r} exists on disk but is not a VLM fine-tune checkpoint "
+            "(no libreyolo_vlm.json inside). LibreVLM loads aliases, "
+            "checkpoint directories, or remote 'provider/model-id' strings."
+        )
+    if _looks_like_path(s):
+        raise FileNotFoundError(
+            f"No VLM checkpoint exists at {Path(s).resolve()}. "
+            "Pass a fine-tune checkpoint directory, a local alias, or a "
+            "remote 'provider/model-id' string."
+        )
+    if "/" in s:
+        # Split on the FIRST slash only, before lowercasing, so
+        # case-sensitive provider model ids survive.
+        prefix, rest = s.split("/", 1)
+        if prefix.lower() in _REMOTE_PROVIDERS:
+            return _load_remote(prefix.lower(), rest, **kwargs)
+        raise _unknown_provider_error(s, prefix)
+
+    _reject_remote_kwargs(kwargs, model)
+    key = s.strip().lower()
     if key in _LAZY_ALIASES:
         from ..sensenova import LibreSenseNovaVision
 

--- a/libreyolo/models/vlm/remote.py
+++ b/libreyolo/models/vlm/remote.py
@@ -107,13 +107,30 @@ class _RemotePayload:
         return self
 
 
+class _RemoteReply:
+    """One decoded response: the text plus whether it was cut off.
+
+    A truncated answer is a per-image event (a crowded image overflows the
+    token budget where a sparse one does not), so it is reported through the
+    side channel rather than raised.
+    """
+
+    __slots__ = ("text", "truncated")
+
+    def __init__(self, text: str, truncated: bool = False):
+        self.text = text
+        self.truncated = truncated
+
+
 class _RemoteFailure:
-    """Sentinel returned by ``_forward`` when the HTTP call failed after the
-    SDK's retries. Carries the detail for the ``result.remote`` side channel."""
+    """Sentinel returned by ``_forward`` when a request failed in a way that
+    is per-image rather than fatal. Carries the kind and detail for the
+    ``result.remote`` side channel."""
 
-    __slots__ = ("detail",)
+    __slots__ = ("kind", "detail")
 
-    def __init__(self, detail: str):
+    def __init__(self, kind: str, detail: str):
+        self.kind = kind
         self.detail = detail
 
 
@@ -241,13 +258,13 @@ class RemoteVLMModel(LibreVLMModel):
         openai = _load_openai()
         return openai.OpenAI(**client_kwargs(self.api_key, self.base_url))
 
-    def _request_text(
+    def _request(
         self,
         image_url: str,
         prompt: str,
         max_new_tokens: Optional[int] = None,
-    ) -> str:
-        """One image+prompt request; returns the model's text verbatim."""
+    ) -> _RemoteReply:
+        """One image+prompt request; returns the text and a truncation flag."""
         cap = max_new_tokens if max_new_tokens is not None else self._token_cap
         payload = build_user_payload(self.api, prompt, image_url)
         body: Dict[str, Any] = {"model": self.model_id}
@@ -256,6 +273,10 @@ class RemoteVLMModel(LibreVLMModel):
             if cap:
                 body["max_output_tokens"] = int(cap)
             response = self._client_instance.responses.create(**body)
+            details = getattr(response, "incomplete_details", None)
+            truncated = getattr(response, "status", None) == "incomplete" and (
+                getattr(details, "reason", None) == "max_output_tokens"
+            )
         else:
             body["messages"] = payload
             if cap:
@@ -268,14 +289,49 @@ class RemoteVLMModel(LibreVLMModel):
                 )
                 body[key] = int(cap)
             response = self._client_instance.chat.completions.create(**body)
-        return response_text(self.api, response)
+            choices = getattr(response, "choices", None) or []
+            truncated = bool(choices) and (
+                getattr(choices[0], "finish_reason", None) == "length"
+            )
+        return _RemoteReply(response_text(self.api, response), truncated)
+
+    def _request_text(
+        self,
+        image_url: str,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+    ) -> str:
+        """One image+prompt request; returns the model's text verbatim."""
+        return self._request(image_url, prompt, max_new_tokens=max_new_tokens).text
 
     @staticmethod
-    def _failure_kind(exc: BaseException) -> Optional[str]:
-        """``"http"`` for transient transport failures (already retried by the
-        SDK), None for everything that must raise (auth, bad model, bad
-        request: those fail on every image, so converting them into empty
-        results would silently zero a whole folder)."""
+    def _is_truncation_error(exc: BaseException) -> bool:
+        """True for the "output limit reached" 400 that OpenAI returns instead
+        of a truncated message.
+
+        Matched on the message because the API gives no distinct error code.
+        Both a length signal and a "was reached" signal are required, so a
+        genuine bad request such as "max_tokens must be an integer" (fatal,
+        identical on every image) is not swallowed as a per-image event.
+        """
+        message = str(exc).lower()
+        length_signal = "max_tokens" in message or "max_output_tokens" in message
+        reached_signal = "was reached" in message or "output limit" in message
+        return length_signal and reached_signal
+
+    @classmethod
+    def _failure_kind(cls, exc: BaseException) -> Optional[str]:
+        """Per-image failure kind, or None when the error must raise.
+
+        ``"http"`` covers transient transport failures (already retried by the
+        SDK). ``"truncated"`` covers the output-limit 400: it depends on how
+        much the model had to say about *this* image, so it must not abort a
+        folder. Everything else (auth, bad model, malformed request) fails on
+        every image, and converting those into empty results would silently
+        zero a whole run.
+        """
+        if cls._is_truncation_error(exc):
+            return "truncated"
         try:
             openai = _load_openai()
         except ImportError:
@@ -286,8 +342,8 @@ class RemoteVLMModel(LibreVLMModel):
             "APITimeoutError",
             "InternalServerError",
         ):
-            cls = getattr(openai, name, None)
-            if isinstance(cls, type) and isinstance(exc, cls):
+            klass = getattr(openai, name, None)
+            if isinstance(klass, type) and isinstance(exc, klass):
                 return "http"
         status = getattr(exc, "status_code", None)
         try:
@@ -388,11 +444,12 @@ class RemoteVLMModel(LibreVLMModel):
     def _forward(self, inputs: Any):
         prompt = self._detection_prompt()
         try:
-            return self._request_text(inputs.image_url, prompt)
+            return self._request(inputs.image_url, prompt)
         except Exception as exc:
-            if self._failure_kind(exc) is None:
+            kind = self._failure_kind(exc)
+            if kind is None:
                 raise
-            return _RemoteFailure(f"{type(exc).__name__}: {exc}")
+            return _RemoteFailure(kind, f"{type(exc).__name__}: {exc}")
 
     def _postprocess(
         self,
@@ -405,12 +462,17 @@ class RemoteVLMModel(LibreVLMModel):
         **kwargs,
     ) -> Dict:
         if isinstance(output, _RemoteFailure):
-            self._record_error("http", output.detail)
+            self._record_error(output.kind, output.detail)
             items = []
         else:
-            text = output if isinstance(output, str) else ""
+            text = output.text if isinstance(output, _RemoteReply) else ""
             items = [self._normalize_item(i) for i in extract_detections(text)]
-            if not items:
+            if isinstance(output, _RemoteReply) and output.truncated:
+                # Whatever parsed is kept (partial boxes beat none), but the
+                # list is incomplete by definition, so it is never a clean
+                # result.
+                self._record_error("truncated", text)
+            elif not items:
                 kind = self._classify_empty(text)
                 if kind is not None:
                     self._record_error(kind, text)

--- a/libreyolo/models/vlm/remote.py
+++ b/libreyolo/models/vlm/remote.py
@@ -1,0 +1,697 @@
+"""Remote LibreVLM: hosted vision chat models as open-vocabulary detectors.
+
+Same contract as a local VLM family (``set_classes`` + ``predict`` returning
+pixel-``xyxy`` ``Results``, ``chat()`` as the raw-text escape hatch), with the
+forward pass replaced by one OpenAI-compatible HTTP request per image. See
+``docs/adr/0020-librevlm-remote-transport.md``.
+
+Ground rules implemented here:
+
+- An empty result is never ambiguous. HTTP failure (after the SDK's own
+  retries), parse failure, and refusal all yield empty boxes and attach
+  ``result.remote = {"error": kind, ...}``; a clean "found nothing" carries
+  no error. Multi-image runs log a failure summary.
+- Live sources (webcam, network streams, screen capture) raise: every frame
+  is a metered API call. Finite sources (image, list, folder, video file)
+  work like local.
+- ``batch=`` means request concurrency (a thread pool over per-image HTTP),
+  not a stacked tensor. Default 8.
+- Auth / bad-model / bad-request errors raise loudly; they would fail on
+  every image, so they are never converted into empty results.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Dict, Generator, Optional, Tuple
+
+import torch
+
+from ...utils.image_loader import ImageInput, ImageLoader
+from ...utils.logging import ensure_default_logging
+from ...utils.results import Results
+from ...utils.source import SourceKind, classify_source
+from ..base.inference import InferenceRunner
+from ..llm.openai_transport import (
+    SUPPORTED_APIS,
+    _encode_pil,
+    _load_openai,
+    build_user_payload,
+    client_kwargs,
+    response_text,
+)
+from .base import LibreVLMModel
+from .parsing import (
+    _iou_xyxy,
+    build_detection_dict,
+    extract_detections,
+    normalize_bbox,
+    to_xyxy,
+)
+
+logger = logging.getLogger(__name__)
+
+_INFERENCE_ONLY = (
+    "Remote LibreVLM is inference-only: the weights live on the provider's "
+    "servers. Use a local family (e.g. LibreVLM('qwen3-vl-4b')) or LibreYOLO "
+    "for train/val/export."
+)
+_LIVE_SOURCE_MESSAGE = (
+    "Remote LibreVLM does not support live sources (webcam indices, network "
+    "streams, screen capture): every frame is a metered API call with seconds "
+    "of latency. Pass an image, a list, a folder, or a video file."
+)
+_DEFAULT_CONCURRENCY = 8
+
+# prefix -> (default base_url, env key, base_url required)
+_PROVIDERS: Dict[str, Tuple[Optional[str], str, bool]] = {
+    "openai": (None, "OPENAI_API_KEY", False),
+    "openrouter": ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY", False),
+    "openai-compat": (None, "OPENAI_API_KEY", True),
+}
+
+_REFUSAL_MARKERS = (
+    "i'm sorry",
+    "i am sorry",
+    "i cannot",
+    "i can't",
+    "i can not",
+    "unable to",
+    "not able to",
+    "cannot assist",
+    "can't assist",
+    "cannot help",
+    "can't help",
+    "against my",
+    "as an ai",
+    "content policy",
+    "i must decline",
+    "refuse",
+)
+
+
+class _RemotePayload:
+    """Encoded request for one image. Duck-types ``.to(device)`` as a no-op so
+    the shared ``_predict_single`` path needs no remote special-casing."""
+
+    __slots__ = ("image_url",)
+
+    def __init__(self, image_url: str):
+        self.image_url = image_url
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+class _RemoteFailure:
+    """Sentinel returned by ``_forward`` when the HTTP call failed after the
+    SDK's retries. Carries the detail for the ``result.remote`` side channel."""
+
+    __slots__ = ("detail",)
+
+    def __init__(self, detail: str):
+        self.detail = detail
+
+
+class _RemoteInferenceRunner(InferenceRunner):
+    """InferenceRunner that attaches the per-image error side channel.
+
+    ``_wrap_results`` is the single funnel every predict path (single image,
+    folder, list, video frame, tracked frame) passes through, so attaching
+    here covers all of them without duplicating routing logic. The pending
+    error is thread-local: pooled folder runs execute the whole
+    preprocess -> forward -> postprocess -> wrap chain on one worker thread.
+    """
+
+    def _wrap_results(self, detections, original_size, image_path, classes):
+        result = super()._wrap_results(detections, original_size, image_path, classes)
+        error = self.model._consume_error()
+        if error is not None:
+            result.remote = error
+        return result
+
+
+class RemoteVLMModel(LibreVLMModel):
+    """Hosted vision chat model behind the standard LibreVLM surface."""
+
+    FAMILY = "remote-vlm"
+
+    def __init__(
+        self,
+        provider: str,
+        model_id: str,
+        *,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        api: str = "chat.completions",
+        names: Optional[list] = None,
+        prompt: Optional[str] = None,
+        max_new_tokens: Optional[int] = None,
+        device: Optional[str] = None,
+        **kwargs,
+    ):
+        ensure_default_logging()
+        if kwargs:
+            raise TypeError(
+                "Unexpected keyword arguments for remote LibreVLM: "
+                f"{', '.join(sorted(kwargs))}. Remote models accept base_url, "
+                "api_key, api, names, prompt, and max_new_tokens."
+            )
+        if device is not None:
+            raise ValueError(
+                "device= does not apply to a remote LibreVLM: inference runs "
+                "on the provider's servers, not on a local GPU."
+            )
+        provider = str(provider).strip().lower()
+        spec = _PROVIDERS.get(provider)
+        if spec is None:
+            raise ValueError(
+                f"Unknown remote provider {provider!r}. Known providers: "
+                f"{', '.join(sorted(_PROVIDERS))}. Self-hosted or gateway "
+                "endpoints use LibreVLM('openai-compat/<model-id>', "
+                "base_url=...)."
+            )
+        if not str(model_id).strip():
+            raise ValueError("Remote model id must be a non-empty string.")
+        if api not in SUPPORTED_APIS:
+            raise ValueError(f"api must be one of {SUPPORTED_APIS}, got {api!r}")
+        default_base_url, env_key, base_url_required = spec
+        if base_url is None:
+            base_url = default_base_url
+        if base_url_required and base_url is None:
+            raise ValueError(
+                "LibreVLM('openai-compat/...') requires base_url= pointing at "
+                "your OpenAI-compatible host (e.g. 'http://localhost:8000/v1')."
+            )
+        if api_key is None and env_key != "OPENAI_API_KEY":
+            import os
+
+            api_key = os.environ.get(env_key)
+            if api_key is None:
+                raise ValueError(
+                    f"Provider {provider!r} reads its key from {env_key}, "
+                    "which is not set. Set it or pass api_key=."
+                )
+
+        self.provider = provider
+        self.model_id = str(model_id)
+        self.base_url = base_url
+        self.api_key = api_key
+        self.api = api
+
+        # Attributes the shared BaseModel/InferenceRunner machinery reads.
+        # BaseModel.__init__ is deliberately not called: it exists to load
+        # local weights, which a remote model does not have.
+        self.family = self.FAMILY
+        self.task = "detect"
+        self.size = self.model_id
+        self.device = torch.device("cpu")  # never used; payloads no-op .to()
+        self.input_size = 1024  # nominal; the provider picks its own scaling
+        self.model = None
+        self.model_path = None
+        self._checkpoint_dir = None
+        self._custom_prompt = prompt
+        self._graph_runner = None
+        self._cuda_graph_mode = None
+        self._runner_instance = None
+        self._token_cap = int(max_new_tokens) if max_new_tokens else None
+        self._pending = threading.local()
+
+        self.nb_classes = 80
+        from ...utils.general import COCO_CLASSES
+
+        self.names = {i: n for i, n in enumerate(COCO_CLASSES)}
+        self._name_to_id = {v.strip().lower(): k for k, v in self.names.items()}
+        if names is not None:
+            self.set_classes(names)
+
+        # Built eagerly so a missing key fails loud at construction, not on
+        # image 7,001 of a folder. Also surfaces the pip-extra hint early.
+        self._client_instance = self._make_client()
+
+    # =========================================================================
+    # HTTP client
+    # =========================================================================
+
+    def _make_client(self):
+        openai = _load_openai()
+        return openai.OpenAI(**client_kwargs(self.api_key, self.base_url))
+
+    def _request_text(
+        self,
+        image_url: str,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+    ) -> str:
+        """One image+prompt request; returns the model's text verbatim."""
+        cap = max_new_tokens if max_new_tokens is not None else self._token_cap
+        payload = build_user_payload(self.api, prompt, image_url)
+        body: Dict[str, Any] = {"model": self.model_id}
+        if self.api == "responses":
+            body["input"] = payload
+            if cap:
+                body["max_output_tokens"] = int(cap)
+            response = self._client_instance.responses.create(**body)
+        else:
+            body["messages"] = payload
+            if cap:
+                # First-party OpenAI rejects max_tokens on current models;
+                # every compat host (vLLM, Ollama, OpenRouter) speaks it.
+                key = (
+                    "max_completion_tokens"
+                    if self.provider == "openai"
+                    else "max_tokens"
+                )
+                body[key] = int(cap)
+            response = self._client_instance.chat.completions.create(**body)
+        return response_text(self.api, response)
+
+    @staticmethod
+    def _failure_kind(exc: BaseException) -> Optional[str]:
+        """``"http"`` for transient transport failures (already retried by the
+        SDK), None for everything that must raise (auth, bad model, bad
+        request: those fail on every image, so converting them into empty
+        results would silently zero a whole folder)."""
+        try:
+            openai = _load_openai()
+        except ImportError:
+            return None
+        for name in (
+            "RateLimitError",
+            "APIConnectionError",
+            "APITimeoutError",
+            "InternalServerError",
+        ):
+            cls = getattr(openai, name, None)
+            if isinstance(cls, type) and isinstance(exc, cls):
+                return "http"
+        status = getattr(exc, "status_code", None)
+        try:
+            if status is not None and int(status) >= 500:
+                return "http"
+        except (TypeError, ValueError):
+            pass
+        return None
+
+    # =========================================================================
+    # Error side channel (thread-local; consumed by the runner's wrap step)
+    # =========================================================================
+
+    def _record_error(self, kind: str, detail: str) -> None:
+        self._pending.error = {
+            "error": kind,
+            "detail": detail[:500],
+            "model": f"{self.provider}/{self.model_id}",
+        }
+
+    def _consume_error(self) -> Optional[dict]:
+        error = getattr(self._pending, "error", None)
+        self._pending.error = None
+        return error
+
+    @staticmethod
+    def _classify_empty(text: str) -> Optional[str]:
+        """Why did a response yield zero detections?
+
+        None means clean (the model followed the format and found nothing).
+        ``"refusal"`` and ``"parse"`` are non-clean and get the side channel.
+        A chatty prose answer without boxes counts as a parse failure even
+        when it reads like a negative: the model broke the format contract,
+        and the caller deserves to know before trusting it as a negative.
+        """
+        stripped = (text or "").strip()
+        if stripped.startswith("```"):
+            stripped = stripped.strip("`").removeprefix("json").strip()
+        if not stripped:
+            return "parse"
+        compact = "".join(stripped.split())
+        if compact in ("[]", "[{}]"):
+            return None
+        if "[]" in compact and len(compact) <= 40:
+            return None
+        lowered = stripped.lower()
+        if any(marker in lowered for marker in _REFUSAL_MARKERS):
+            return "refusal"
+        return "parse"
+
+    @staticmethod
+    def _normalize_item(item: dict) -> dict:
+        """Map a parsed item onto the normalized ``bbox`` [0, 1] convention.
+
+        The generic prompt asks for ``bbox`` in [0, 1], but Qwen-lineage
+        hosted models often answer in their native ``bbox_2d`` 0-1000 grid
+        regardless; values above ~1 are rescaled. Anything else out of range
+        is clamped/dropped downstream by ``normalize_bbox``.
+        """
+        raw = item.get("bbox")
+        if raw is None:
+            raw = item.get("bbox_2d")
+        if not isinstance(raw, (list, tuple)) or len(raw) != 4:
+            return item
+        try:
+            vals = [float(v) for v in raw]
+        except (TypeError, ValueError):
+            return item
+        if any(abs(v) > 1.5 for v in vals):
+            vals = [v / 1000.0 for v in vals]
+        return {**item, "bbox": vals}
+
+    # =========================================================================
+    # Runner hooks: preprocess -> forward (HTTP) -> postprocess
+    # =========================================================================
+
+    @property
+    def _runner(self):
+        if self._runner_instance is None:
+            self._runner_instance = _RemoteInferenceRunner(self)
+        return self._runner_instance
+
+    def _get_input_size(self) -> int:
+        return self.input_size
+
+    def _get_available_layers(self) -> Dict[str, Any]:
+        return {}
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[Any, Any, Tuple[int, int], float]:
+        img = ImageLoader.load(image, color_format=color_format)
+        return _RemotePayload(_encode_pil(img)), img, img.size, 1.0
+
+    def _forward(self, inputs: Any):
+        prompt = self._detection_prompt()
+        try:
+            return self._request_text(inputs.image_url, prompt)
+        except Exception as exc:
+            if self._failure_kind(exc) is None:
+                raise
+            return _RemoteFailure(f"{type(exc).__name__}: {exc}")
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        if isinstance(output, _RemoteFailure):
+            self._record_error("http", output.detail)
+            items = []
+        else:
+            text = output if isinstance(output, str) else ""
+            items = [self._normalize_item(i) for i in extract_detections(text)]
+            if not items:
+                kind = self._classify_empty(text)
+                if kind is not None:
+                    self._record_error(kind, text)
+        return build_detection_dict(
+            items,
+            self._name_to_id,
+            original_size,
+            conf_thres=conf_thres,
+            max_det=max_det,
+            classes=kwargs.get("classes"),
+            default_score=self.DEFAULT_SCORE,
+            bbox_key="bbox",
+            coord_divisor=1.0,
+            box_format="xyxy",
+            iou_thres=iou_thres,
+        )
+
+    # =========================================================================
+    # Public surface: guards, metered banner, concurrency, summary
+    # =========================================================================
+
+    @staticmethod
+    def _reject_remote_kwargs(kwargs: dict) -> None:
+        if kwargs.get("device") is not None:
+            raise ValueError(
+                "device= does not apply to a remote LibreVLM: inference runs "
+                "on the provider's servers, not on a local GPU."
+            )
+        if kwargs.get("tiling"):
+            raise ValueError(
+                "tiling= is meaningless for a remote generator; the provider "
+                "controls its own image scaling."
+            )
+        if kwargs.get("augment"):
+            raise ValueError(
+                "augment= (test-time augmentation) is meaningless for a "
+                "remote generator."
+            )
+        if kwargs.get("cuda_graph"):
+            raise ValueError("cuda_graph= does not apply to a remote LibreVLM.")
+
+    def _announce_metered(self, count: Optional[int], unit: str) -> None:
+        amount = f"~{count} {unit}" if count else f"multiple {unit}"
+        logger.warning(
+            "Remote LibreVLM: %s will be sent to %s (%s), a paid/metered "
+            "endpoint.",
+            amount,
+            self.provider,
+            self.model_id,
+        )
+
+    def _summarize(self, results) -> None:
+        failures = Counter(
+            r.remote["error"]
+            for r in results
+            if isinstance(getattr(r, "remote", None), dict) and r.remote.get("error")
+        )
+        if not failures:
+            return
+        failed = sum(failures.values())
+        detail = ", ".join(f"{k}: {v}" for k, v in sorted(failures.items()))
+        logger.warning(
+            "Remote LibreVLM run: %d ok, %d failed (%s); failed results carry "
+            "result.remote.",
+            len(results) - failed,
+            failed,
+            detail,
+        )
+
+    def _summarizing_stream(self, gen) -> Generator[Results, None, None]:
+        seen = []
+        try:
+            for result in gen:
+                seen.append(result)
+                yield result
+        finally:
+            self._summarize(seen)
+
+    @staticmethod
+    def _video_frame_estimate(source, vid_stride: int = 1) -> Optional[int]:
+        try:
+            import cv2
+
+            cap = cv2.VideoCapture(str(source))
+            try:
+                frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            finally:
+                cap.release()
+            if frames > 0:
+                return max(1, frames // max(1, int(vid_stride)))
+        except Exception:
+            pass
+        return None
+
+    def __call__(self, source: Any = None, **kwargs):
+        self._reject_remote_kwargs(kwargs)
+        spec = classify_source(source)
+        if spec.live or spec.kind == SourceKind.SCREEN:
+            raise ValueError(_LIVE_SOURCE_MESSAGE)
+
+        concurrency = kwargs.pop("batch", None) or _DEFAULT_CONCURRENCY
+        concurrency = max(1, int(concurrency))
+        stream = bool(kwargs.get("stream"))
+
+        if spec.kind == SourceKind.VIDEO:
+            estimate = self._video_frame_estimate(
+                spec.source, kwargs.get("vid_stride", 1)
+            )
+            self._announce_metered(estimate, "frames")
+            out = self._runner(source, **kwargs)
+            if stream:
+                return self._summarizing_stream(out)
+            self._summarize(out)
+            return out
+
+        images = None
+        if spec.kind == SourceKind.DIRECTORY:
+            images = ImageLoader.collect_images(spec.source)
+        elif spec.kind == SourceKind.IMAGE_BATCH:
+            images = list(spec.items)
+
+        if images is not None:
+            if not images:
+                return iter(()) if stream else []
+            self._announce_metered(len(images), "images")
+            if stream:
+                return self._summarizing_stream(
+                    self._runner(source, batch=1, **kwargs)
+                )
+            # ``batch`` is request concurrency here, never a stacked tensor.
+            # In-memory items with save=True keep the sequential path so the
+            # runner's indexed save stems cannot collide across threads.
+            poolable = concurrency > 1 and len(images) > 1
+            if kwargs.get("save") and not all(
+                isinstance(im, (str, Path)) for im in images
+            ):
+                poolable = False
+            if not poolable:
+                results = self._runner(source, batch=1, **kwargs)
+            else:
+                runner = self._runner  # materialize once before forking
+                with ThreadPoolExecutor(
+                    max_workers=min(concurrency, len(images))
+                ) as pool:
+                    results = list(
+                        pool.map(lambda im: runner(im, **kwargs), images)
+                    )
+            self._summarize(results)
+            return results
+
+        # Single image (path or in-memory).
+        return self._runner(source, **kwargs)
+
+    def predict(self, *args, **kwargs):
+        return self(*args, **kwargs)
+
+    def track(self, source, **kwargs):
+        spec = classify_source(source)
+        if spec.live or spec.kind == SourceKind.SCREEN:
+            raise ValueError(_LIVE_SOURCE_MESSAGE)
+        estimate = self._video_frame_estimate(source, kwargs.get("vid_stride", 1))
+        self._announce_metered(estimate, "frames")
+        return super().track(source, **kwargs)
+
+    # =========================================================================
+    # chat(): the raw escape hatch (same signature/return as local)
+    # =========================================================================
+
+    def chat(
+        self,
+        image: ImageInput,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+        color_format: str = "auto",
+    ) -> str:
+        """Raw multimodal generation over HTTP: image + prompt in, text out.
+
+        Single-shot and loud: transport errors raise. For streaming, async,
+        history, or the native SDK object, use ``LibreLLM``.
+        """
+        img = ImageLoader.load(image, color_format=color_format)
+        return self._request_text(
+            _encode_pil(img), str(prompt), max_new_tokens=max_new_tokens
+        )
+
+    # =========================================================================
+    # selftest(): can this hosted model actually ground?
+    # =========================================================================
+
+    def selftest(self, iou_pass: float = 0.5) -> dict:
+        """Probe whether this hosted model returns usable boxes.
+
+        Two metered calls: a red rectangle on white at a known position
+        (expects one parseable box with IoU >= ``iou_pass``), and a blank
+        gray image (expects zero boxes). Makes no mAP claim; it is a cheap
+        go/no-go before pointing a folder at an unknown model. Does not
+        touch the sticky ``set_classes`` vocabulary.
+
+        Returns a dict: ``passed``, ``iou``, ``false_positives``, ``raw``
+        (the two response texts).
+        """
+        from PIL import Image, ImageDraw
+
+        width, height = 640, 480
+        target = (0.2, 0.2, 0.8, 0.8)
+        positive = Image.new("RGB", (width, height), (255, 255, 255))
+        ImageDraw.Draw(positive).rectangle(
+            (
+                int(target[0] * width),
+                int(target[1] * height),
+                int(target[2] * width),
+                int(target[3] * height),
+            ),
+            fill=(220, 30, 30),
+        )
+        blank = Image.new("RGB", (width, height), (128, 128, 128))
+
+        prompt = self._custom_prompt or self._format_detection_prompt(
+            "red rectangle"
+        )
+
+        def probe_boxes(img):
+            text = self._request_text(_encode_pil(img), prompt)
+            boxes = []
+            for item in extract_detections(text):
+                normalized = self._normalize_item(item)
+                box = normalize_bbox(to_xyxy(normalized.get("bbox")))
+                if box is not None:
+                    boxes.append(box)
+            return text, boxes
+
+        raw_positive, boxes_positive = probe_boxes(positive)
+        raw_blank, boxes_blank = probe_boxes(blank)
+
+        best_iou = max(
+            (_iou_xyxy(box, target) for box in boxes_positive), default=0.0
+        )
+        false_positives = len(boxes_blank)
+        passed = best_iou >= iou_pass and false_positives == 0
+        if passed:
+            logger.warning(
+                "Remote LibreVLM selftest PASSED for %s/%s: probe IoU %.2f, "
+                "no false positives on a blank image.",
+                self.provider,
+                self.model_id,
+                best_iou,
+            )
+        else:
+            logger.warning(
+                "Remote LibreVLM selftest FAILED for %s/%s: probe IoU %.2f "
+                "(need >= %.2f), %d box(es) on a blank image. This model does "
+                "not ground reliably with the generic prompt; use chat(), "
+                "pass prompt=, or pick a different model.",
+                self.provider,
+                self.model_id,
+                best_iou,
+                iou_pass,
+                false_positives,
+            )
+        return {
+            "passed": passed,
+            "iou": best_iou,
+            "false_positives": false_positives,
+            "raw": [raw_positive, raw_blank],
+        }
+
+    # =========================================================================
+    # Out of scope
+    # =========================================================================
+
+    def train(self, *args, **kwargs):
+        raise NotImplementedError(_INFERENCE_ONLY)
+
+    def val(self, *args, **kwargs):
+        raise NotImplementedError(_INFERENCE_ONLY)
+
+    def export(self, *args, **kwargs):
+        raise NotImplementedError(_INFERENCE_ONLY)
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(provider={self.provider!r}, "
+            f"model={self.model_id!r}, api={self.api!r})"
+        )

--- a/tests/unit/test_vlm_remote.py
+++ b/tests/unit/test_vlm_remote.py
@@ -1,0 +1,467 @@
+"""Unit tests for the remote LibreVLM transport (offline; SDK boundary faked)."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from libreyolo import LibreVLM
+from libreyolo.models.vlm import remote as remote_mod
+from libreyolo.models.vlm.remote import RemoteVLMModel
+
+pytestmark = [pytest.mark.unit, pytest.mark.vlm]
+
+
+class FakeOpenAIError(Exception):
+    pass
+
+
+class FakeRateLimitError(FakeOpenAIError):
+    pass
+
+
+class FakeConnectionError(FakeOpenAIError):
+    pass
+
+
+class FakeTimeoutError(FakeOpenAIError):
+    pass
+
+
+class FakeServerError(FakeOpenAIError):
+    pass
+
+
+class FakeAuthError(FakeOpenAIError):
+    pass
+
+
+def _chat_response(text):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+    )
+
+
+def _responses_response(text):
+    return SimpleNamespace(output_text=text)
+
+
+class FakeChatCompletions:
+    """Returns scripted replies in call order; an Exception entry is raised.
+
+    The last entry repeats once the script is exhausted, so concurrency tests
+    can serve any number of requests.
+    """
+
+    def __init__(self, script):
+        self.script = list(script)
+        self.calls = []
+        self.active = 0
+        self.max_active = 0
+        self._lock = threading.Lock()
+
+    def create(self, **kwargs):
+        with self._lock:
+            self.calls.append(kwargs)
+            entry = self.script.pop(0) if len(self.script) > 1 else self.script[0]
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        try:
+            if kwargs.get("_sleep") or getattr(self, "sleep", 0):
+                time.sleep(getattr(self, "sleep", 0))
+            if isinstance(entry, Exception):
+                raise entry
+            return _chat_response(entry)
+        finally:
+            with self._lock:
+                self.active -= 1
+
+
+class FakeResponsesAPI:
+    def __init__(self, script):
+        self.script = list(script)
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        entry = self.script.pop(0) if len(self.script) > 1 else self.script[0]
+        if isinstance(entry, Exception):
+            raise entry
+        return _responses_response(entry)
+
+
+class FakeClient:
+    def __init__(self, script):
+        self.chat = SimpleNamespace(completions=FakeChatCompletions(script))
+        self.responses = FakeResponsesAPI(script)
+
+
+def _fake_openai(client):
+    return SimpleNamespace(
+        OpenAI=lambda **kwargs: client,
+        RateLimitError=FakeRateLimitError,
+        APIConnectionError=FakeConnectionError,
+        APITimeoutError=FakeTimeoutError,
+        InternalServerError=FakeServerError,
+        AuthenticationError=FakeAuthError,
+    )
+
+
+@pytest.fixture
+def make_remote(monkeypatch):
+    """Build a remote model whose SDK boundary is a scripted fake."""
+
+    def factory(script, model="openai/gpt-test", **kwargs):
+        client = FakeClient(script)
+        monkeypatch.setattr(remote_mod, "_load_openai", lambda: _fake_openai(client))
+        return LibreVLM(model, **kwargs), client
+
+    return factory
+
+
+@pytest.fixture
+def image_100x50(tmp_path):
+    path = tmp_path / "img.jpg"
+    Image.new("RGB", (100, 50), color=(10, 120, 200)).save(path, format="JPEG")
+    return path
+
+
+@pytest.fixture
+def image_dir(tmp_path):
+    folder = tmp_path / "frames"
+    folder.mkdir()
+    for i in range(3):
+        Image.new("RGB", (100, 50), color=(i * 40, 0, 0)).save(
+            folder / f"frame_{i}.jpg", format="JPEG"
+        )
+    return folder
+
+
+BOAT_JSON = '[{"label": "boat", "bbox": [0.1, 0.2, 0.5, 0.8]}]'
+
+
+# =============================================================================
+# Factory routing
+# =============================================================================
+
+
+def test_slash_routes_to_remote(make_remote):
+    model, _ = make_remote([BOAT_JSON])
+    assert isinstance(model, RemoteVLMModel)
+    assert model.provider == "openai"
+    assert model.model_id == "gpt-test"
+
+
+def test_model_id_case_preserved(make_remote):
+    model, _ = make_remote([BOAT_JSON], model="openai/GPT-Test-V2")
+    assert model.model_id == "GPT-Test-V2"
+
+
+def test_nested_slug_kept_verbatim(make_remote, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    model, _ = make_remote([BOAT_JSON], model="openrouter/qwen/qwen3-max")
+    assert model.provider == "openrouter"
+    assert model.model_id == "qwen/qwen3-max"
+    assert model.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_kwarg_provider_form(make_remote):
+    model, _ = make_remote([BOAT_JSON], model="gpt-test", provider="openai")
+    assert isinstance(model, RemoteVLMModel)
+    assert model.model_id == "gpt-test"
+
+
+def test_unknown_provider_error_covers_all_intents():
+    with pytest.raises(ValueError) as excinfo:
+        LibreVLM("Qwen/Qwen3-VL-4B")
+    message = str(excinfo.value)
+    assert "Unknown remote provider 'Qwen'" in message
+    assert "openai, openrouter, openai-compat" in message
+    assert "Hugging Face repo ids are not accepted" in message
+    assert "qwen3-vl-4b" in message
+    assert "checkpoint path" in message
+
+
+def test_windows_drive_path_is_never_a_provider():
+    with pytest.raises(FileNotFoundError, match="No VLM checkpoint"):
+        LibreVLM(r"C:\nonexistent\finetune_dir")
+
+
+def test_relative_path_shape_is_never_a_provider():
+    with pytest.raises(FileNotFoundError, match="No VLM checkpoint"):
+        LibreVLM("./nonexistent_dir")
+
+
+def test_existing_non_checkpoint_path_raises(tmp_path):
+    with pytest.raises(ValueError, match="not a VLM fine-tune checkpoint"):
+        LibreVLM(str(tmp_path))
+
+
+def test_local_alias_rejects_remote_kwargs():
+    with pytest.raises(ValueError, match="only applies to remote"):
+        LibreVLM("qwen3-vl-4b", api_key="sk-x")
+
+
+def test_openai_compat_requires_base_url(make_remote):
+    with pytest.raises(ValueError, match="base_url="):
+        make_remote([BOAT_JSON], model="openai-compat/qwen3-vl-32b")
+
+
+def test_openai_compat_with_base_url(make_remote):
+    model, _ = make_remote(
+        [BOAT_JSON],
+        model="openai-compat/qwen3-vl-32b",
+        base_url="http://localhost:8000/v1",
+        api_key="empty",
+    )
+    assert model.base_url == "http://localhost:8000/v1"
+
+
+def test_openrouter_without_env_key_raises(make_remote, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+        make_remote([BOAT_JSON], model="openrouter/qwen/qwen3-max")
+
+
+def test_device_kwarg_raises(make_remote):
+    with pytest.raises(ValueError, match="provider's servers"):
+        make_remote([BOAT_JSON], device="cuda")
+
+
+def test_unexpected_kwarg_raises(make_remote):
+    with pytest.raises(TypeError, match="Unexpected keyword"):
+        make_remote([BOAT_JSON], tiling=True)
+
+
+# =============================================================================
+# Detection contract
+# =============================================================================
+
+
+def test_predict_returns_pixel_xyxy(make_remote, image_100x50):
+    model, client = make_remote([BOAT_JSON], names=["boat"])
+    result = model.predict(str(image_100x50))
+    xyxy = result.boxes.xyxy[0].tolist()
+    assert xyxy == pytest.approx([10.0, 10.0, 50.0, 40.0])
+    assert getattr(result, "remote", None) is None
+    # chat.completions is the remote default wire API
+    assert client.chat.completions.calls
+    assert not client.responses.calls
+
+
+def test_set_classes_is_sticky_and_in_prompt(make_remote, image_100x50):
+    model, client = make_remote([BOAT_JSON])
+    model.set_classes(["boat", "pink car"])
+    model.predict(str(image_100x50))
+    text = client.chat.completions.calls[0]["messages"][0]["content"][0]["text"]
+    assert "boat" in text and "pink car" in text
+
+
+def test_out_of_vocabulary_labels_dropped(make_remote, image_100x50):
+    model, _ = make_remote(
+        ['[{"label": "zebra", "bbox": [0.1, 0.2, 0.5, 0.8]}]'], names=["boat"]
+    )
+    result = model.predict(str(image_100x50))
+    assert len(result.boxes.xyxy) == 0
+    assert getattr(result, "remote", None) is None  # clean: parsed fine
+
+
+def test_bbox_2d_1000_scale_rescaled(make_remote, image_100x50):
+    model, _ = make_remote(
+        ['[{"label": "boat", "bbox_2d": [100, 200, 500, 800]}]'], names=["boat"]
+    )
+    result = model.predict(str(image_100x50))
+    assert result.boxes.xyxy[0].tolist() == pytest.approx([10.0, 10.0, 50.0, 40.0])
+
+
+def test_responses_api_optin(make_remote, image_100x50):
+    model, client = make_remote([BOAT_JSON], api="responses", names=["boat"])
+    result = model.predict(str(image_100x50))
+    assert len(result.boxes.xyxy) == 1
+    assert client.responses.calls
+    assert not client.chat.completions.calls
+
+
+def test_max_new_tokens_sent_as_cap(make_remote, image_100x50):
+    model, client = make_remote([BOAT_JSON], names=["boat"], max_new_tokens=256)
+    model.predict(str(image_100x50))
+    assert client.chat.completions.calls[0]["max_completion_tokens"] == 256
+
+
+# =============================================================================
+# Errors: empty is never ambiguous
+# =============================================================================
+
+
+def test_parse_failure_attaches_side_channel(make_remote, image_100x50):
+    model, _ = make_remote(["There are two boats near the dock."], names=["boat"])
+    result = model.predict(str(image_100x50))
+    assert len(result.boxes.xyxy) == 0
+    assert result.remote["error"] == "parse"
+    assert result.remote["model"] == "openai/gpt-test"
+
+
+def test_refusal_attaches_side_channel(make_remote, image_100x50):
+    model, _ = make_remote(
+        ["I'm sorry, I can't help with identifying that."], names=["boat"]
+    )
+    result = model.predict(str(image_100x50))
+    assert result.remote["error"] == "refusal"
+
+
+def test_clean_empty_has_no_side_channel(make_remote, image_100x50):
+    model, _ = make_remote(["[]"], names=["boat"])
+    result = model.predict(str(image_100x50))
+    assert len(result.boxes.xyxy) == 0
+    assert getattr(result, "remote", None) is None
+
+
+def test_transient_http_error_becomes_empty_result(make_remote, image_100x50):
+    model, _ = make_remote([FakeRateLimitError("429")], names=["boat"])
+    result = model.predict(str(image_100x50))
+    assert len(result.boxes.xyxy) == 0
+    assert result.remote["error"] == "http"
+    assert "FakeRateLimitError" in result.remote["detail"]
+
+
+def test_auth_error_raises_loud(make_remote, image_100x50):
+    model, _ = make_remote([FakeAuthError("bad key")], names=["boat"])
+    with pytest.raises(FakeAuthError):
+        model.predict(str(image_100x50))
+
+
+def test_folder_run_isolates_failures_and_summarizes(
+    make_remote, image_dir, caplog
+):
+    script = [BOAT_JSON, FakeRateLimitError("429"), BOAT_JSON]
+    model, _ = make_remote(script, names=["boat"])
+    with caplog.at_level(logging.WARNING):
+        results = model.predict(str(image_dir), batch=1)
+    assert len(results) == 3
+    errors = [getattr(r, "remote", None) for r in results]
+    assert errors[0] is None and errors[2] is None
+    assert errors[1]["error"] == "http"
+    assert any("2 ok, 1 failed" in rec.getMessage() for rec in caplog.records)
+
+
+# =============================================================================
+# Cost safety: guards, banner, concurrency
+# =============================================================================
+
+
+@pytest.mark.parametrize("source", [0, "screen", "rtsp://cam.local/stream"])
+def test_live_sources_raise(make_remote, source):
+    model, _ = make_remote([BOAT_JSON])
+    with pytest.raises(ValueError, match="metered API call"):
+        model.predict(source)
+
+
+def test_track_live_source_raises(make_remote):
+    model, _ = make_remote([BOAT_JSON])
+    with pytest.raises(ValueError, match="metered API call"):
+        model.track(0)
+
+
+def test_metered_banner_before_folder(make_remote, image_dir, caplog):
+    model, _ = make_remote([BOAT_JSON], names=["boat"])
+    with caplog.at_level(logging.WARNING):
+        model.predict(str(image_dir), batch=1)
+    banner = [r for r in caplog.records if "paid/metered" in r.getMessage()]
+    assert banner
+    assert "3 images" in banner[0].getMessage()
+
+
+def test_folder_requests_run_concurrently(make_remote, image_dir):
+    model, client = make_remote([BOAT_JSON], names=["boat"])
+    client.chat.completions.sleep = 0.05
+    results = model.predict(str(image_dir))  # default concurrency 8
+    assert len(results) == 3
+    assert client.chat.completions.max_active >= 2
+
+
+def test_folder_stream_yields_results(make_remote, image_dir):
+    model, _ = make_remote([BOAT_JSON], names=["boat"])
+    results = list(model.predict(str(image_dir), stream=True))
+    assert len(results) == 3
+
+
+def test_predict_tiling_and_augment_raise(make_remote, image_100x50):
+    model, _ = make_remote([BOAT_JSON])
+    with pytest.raises(ValueError, match="remote generator"):
+        model.predict(str(image_100x50), tiling=True)
+    with pytest.raises(ValueError, match="remote generator"):
+        model.predict(str(image_100x50), augment=True)
+
+
+def test_predict_device_raises(make_remote, image_100x50):
+    model, _ = make_remote([BOAT_JSON])
+    with pytest.raises(ValueError, match="provider's servers"):
+        model.predict(str(image_100x50), device="cuda")
+
+
+# =============================================================================
+# chat() and CV verbs
+# =============================================================================
+
+
+def test_chat_returns_plain_string(make_remote, image_100x50):
+    model, client = make_remote(["Two boats, one pink."])
+    answer = model.chat(str(image_100x50), "How many boats?")
+    assert answer == "Two boats, one pink."
+    text = client.chat.completions.calls[0]["messages"][0]["content"][0]["text"]
+    assert text == "How many boats?"
+
+
+@pytest.mark.parametrize("verb", ["train", "val", "export"])
+def test_cv_verbs_raise_inference_only(make_remote, verb):
+    model, _ = make_remote([BOAT_JSON])
+    with pytest.raises(NotImplementedError, match="inference-only"):
+        getattr(model, verb)()
+
+
+# =============================================================================
+# selftest()
+# =============================================================================
+
+
+def test_selftest_passes_on_grounded_model(make_remote):
+    script = [
+        '[{"label": "red rectangle", "bbox": [0.2, 0.2, 0.8, 0.8]}]',
+        "[]",
+    ]
+    model, _ = make_remote(script)
+    report = model.selftest()
+    assert report["passed"] is True
+    assert report["iou"] == pytest.approx(1.0)
+    assert report["false_positives"] == 0
+    assert len(report["raw"]) == 2
+
+
+def test_selftest_fails_on_ungrounded_model(make_remote):
+    model, _ = make_remote(["I see a beautiful red shape in this image."])
+    report = model.selftest()
+    assert report["passed"] is False
+    assert report["iou"] == 0.0
+
+
+def test_selftest_fails_on_blank_false_positive(make_remote):
+    script = [
+        '[{"label": "red rectangle", "bbox": [0.2, 0.2, 0.8, 0.8]}]',
+        '[{"label": "red rectangle", "bbox": [0.4, 0.4, 0.6, 0.6]}]',
+    ]
+    model, _ = make_remote(script)
+    report = model.selftest()
+    assert report["passed"] is False
+    assert report["false_positives"] == 1
+
+
+def test_selftest_does_not_touch_vocabulary(make_remote):
+    model, _ = make_remote(["[]"], names=["helmet"])
+    model.selftest()
+    assert list(model.names.values()) == ["helmet"]

--- a/tests/unit/test_vlm_remote.py
+++ b/tests/unit/test_vlm_remote.py
@@ -42,14 +42,30 @@ class FakeAuthError(FakeOpenAIError):
     pass
 
 
-def _chat_response(text):
+class FakeBadRequestError(FakeOpenAIError):
+    pass
+
+
+def _chat_response(text, finish_reason="stop"):
     return SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=text), finish_reason=finish_reason
+            )
+        ]
     )
 
 
-def _responses_response(text):
-    return SimpleNamespace(output_text=text)
+def _responses_response(text, status="completed", reason=None):
+    return SimpleNamespace(
+        output_text=text,
+        status=status,
+        incomplete_details=SimpleNamespace(reason=reason),
+    )
+
+
+class Truncated(str):
+    """Marker: serve this text with a length/incomplete finish signal."""
 
 
 class FakeChatCompletions:
@@ -77,6 +93,8 @@ class FakeChatCompletions:
                 time.sleep(getattr(self, "sleep", 0))
             if isinstance(entry, Exception):
                 raise entry
+            if isinstance(entry, Truncated):
+                return _chat_response(str(entry), finish_reason="length")
             return _chat_response(entry)
         finally:
             with self._lock:
@@ -93,6 +111,10 @@ class FakeResponsesAPI:
         entry = self.script.pop(0) if len(self.script) > 1 else self.script[0]
         if isinstance(entry, Exception):
             raise entry
+        if isinstance(entry, Truncated):
+            return _responses_response(
+                str(entry), status="incomplete", reason="max_output_tokens"
+            )
         return _responses_response(entry)
 
 
@@ -110,6 +132,7 @@ def _fake_openai(client):
         APITimeoutError=FakeTimeoutError,
         InternalServerError=FakeServerError,
         AuthenticationError=FakeAuthError,
+        BadRequestError=FakeBadRequestError,
     )
 
 
@@ -328,6 +351,59 @@ def test_transient_http_error_becomes_empty_result(make_remote, image_100x50):
     assert len(result.boxes.xyxy) == 0
     assert result.remote["error"] == "http"
     assert "FakeRateLimitError" in result.remote["detail"]
+
+
+def test_truncation_400_is_per_image_not_fatal(make_remote, image_100x50):
+    # OpenAI returns a 400 (not a truncated string) when the output limit is
+    # hit. That depends on how much the model had to say about THIS image, so
+    # it must isolate like a parse failure instead of aborting the run.
+    error = FakeBadRequestError(
+        "Error code: 400 - Could not finish the message because max_tokens "
+        "or model output limit was reached. Please try again with higher "
+        "max_tokens."
+    )
+    model, _ = make_remote([error], names=["boat"])
+    result = model.predict(str(image_100x50))
+    assert len(result.boxes.xyxy) == 0
+    assert result.remote["error"] == "truncated"
+
+
+def test_truncation_400_isolated_in_folder(make_remote, image_dir, caplog):
+    error = FakeBadRequestError(
+        "Could not finish the message because max_tokens or model output "
+        "limit was reached."
+    )
+    model, _ = make_remote([BOAT_JSON, error, BOAT_JSON], names=["boat"])
+    with caplog.at_level(logging.WARNING):
+        results = model.predict(str(image_dir), batch=1)
+    assert len(results) == 3
+    assert results[1].remote["error"] == "truncated"
+    assert any("truncated: 1" in rec.getMessage() for rec in caplog.records)
+
+
+def test_malformed_bad_request_still_raises(make_remote, image_100x50):
+    # Same 400 class, but a config error identical on every image: fatal.
+    error = FakeBadRequestError("Invalid value: 'max_tokens' must be an integer")
+    model, _ = make_remote([error], names=["boat"])
+    with pytest.raises(FakeBadRequestError):
+        model.predict(str(image_100x50))
+
+
+def test_finish_reason_length_flags_truncation(make_remote, image_100x50):
+    # Compat hosts (vLLM, Ollama) return 200 + finish_reason="length" with
+    # partial content instead of a 400. Keep the parsed boxes, flag the run.
+    model, _ = make_remote([Truncated(BOAT_JSON)], names=["boat"])
+    result = model.predict(str(image_100x50))
+    assert len(result.boxes.xyxy) == 1  # partial boxes beat none
+    assert result.remote["error"] == "truncated"
+
+
+def test_responses_incomplete_flags_truncation(make_remote, image_100x50):
+    model, _ = make_remote(
+        [Truncated(BOAT_JSON)], api="responses", names=["boat"]
+    )
+    result = model.predict(str(image_100x50))
+    assert result.remote["error"] == "truncated"
 
 
 def test_auth_error_raises_loud(make_remote, image_100x50):


### PR DESCRIPTION
## What

Stacked on #791 (`add-librellm`). Implements ADR 0020: hosted vision chat models behind the existing LibreVLM detector contract.

- `LibreVLM("openai/gpt-5.6-luna")`, `LibreVLM("openrouter/qwen/qwen3.8-max")`, `LibreVLM("openai-compat/<id>", base_url=...)`
- Slash = remote, bare alias = local; path-shaped strings never parse as providers; unknown-provider error covers HF ids, typo'd paths, typo'd providers
- Model id after first slash passes through verbatim (new hosted models work day one)
- Same surface as local: sticky `set_classes`, `predict` on image/list/folder/video file -> pixel-xyxy `Results`, `chat() -> str`, `track()` on files
- One HTTP request per image via shared `openai_transport.py` (extracted from the LLM client, no behavior change); generic [0,1] bbox prompt; `parsing.py` reused; `bbox_2d` 0-1000 rescaled
- Empty is never ambiguous: http/parse/refusal -> empty boxes + `result.remote` side channel + run summary; auth/bad-model raise loud
- Cost rails: live sources raise; metered banner before multi-image runs; `batch=` is request concurrency (default 8)
- `device/tiling/augment/cuda_graph/train/val/export` raise
- `selftest()": 2-probe grounding check (known rectangle IoU + blank-image FP)
- Requires `libreyolo[llm]` only (no transformers for hosted-only machines)
- 43 new offline tests; 345 vlm+llm+factory-adjacent tests green; ADR 0020 + design-doc section + ADR 0002 pointer

## Not in this PR

- `estimate()`/`budget=", Gemini/Anthropic-native transports, autolabel, CLI (ADR 0020 out-of-scope list)
- Live smoke against a real key: manual, one predict + one chat

## Code provenance

Written from scratch for this PR. Reuses in-repo `parsing.py` and the InferenceRunner hooks; talks to the official OpenAI Python SDK (Apache-2.0) as an optional dependency. No third-party code copied.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds OpenAI-compatible remote vision-model routing behind the existing LibreVLM interface and extracts shared OpenAI transport helpers.

- Adds provider/model-id factory routing for OpenAI, OpenRouter, and custom compatible endpoints.
- Implements remote detection, chat, finite-source batching, error metadata, and grounding self-tests.
- Documents the transport contract and adds offline unit coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/vlm/remote.py | Implements the remote LibreVLM client, request lifecycle, parsing, finite-source concurrency, error side channel, and self-test behavior. |
| libreyolo/models/vlm/__init__.py | Extends LibreVLM factory routing to distinguish local aliases, checkpoint paths, and remote provider/model identifiers. |
| libreyolo/models/llm/openai_transport.py | Centralizes lazy SDK loading, image encoding, payload construction, response decoding, and client options shared by LibreLLM and remote LibreVLM. |
| libreyolo/models/llm/client.py | Refactors LibreLLM to consume the shared transport helpers without changing its public request surface. |
| tests/unit/test_vlm_remote.py | Adds offline coverage for remote routing, request construction, detection parsing, errors, batching, chat, tracking, and self-test behavior. |
| docs/adr/0020-librevlm-remote-transport.md | Defines the remote transport’s routing, failure, cost-safety, parsing, installation, and compatibility decisions. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Factory[LibreVLM factory] -->|bare alias or checkpoint| Local[Local VLM]
    Factory -->|provider/model-id| Remote[RemoteVLMModel]
    Remote --> Encode[Encode image and build prompt]
    Encode --> API[OpenAI-compatible API]
    API --> Parse[Parse and normalize boxes]
    Parse --> Results[Pixel-xyxy Results]
    API -->|per-image recoverable failure| Metadata[result.remote metadata]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Isolate output-limit truncation as a per..."](https://github.com/libreyolo/libreyolo/commit/e21e206d17301dc11c92de8a16e929dd0c7b6bf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53524700)</sub>

<!-- /greptile_comment -->