### PR TITLE
Disable EMA and SyncBN during QAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
+- **QAT training-state guards (#768).** Training a quantized model now
+  disables EMA and SyncBatchNorm before setup and logs the changes, preventing
+  those features from interfering with fake-quant observer and scale state.
 - **CUDA MSDA discovery (#781).** Eager DETR-family CUDA calls that no
   accelerated provider accepts log one hint for `libreyolo[hub-kernels]`;
   `LIBREYOLO_HUB_KERNELS=0` keeps the portable path and silences the hint.

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -277,6 +277,17 @@ Used for: PP-LiteSeg semantic segmentation family
           libreyolo/models/ppliteseg/NOTICE.
 
 --------------------------------------------------------------------
+SuperGradients / QAT training safeguards
+--------------------------------------------------------------------
+Source: https://github.com/Deci-AI/super-gradients
+        pinned commit 63de22c404d5740f34f7706c302b37fce3c8fe5d
+License: Apache License 2.0 (repository LICENSE.md at that commit)
+Copyright (c) 2021-2024 Deci AI
+Used for: the QAT-time EMA and SyncBatchNorm disable policy in
+          libreyolo/training/qat_defaults.py. The LibreYOLO implementation
+          is original; no upstream source code was copied.
+
+--------------------------------------------------------------------
 STDC-Seg (MichaelFan01)
 --------------------------------------------------------------------
 Source: https://github.com/MichaelFan01/STDC-Seg

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -224,8 +224,10 @@ noise. The CLI equivalent is
 ## QAT and QAD mechanics
 
 Quantized modules keep fp32 master weights; fake-quantization applies STE so
-gradients flow to the masters. The existing trainers work unchanged: EMA,
-AMP, checkpoint resume, and the `distill_*` kwargs (MGD/CWD) all compose.
+gradients flow to the masters. AMP, checkpoint resume, and the `distill_*`
+kwargs (MGD/CWD) compose with QAT. At setup, QAT automatically disables EMA
+and SyncBatchNorm and logs the changes because both can interfere with
+fake-quant observer and scale state. Float training is unchanged.
 `fp16`-quantized models are inference-only; the trainer rejects them with a
 pointer to `amp=True`.
 

--- a/libreyolo/training/qat_defaults.py
+++ b/libreyolo/training/qat_defaults.py
@@ -1,0 +1,13 @@
+"""Training safeguards for quantization-aware fine-tuning."""
+
+from typing import Any, Tuple
+
+
+def apply_qat_training_guards(config: Any) -> Tuple[str, ...]:
+    """Disable training features that can interfere with fake-quant state."""
+    changed = []
+    for option in ("ema", "sync_bn"):
+        if getattr(config, option, False):
+            setattr(config, option, False)
+            changed.append(option)
+    return tuple(changed)

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -54,6 +54,7 @@ from .distributed import (
 from .ema import ModelEMA
 from .optim import build_optimizer, restore_optimizer_state
 from .freezing import FreezeGroup, apply_freeze, default_freeze_groups
+from .qat_defaults import apply_qat_training_guards
 from ..data.dataset import YOLODataset, COCODataset, create_dataloader
 from ..data import (
     get_coco_annotation_file,
@@ -1487,6 +1488,16 @@ class BaseTrainer(ABC):
             from ..quant.api import reprepare_model
 
             reprepare_model(self.wrapper_model)
+
+        if quant_manifest:
+            qat_changes = apply_qat_training_guards(self.config)
+            if qat_changes and is_main_process():
+                logger.warning(
+                    "QAT recipe '%s': disabled %s because these features can "
+                    "interfere with fake-quant observer and scale state.",
+                    quant_manifest.get("recipe", "unknown"),
+                    ", ".join(f"{option}=False" for option in qat_changes),
+                )
 
         if getattr(self.config, "lora", False) and not self.supports_lora:
             family = self.get_model_family() if hasattr(self, "get_model_family") else "this model"

--- a/tests/unit/test_qat_defaults.py
+++ b/tests/unit/test_qat_defaults.py
@@ -1,0 +1,86 @@
+"""Tests for quantization-aware training safeguards."""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from libreyolo.training.qat_defaults import apply_qat_training_guards
+from libreyolo.training.trainer import BaseTrainer
+
+
+pytestmark = pytest.mark.unit
+
+
+class _StopSetup(Exception):
+    pass
+
+
+class _ProbeTrainer(BaseTrainer):
+    """Concrete trainer that stops immediately after the QAT guard block."""
+
+    def get_model_family(self):
+        raise _StopSetup
+
+    def get_model_tag(self):
+        raise NotImplementedError
+
+    def create_transforms(self):
+        raise NotImplementedError
+
+    def create_scheduler(self, iters_per_epoch):
+        raise NotImplementedError
+
+    def get_loss_components(self, outputs):
+        raise NotImplementedError
+
+
+def test_qat_guards_disable_ema_and_sync_bn():
+    config = SimpleNamespace(ema=True, sync_bn=True)
+
+    changed = apply_qat_training_guards(config)
+
+    assert changed == ("ema", "sync_bn")
+    assert config.ema is False
+    assert config.sync_bn is False
+
+
+def test_qat_guards_leave_disabled_options_unchanged():
+    config = SimpleNamespace(ema=False, sync_bn=False)
+
+    assert apply_qat_training_guards(config) == ()
+    assert config.ema is False
+    assert config.sync_bn is False
+
+
+def test_trainer_logs_qat_guard_changes(caplog):
+    config = SimpleNamespace(ema=True, sync_bn=True, imgsz=(32, 64))
+    trainer = _ProbeTrainer.__new__(_ProbeTrainer)
+    trainer._is_setup = False
+    trainer.config = config
+    trainer.wrapper_model = SimpleNamespace(
+        _quant_manifest={"recipe": "int8", "state": "prepared"}
+    )
+
+    with caplog.at_level(logging.WARNING, logger="libreyolo.training.trainer"):
+        with pytest.raises(_StopSetup):
+            trainer.setup()
+
+    assert config.ema is False
+    assert config.sync_bn is False
+    assert "ema=False, sync_bn=False" in caplog.text
+    assert "QAT recipe 'int8'" in caplog.text
+
+
+def test_float_trainer_does_not_apply_qat_guards():
+    config = SimpleNamespace(ema=True, sync_bn=True, imgsz=(32, 64))
+    trainer = _ProbeTrainer.__new__(_ProbeTrainer)
+    trainer._is_setup = False
+    trainer.config = config
+    trainer.wrapper_model = SimpleNamespace(_quant_manifest=None)
+
+    with pytest.raises(_StopSetup):
+        trainer.setup()
+
+    assert config.ema is True
+    assert config.sync_bn is True


### PR DESCRIPTION
## Summary

- Disable EMA and SyncBatchNorm when a quantized model enters training setup.
- Log the settings changed for QAT; leave float training unchanged.
- Document the contract and add focused setup coverage.
- Addresses the QAT safety-guard portion of #768; broader QAT tuning remains separate.

## Verification

- 72 quantization unit tests passed.
- 68 focused trainer, QAT, and AMP tests passed.
- Ruff and compile checks passed.

## Code provenance

- Implementation and tests are original code written for this PR.
- The disable policy is derived from Deci-AI/super-gradients commit 63de22c404d5740f34f7706c302b37fce3c8fe5d (Apache-2.0); no upstream source code was copied.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds QAT setup guards that disable EMA and SyncBatchNorm before those features are initialized, while preserving float-training behavior.
- Adds a small helper that mutates enabled QAT-incompatible settings and reports which settings changed.
- Applies the guard after quantization-state validation and finalized-model preparation.
- Documents the QAT contract, provenance, and release-note entry.
- Adds focused tests for guard mutation, warning output, and unchanged float-training settings.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the guards executing before the affected training features are initialized and float training remaining unchanged.

The changed setup path rejects inference-only quantization first, prepares trainable quantized models, disables EMA and SyncBatchNorm before their initialization points, and consistently handles checkpoints without EMA state.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/qat_defaults.py | Adds an idempotent helper that disables enabled EMA and SyncBatchNorm configuration options and returns the changed option names. |
| libreyolo/training/trainer.py | Applies QAT guards before SyncBatchNorm conversion and EMA construction, with rank-aware warning output. |
| tests/unit/test_qat_defaults.py | Covers direct guard behavior, trainer warning output, and preservation of float-training settings. |
| docs/quantization.md | Updates the documented QAT contract to state that EMA and SyncBatchNorm are disabled during setup. |
| THIRD_PARTY_NOTICES.txt | Records the permissively licensed upstream policy influence, pinned commit, and original-implementation status. |
| CHANGELOG.md | Records the new QAT training-state safeguards under the unreleased fixes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BaseTrainer.setup] --> B{Quantization manifest present?}
    B -- No --> F[Continue float-training setup unchanged]
    B -- Yes --> C{Inference-only fp16 or bf16?}
    C -- Yes --> D[Reject training]
    C -- No --> E[Reprepare finalized model if needed]
    E --> G[Disable EMA and SyncBatchNorm]
    G --> H[Log changed settings on main process]
    H --> I[Continue optimizer, DDP, AMP, and model setup]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Disable EMA and SyncBN for QAT"](https://github.com/libreyolo/libreyolo/commit/19aad5dde67e6ea2bb20972088dd8beffd6a52fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53595967)</sub>

**Context used:**

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)

<!-- /greptile_comment -->