### PR TITLE
Add CUDA MSDA install hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
+- **CUDA MSDA discovery (#781).** Eager DETR-family CUDA calls that no
+  accelerated provider accepts log one hint for `libreyolo[hub-kernels]`;
+  `LIBREYOLO_HUB_KERNELS=0` keeps the portable path and silences the hint.
 - **MSDA slot follow-ups from #784.** `maybe_ms_deform_attn` walks eligible
   providers when the preferred Hub kernel returns None, so Triton still
   runs after a Hub reject or disable. Triton skips the `spatial_shapes`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ result = model(SAMPLE_IMAGE, save=True)
 
 The base install covers YOLOv9 and the other core detectors, training, and
 inference. Add an extra when you need a heavier family or an export backend.
-Comma-separate to combine, for example `pip install "libreyolo[rfdetr,onnx]"`.
+Comma-separate to combine, for example `pip install "libreyolo[rfdetr,hub-kernels]"`.
 
 | Group | Extras |
 | --- | --- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@ result = model(SAMPLE_IMAGE, save=True)
 
 基础安装已覆盖 YOLOv9 与其他核心检测器、训练和推理。当你需要更重的模型系列
 或某个导出后端时，再安装对应的扩展依赖即可。多个扩展用逗号组合，例如
-`pip install "libreyolo[rfdetr,onnx]"`。
+`pip install "libreyolo[rfdetr,hub-kernels]"`。
 
 | 分组 | 扩展依赖 |
 | --- | --- |

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -44,10 +44,13 @@ first eligible name.
 
 Compiled kernels published on the Hugging Face Hub load at runtime through
 the optional `kernels` package. Installing the extra is the opt-in:
-`pip install libreyolo[hub-kernels]` enables them, and without the package
-nothing changes (no network access, portable paths everywhere). Set
-`LIBREYOLO_HUB_KERNELS=0` to disable them without uninstalling. Nothing is
-vendored; artifacts are fetched and cached by the `kernels` package, and a
+`pip install libreyolo[hub-kernels]` enables them. Without the package, an
+eager CUDA DETR call that no in-tree provider accepts uses the portable path
+and logs one install hint. Set `LIBREYOLO_HUB_KERNELS=0` to disable them
+without uninstalling and silence the hint. Nothing is vendored; artifacts are
+fetched and cached by the `kernels` package. The global
+`LIBREYOLO_KERNELS=off|reference` portable-path override also suppresses the
+hint. A
 kernel that fails to load or run disables itself for the process and falls
 back to the portable path with one warning. When the installed `kernels`
 release cannot resolve the pinned commit (newer releases reject SHA

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -62,21 +62,49 @@ _SLOT_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
 
 _hub_kernel = None
 _hub_failed = False
+_missing_hub_hint_emitted = False
 
 
 def _hub_enabled() -> bool:
     """Hub kernels are on by default; installing the extra is the opt-in.
 
     The runtime fetch only ever happens when the optional ``kernels``
-    package is installed (see :func:`_eligible`), so users who never
-    installed ``libreyolo[hub-kernels]`` are unaffected.
-    ``LIBREYOLO_HUB_KERNELS=0`` is the opt-out.
+    package is installed (see :func:`_eligible`). Without it, an eager CUDA
+    call that falls back emits one install hint.
+    ``LIBREYOLO_HUB_KERNELS=0`` disables the provider and the hint.
     """
     return os.environ.get("LIBREYOLO_HUB_KERNELS", "").strip().lower() not in (
         "0",
         "false",
         "off",
         "no",
+    )
+
+
+def _kernel_selection_disables_acceleration() -> bool:
+    """Whether the global selector explicitly requests the portable path."""
+    forced = os.environ.get("LIBREYOLO_KERNELS", "").strip().lower()
+    if not forced:
+        forced = os.environ.get("LIBREYOLO_QUANT_KERNELS", "").strip().lower()
+    return forced in ("off", "reference")
+
+
+def _warn_missing_hub_kernels_once(value: Optional[torch.Tensor]) -> None:
+    """Hint once when a real CUDA call has no Hub client to accelerate it."""
+    global _missing_hub_hint_emitted
+    if (
+        _missing_hub_hint_emitted
+        or not getattr(value, "is_cuda", False)
+        or not _hub_enabled()
+        or _kernel_selection_disables_acceleration()
+        or importlib.util.find_spec("kernels") is not None
+    ):
+        return
+    _missing_hub_hint_emitted = True
+    logger.warning(
+        "No accelerated MSDA provider accepted this CUDA call; using the portable "
+        "path. Install `libreyolo[hub-kernels]` for the compiled kernel, or set "
+        "LIBREYOLO_HUB_KERNELS=0 to silence this hint."
     )
 
 
@@ -326,7 +354,7 @@ def _not_exporting() -> bool:
     return False
 
 
-def ms_deform_attn_available() -> bool:
+def ms_deform_attn_available(value: Optional[torch.Tensor] = None) -> bool:
     """Whether the slot could run here, checked before adapting layouts.
 
     Families whose native layout differs from the slot's ask this first so
@@ -335,6 +363,9 @@ def ms_deform_attn_available() -> bool:
     report unavailable: exported graphs must not capture a runtime-fetched
     kernel. ``is_exporting`` covers non-strict ``torch.export``, which traces
     with FakeTensors without setting ``is_compiling``.
+
+    Pass the original value tensor so an actual CUDA fallback can emit the
+    one-time Hub-kernel install hint without warning for CPU model calls.
     """
     if (
         torch.jit.is_tracing()
@@ -343,7 +374,10 @@ def ms_deform_attn_available() -> bool:
         or torch.onnx.is_in_onnx_export()
     ):
         return False
-    return resolve("ms_deform_attn") is not None
+    available = resolve("ms_deform_attn") is not None
+    if not available:
+        _warn_missing_hub_kernels_once(value)
+    return available
 
 
 @functools.lru_cache(maxsize=32)
@@ -384,7 +418,7 @@ def maybe_ms_deform_attn(
     ``torch.export``, which traces with FakeTensors without setting
     ``is_compiling``.
     """
-    if not ms_deform_attn_available():
+    if not ms_deform_attn_available(value):
         return None
     # Walk eligible providers. Hub is preferred but may return None for an
     # input or disable itself after a launch failure; Triton must still run.
@@ -394,6 +428,7 @@ def maybe_ms_deform_attn(
         )
         if output is not None:
             return output
+    _warn_missing_hub_kernels_once(value)
     return None
 
 
@@ -413,7 +448,7 @@ def maybe_ms_deform_attn_v2(
     portable path. ``value`` must already be in the slot's
     ``(bs, Len_in, n_heads, c)`` layout.
     """
-    if not ms_deform_attn_available():
+    if not ms_deform_attn_available(value):
         return None
     levels = len(num_points_list)
     if levels == 0 or len(spatial_shapes) != levels:

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -89,6 +89,16 @@ def _kernel_selection_disables_acceleration() -> bool:
     return forced in ("off", "reference")
 
 
+def _hub_client_installed_for_hint() -> bool:
+    """Check discovery without letting an importer error break fallback."""
+    try:
+        return importlib.util.find_spec("kernels") is not None
+    except Exception:
+        # The registry already logs predicate failures. Suppress this optional
+        # install hint rather than raising again or misdiagnosing the package.
+        return True
+
+
 def _warn_missing_hub_kernels_once(value: Optional[torch.Tensor]) -> None:
     """Hint once when a real CUDA call has no Hub client to accelerate it."""
     global _missing_hub_hint_emitted
@@ -97,7 +107,7 @@ def _warn_missing_hub_kernels_once(value: Optional[torch.Tensor]) -> None:
         or not getattr(value, "is_cuda", False)
         or not _hub_enabled()
         or _kernel_selection_disables_acceleration()
-        or importlib.util.find_spec("kernels") is not None
+        or _hub_client_installed_for_hint()
     ):
         return
     _missing_hub_hint_emitted = True

--- a/libreyolo/models/deim/ms_deform.py
+++ b/libreyolo/models/deim/ms_deform.py
@@ -142,7 +142,7 @@ def deformable_attention_core_func_v2(
     ``method='discrete'`` never does, its integer-index sampling is a
     different equation.
     """
-    if method == "default" and ms_deform_attn_available():
+    if method == "default" and ms_deform_attn_available(value[0]):
         accelerated = maybe_ms_deform_attn_v2(
             # Per-level (bs, n_head, c, H*W) -> the slot's (bs, Len_in, n_head, c).
             torch.cat(list(value), dim=-1).permute(0, 3, 1, 2),

--- a/libreyolo/models/dfine/ms_deform.py
+++ b/libreyolo/models/dfine/ms_deform.py
@@ -161,7 +161,7 @@ def deformable_attention_core_func_v2(
         method == "default"
         and not _FORCE_MANUAL_GRID_SAMPLE_EXPORT
         and not _FORCE_MANUAL_GRID_SAMPLE.get()
-        and ms_deform_attn_available()
+        and ms_deform_attn_available(value[0])
     ):
         accelerated = maybe_ms_deform_attn_v2(
             # Per-level (bs, n_head, c, H*W) -> the slot's (bs, Len_in, n_head, c).

--- a/libreyolo/models/ec/decoder.py
+++ b/libreyolo/models/ec/decoder.py
@@ -1339,7 +1339,7 @@ def _ms_deform_attn_core_pytorch_pose(
     slot is consulted when that tuple reshapes onto the classic layout;
     export and any shape that cannot adapt keep the ``grid_sample`` path.
     """
-    if ms_deform_attn_available():
+    if ms_deform_attn_available(value[0]):
         flat = _pose_value_to_slot(value, sampling_locations)
         if flat is not None:
             accelerated = maybe_ms_deform_attn(

--- a/libreyolo/models/ec/utils.py
+++ b/libreyolo/models/ec/utils.py
@@ -107,7 +107,8 @@ def deformable_attention_core_func_v2(
     ``method='discrete'`` never does, its integer-index sampling is a
     different equation.
     """
-    if method == "default" and ms_deform_attn_available():
+    hint_value = value[0] if value_shape == "default" else value
+    if method == "default" and ms_deform_attn_available(hint_value):
         if value_shape == "default":
             # Per-level (bs, n_head, c, H*W) -> the slot's (bs, Len_in, n_head, c).
             flat_value = torch.cat(list(value), dim=-1).permute(0, 3, 1, 2)

--- a/libreyolo/models/grounding_dino/nn.py
+++ b/libreyolo/models/grounding_dino/nn.py
@@ -71,7 +71,7 @@ def _msda(value, shapes_list, sampling_locations, attention_weights):
     optional accelerated ``ms_deform_attn`` slot resolves it takes over
     (see ``libreyolo/kernels/attention/ms_deform_attn.py``).
     """
-    if ms_deform_attn_available():
+    if ms_deform_attn_available(value):
         accelerated = maybe_ms_deform_attn(
             value,
             spatial_shapes_tensor(shapes_list, value.device),

--- a/libreyolo/models/lwdetr/nn.py
+++ b/libreyolo/models/lwdetr/nn.py
@@ -827,7 +827,7 @@ def ms_deform_attn_core_pytorch(
     (see ``libreyolo/kernels/attention/ms_deform_attn.py``) it takes over;
     the grid_sample path below stays the default and the export path.
     """
-    if ms_deform_attn_available():
+    if ms_deform_attn_available(value):
         weights = attention_weights
         if weights.dim() == 4:
             # The caller flattens (levels, points); the slot takes them split.

--- a/libreyolo/models/openvocab/ovdeim/decoder.py
+++ b/libreyolo/models/openvocab/ovdeim/decoder.py
@@ -62,7 +62,7 @@ def deformable_attention_core_func_v2(
     ``method='discrete'`` never does, its integer-index sampling is a
     different equation.
     """
-    if method == "default" and ms_deform_attn_available():
+    if method == "default" and ms_deform_attn_available(value):
         accelerated = maybe_ms_deform_attn_v2(
             value,
             spatial_shapes_tensor(value_spatial_shapes, value.device),

--- a/libreyolo/models/rtdetr/utils.py
+++ b/libreyolo/models/rtdetr/utils.py
@@ -79,7 +79,7 @@ def deformable_attention_core_func(
     # optional accelerated ``ms_deform_attn`` slot resolves it takes over
     # (see ``libreyolo/kernels/attention/ms_deform_attn.py``). The layout here
     # is already the slot's, so only the spatial shapes need normalizing.
-    if ms_deform_attn_available():
+    if ms_deform_attn_available(value):
         accelerated = maybe_ms_deform_attn(
             value,
             spatial_shapes_tensor(value_spatial_shapes, value.device),

--- a/libreyolo/models/rtdetrv2/utils.py
+++ b/libreyolo/models/rtdetrv2/utils.py
@@ -69,7 +69,11 @@ def deformable_attention_core_func_v2(
     ``method='discrete'`` never does, its integer-index sampling is a
     different equation.
     """
-    if method == "default" and allow_acceleration and ms_deform_attn_available():
+    if (
+        method == "default"
+        and allow_acceleration
+        and ms_deform_attn_available(value)
+    ):
         accelerated = maybe_ms_deform_attn_v2(
             value,
             spatial_shapes_tensor(value_spatial_shapes, value.device),

--- a/tests/unit/kernels/test_ms_deform_attn.py
+++ b/tests/unit/kernels/test_ms_deform_attn.py
@@ -31,14 +31,21 @@ LEVELS, POINTS = len(SHAPES), 2
 LEN_IN = sum(h * w for h, w in SHAPES)
 
 
+class _CudaValue:
+    is_cuda = True
+
+
 @pytest.fixture(autouse=True)
 def _clean_registry_env(monkeypatch):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
     monkeypatch.delenv("LIBREYOLO_KERNELS", raising=False)
     monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
     # Accelerated providers are on by default when their extras/runtime
     # exist; pin them off so these tests behave the same on any machine.
     monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", "0")
     monkeypatch.setenv("LIBREYOLO_TRITON_MSDA", "0")
+    monkeypatch.setattr(module, "_missing_hub_hint_emitted", False)
     kernels.clear_cache()
     yield
     kernels.unregister("ms_deform_attn", "mock")
@@ -75,6 +82,132 @@ def test_hub_default_on_and_env_opt_out(monkeypatch):
     for value in ("0", "false", "off", "no"):
         monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", value)
         assert not module._hub_enabled()
+
+
+def test_missing_provider_cuda_hint_warns_once(monkeypatch, caplog):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda _name: None)
+    kernels.clear_cache()
+
+    with caplog.at_level("WARNING", logger=module.__name__):
+        assert not module.ms_deform_attn_available(_CudaValue())
+        assert not module.ms_deform_attn_available(_CudaValue())
+
+    hints = [
+        record.getMessage()
+        for record in caplog.records
+        if "libreyolo[hub-kernels]" in record.getMessage()
+    ]
+    assert len(hints) == 1
+    assert "LIBREYOLO_HUB_KERNELS=0" in hints[0]
+
+
+def test_missing_provider_cuda_hint_after_provider_rejects(monkeypatch, caplog):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda _name: None)
+    kernels.register("ms_deform_attn", lambda *_args: None, name="mock")
+    kernels.clear_cache()
+
+    with caplog.at_level("WARNING", logger=module.__name__):
+        assert maybe_ms_deform_attn(_CudaValue(), None, None, None) is None
+        assert maybe_ms_deform_attn(_CudaValue(), None, None, None) is None
+
+    hints = [
+        record.getMessage()
+        for record in caplog.records
+        if "libreyolo[hub-kernels]" in record.getMessage()
+    ]
+    assert len(hints) == 1
+
+
+def test_missing_provider_hint_respects_opt_out(monkeypatch, caplog):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda _name: None)
+    kernels.clear_cache()
+
+    with caplog.at_level("WARNING", logger=module.__name__):
+        assert not module.ms_deform_attn_available(_CudaValue())
+
+    assert not any(
+        "libreyolo[hub-kernels]" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_missing_provider_hint_when_hub_is_forced(monkeypatch, caplog):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    monkeypatch.setenv("LIBREYOLO_KERNELS", "hub")
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda _name: None)
+    kernels.clear_cache()
+
+    with caplog.at_level("WARNING", logger=module.__name__):
+        assert not module.ms_deform_attn_available(_CudaValue())
+
+    assert any(
+        "libreyolo[hub-kernels]" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize("forced", ["off", "reference"])
+def test_missing_provider_hint_respects_global_portable_override(
+    monkeypatch, caplog, forced
+):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    monkeypatch.setenv("LIBREYOLO_KERNELS", forced)
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda _name: None)
+    kernels.clear_cache()
+
+    with caplog.at_level("WARNING", logger=module.__name__):
+        assert not module.ms_deform_attn_available(_CudaValue())
+
+    assert not any(
+        "libreyolo[hub-kernels]" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_missing_provider_hint_ignores_installed_hub_client(monkeypatch, caplog):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(module, "_hub_failed", True)
+    kernels.clear_cache()
+
+    with caplog.at_level("WARNING", logger=module.__name__):
+        assert not module.ms_deform_attn_available(_CudaValue())
+
+    assert not any(
+        "libreyolo[hub-kernels]" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_missing_provider_hint_ignores_cpu_calls(monkeypatch, caplog):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda _name: None)
+    kernels.clear_cache()
+
+    value, *_ = _classic_inputs()
+    with caplog.at_level("WARNING", logger=module.__name__):
+        assert not module.ms_deform_attn_available(value)
+
+    assert not any(
+        "libreyolo[hub-kernels]" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_hub_impl_rejects_cpu_inputs():

--- a/tests/unit/kernels/test_ms_deform_attn.py
+++ b/tests/unit/kernels/test_ms_deform_attn.py
@@ -193,6 +193,27 @@ def test_missing_provider_hint_ignores_installed_hub_client(monkeypatch, caplog)
     )
 
 
+def test_missing_provider_hint_does_not_propagate_importer_errors(
+    monkeypatch, caplog
+):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    def broken_finder(_name):
+        raise RuntimeError("broken meta path finder")
+
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    monkeypatch.setattr(module.importlib.util, "find_spec", broken_finder)
+    kernels.clear_cache()
+
+    with caplog.at_level("WARNING"):
+        assert not module.ms_deform_attn_available(_CudaValue())
+
+    assert not any(
+        "libreyolo[hub-kernels]" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 def test_missing_provider_hint_ignores_cpu_calls(monkeypatch, caplog):
     from libreyolo.kernels.attention import ms_deform_attn as module
 


### PR DESCRIPTION
What: Make optional compiled MSDA acceleration discoverable for CUDA DETR users.
Why: RF-DETR and related families silently use the portable fallback when no provider accepts a call.

- Log one actionable hint on eager CUDA fallback; CPU, export, installed-client, and explicit opt-out paths stay quiet.
- Pass the actual value tensor through all DETR-family availability checks.
- Advertise `libreyolo[rfdetr,hub-kernels]` in both README mirrors.
- Verified: 92 focused MSDA tests and a real RTX 5070 Ti one-shot warning probe.
- Not verified: the complete kernel directory; unrelated Triton compilation cases exceeded the local three-minute timeout.
- Opened by an agent.

## Code provenance

Original code written for this PR; changes to LibreYOLO first-party code, tests, and documentation only. No third-party code ported, adapted, or introduced; no incompatible-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes optional compiled MSDA acceleration more discoverable for eager CUDA DETR-family calls.
- Passes the original value tensor through MSDA availability checks so CPU and CUDA calls can be distinguished.
- Emits a one-time installation hint when CUDA execution falls back without the optional Hub kernel client.
- Keeps explicit opt-out, export, CPU, and installed-client paths quiet.
- Updates kernel documentation, changelog entries, and focused tests for warning behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/kernels/attention/ms_deform_attn.py | Adds guarded Hub-client discovery and a one-time CUDA fallback hint while preserving portable fallback behavior. |
| tests/unit/kernels/test_ms_deform_attn.py | Adds focused coverage for one-shot warnings, opt-outs, CPU calls, installed clients, and importer exceptions. |
| docs/kernels.md | Documents when the new installation hint appears and which selectors suppress it. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Guard MSDA hint discovery"](https://github.com/libreyolo/libreyolo/commit/361b81fec5cd926723129e2dfb80544bd00fac4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53592393)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/libreyolo/libreyolo/blob/dev/CLAUDE.md))
- Knowledge Base — [Kernel and quantization runtime](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/kernel-and-quantization.md)

<!-- /greptile_comment -->