### PR TITLE
Stamp YOLOv9 letterbox pad and restore training-only PGI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ before 1.4.0 are documented in the
 
 ## [Unreleased]
 
+### Changed
+
+- **YOLOv9 letterbox is now stamped on the checkpoint, not flipped
+  globally.** Unmarked ≤1.5 weights keep top-left pad (same predict/val
+  boxes as today). Newly converted official MultimediaTechLab checkpoints
+  stamp `letterbox_pad: center`. A 1.6 upgrade does not silently move
+  boxes on existing user fine-tunes. YOLO-NAS is unchanged (its official
+  pipeline already pads bottom-right).
+- **YOLOv9 training recipe closer to MultimediaTechLab/YOLO.**
+  `max_labels` default is 300 (was 100). LinearLR SGD momentum warms
+  `0.8 → 0.937` over the existing 3-epoch warmup. New stock-detect
+  fine-tunes attach the PGI auxiliary head (`aux_weight=0.25`); resume of
+  a single-head 1.5 checkpoint stays single-head. Inference and export
+  remain single-head either way. Val NMS defaults are **not** changed
+  (`0.001` / `0.6` / `300`); reported mAP stays comparable across 1.5
+  and 1.6 for the same unmarked weights.
+
 ### Fixed
 
 - **QAT training-state guards (#768).** Training a quantized model now

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -48,6 +48,15 @@ Required field meanings:
   inference sizing follows the family's documented predict and validation
   rules.
 
+Optional family-specific geometry (not required by schema v1.0):
+
+- `letterbox_pad`: `"topleft"` or `"center"`. YOLOv9 only. Official
+  MultimediaTechLab conversions stamp `"center"`. Checkpoints written before
+  this field existed, and every user fine-tune from LibreYOLO ≤1.5, are
+  treated as `"topleft"`. Loaders must not assume a family-wide default other
+  than that unmarked-means-topleft rule. YOLO-NAS is not this field: its
+  official pipeline already pads bottom-right in `preprocess/yolonas.py`.
+
 Pose checkpoints additionally include:
 
 - `nc` / `names`: pose is usually single-class (`nc: 1`, `person`), but the

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,6 +7,41 @@ The full list of changes for any release is in
 [CHANGELOG.md](../CHANGELOG.md); this page carries only the parts that require
 you to edit code or re-check numbers.
 
+## v1.5.x to v1.6.0
+
+Existing YOLOv9 checkpoints keep the same predict/val boxes after the
+upgrade. Do not re-export or re-evaluate old weights expecting a silent
+letterbox flip: there is none.
+
+### What does not break
+
+- Unmarked YOLOv9 `.pt` files (every LibreYOLO ≤1.5 fine-tune, and the
+  already-published `LibreYOLO9{t,s,m,c}.pt` mirrors) keep **top-left**
+  letterbox. Inference of those files is bit-identical to 1.5.
+- The PGI auxiliary head is training-only. Old checkpoints load and infer
+  as single-head models. Export graphs stay on the main head.
+- Validation NMS defaults (`0.001` / `0.6` / `300`) are unchanged. Val
+  numbers from 1.5 remain comparable.
+
+### What does change (new training / new converts only)
+
+- Newly converted official MultimediaTechLab weights stamp
+  `letterbox_pad: center` and keep the auxiliary PGI tensors. Fine-tunes
+  that start from those files train with center-pad and PGI.
+- New YOLOv9 training defaults: `max_labels=300`, SGD momentum warmup
+  `0.8 → 0.937` over the existing 3-epoch LR warmup, and `aux_weight=0.25`
+  on stock detect (not P2/E2E). Resume of a 1.5 checkpoint without `aux.*`
+  keys stays single-head.
+- To force center-pad on an unmarked checkpoint: `model.train(...,
+  letterbox_pad="center")`. To disable PGI: `aux_weight=0`.
+
+### What you should re-check
+
+- If you compare val mAP of a **new** official convert (center-stamped)
+  against a 1.5 number that used the same weights under top-left pad, the
+  scores will move. That is the intended geometry match with upstream, not
+  a silent default flip of your old files.
+
 ## v1.4.0 to v1.5.0
 
 Nothing was removed from the public API surface: every class and function that

--- a/libreyolo/data/augment/geometry.py
+++ b/libreyolo/data/augment/geometry.py
@@ -233,7 +233,15 @@ def rot90_image_boxes(image, boxes, k):
     return rotated, out
 
 
-def letterbox_preproc(img, input_size, swap=(2, 0, 1), *, to_rgb=False, scale=False):
+def letterbox_preproc(
+    img,
+    input_size,
+    swap=(2, 0, 1),
+    *,
+    to_rgb=False,
+    scale=False,
+    letterbox_pad=None,
+):
     """Letterbox resize + pad (114) + HWC→CHW transpose.
 
     The historical per-family ``preproc`` copies differed only in two finalize
@@ -241,19 +249,19 @@ def letterbox_preproc(img, input_size, swap=(2, 0, 1), *, to_rgb=False, scale=Fa
 
     - ``to_rgb=False, scale=False`` — YOLOX/PicoDet/RTMDet (BGR, raw 0-255)
     - ``to_rgb=True, scale=True``   — YOLO9/RT-DETR/YOLO-NAS (RGB, /255)
-    """
-    if len(img.shape) == 3:
-        padded_img = np.ones((input_size[0], input_size[1], 3), dtype=np.uint8) * 114
-    else:
-        padded_img = np.ones(input_size, dtype=np.uint8) * 114
 
-    r = min(input_size[0] / img.shape[0], input_size[1] / img.shape[1])
-    resized_img = cv2.resize(
+    ``letterbox_pad`` is ``topleft`` (historical default) or ``center``.
+    YOLOX and other non-YOLOv9 callers must leave it unset.
+    """
+    from libreyolo.preprocess.letterbox import apply_letterbox_hwc
+
+    padded_img, r, _pad_left, _pad_top = apply_letterbox_hwc(
         img,
-        (int(img.shape[1] * r), int(img.shape[0] * r)),
-        interpolation=cv2.INTER_LINEAR,
-    ).astype(np.uint8)
-    padded_img[: int(img.shape[0] * r), : int(img.shape[1] * r)] = resized_img
+        int(input_size[0]),
+        int(input_size[1]),
+        pad=letterbox_pad,
+        fill=114,
+    )
 
     if to_rgb:
         padded_img = padded_img[:, :, ::-1]

--- a/libreyolo/data/augment/yolo9.py
+++ b/libreyolo/data/augment/yolo9.py
@@ -41,9 +41,11 @@ from .segments import (
 logger = logging.getLogger(__name__)
 
 
-def preproc(img, input_size, swap=(2, 0, 1)):
+def preproc(img, input_size, swap=(2, 0, 1), letterbox_pad=None):
     """Letterbox to RGB float32/0-1 (matches YOLO9ValPreprocessor and weights)."""
-    return letterbox_preproc(img, input_size, swap, to_rgb=True, scale=True)
+    return letterbox_preproc(
+        img, input_size, swap, to_rgb=True, scale=True, letterbox_pad=letterbox_pad
+    )
 
 
 class YOLO9TrainTransform:
@@ -56,7 +58,7 @@ class YOLO9TrainTransform:
 
     def __init__(
         self,
-        max_labels=100,
+        max_labels=300,
         flip_prob=0.5,
         vertical_flip_prob=0.0,
         hsv_prob=1.0,
@@ -64,6 +66,7 @@ class YOLO9TrainTransform:
         output_label_dim=None,
         flipud=None,
         rot90_prob=0.0,
+        letterbox_pad=None,
     ):
         """
         Args:
@@ -88,6 +91,7 @@ class YOLO9TrainTransform:
         self.mask_downsample_ratio = mask_downsample_ratio
         self.output_label_dim = output_label_dim
         self.rot90_prob = rot90_prob
+        self.letterbox_pad = letterbox_pad
 
     def __call__(self, image, targets, input_dim, segments=None):
         """
@@ -135,7 +139,9 @@ class YOLO9TrainTransform:
                 image = image[:, ::-1]
             if random.random() < self.vertical_flip_prob:
                 image = image[::-1, :]
-            image, _ = preproc(image, input_dim)
+            image, _ = preproc(
+                image, input_dim, letterbox_pad=self.letterbox_pad
+            )
             if return_masks:
                 # No instances -> zero mask rows (masks are variable-length
                 # per image and padded to the batch max at collate, #527).
@@ -205,12 +211,27 @@ class YOLO9TrainTransform:
             segments_t = _flip_segments_ud(segments_t, height)
 
         # Resize with letterbox
-        image_t, r = preproc(image_t, input_dim)
+        src_h, src_w = image_t.shape[:2]
+        image_t, r = preproc(
+            image_t, input_dim, letterbox_pad=self.letterbox_pad
+        )
 
-        # Scale boxes by resize ratio
+        # Scale boxes by resize ratio, then shift by pad (0 for topleft).
+        from libreyolo.preprocess.letterbox import letterbox_geometry
+
+        _ratio, _nh, _nw, pad_left, pad_top = letterbox_geometry(
+            src_h, src_w, input_dim[0], input_dim[1], self.letterbox_pad
+        )
         boxes = boxes * r
+        boxes[:, [0, 2]] = boxes[:, [0, 2]] + pad_left
+        boxes[:, [1, 3]] = boxes[:, [1, 3]] + pad_top
         segments_t = _transform_segments(
-            segments_t, scale=r, width=input_dim[1], height=input_dim[0]
+            segments_t,
+            scale=r,
+            padw=pad_left,
+            padh=pad_top,
+            width=input_dim[1],
+            height=input_dim[0],
         )
 
         # Filter out tiny boxes (after resize)
@@ -224,12 +245,25 @@ class YOLO9TrainTransform:
 
         # Fallback to original if all boxes filtered
         if len(boxes_t) == 0:
-            image_t, r = preproc(image_o, input_dim)
+            src_h, src_w = image_o.shape[:2]
+            image_t, r = preproc(
+                image_o, input_dim, letterbox_pad=self.letterbox_pad
+            )
+            _ratio, _nh, _nw, pad_left, pad_top = letterbox_geometry(
+                src_h, src_w, input_dim[0], input_dim[1], self.letterbox_pad
+            )
             boxes_t = boxes_o * r
+            boxes_t[:, [0, 2]] = boxes_t[:, [0, 2]] + pad_left
+            boxes_t[:, [1, 3]] = boxes_t[:, [1, 3]] + pad_top
             labels_t = labels_o
             angles_t = angles_o
             segments_t = _transform_segments(
-                segments_o, scale=r, width=input_dim[1], height=input_dim[0]
+                segments_o,
+                scale=r,
+                padw=pad_left,
+                padh=pad_top,
+                width=input_dim[1],
+                height=input_dim[0],
             )
 
         # Normalize coordinates to [0, 1]
@@ -289,7 +323,9 @@ class YOLO9ValTransform:
             img: Preprocessed image
             dummy: Dummy labels array
         """
-        img, _ = preproc(img, input_size, self.swap)
+        img, _ = preproc(
+            img, input_size, self.swap, letterbox_pad=getattr(self, "letterbox_pad", None)
+        )
         return img, np.zeros((1, 5))
 
 
@@ -661,7 +697,7 @@ class YOLO9MosaicMixupDataset:
         r = np.random.beta(32.0, 32.0)
         img = (img * r + img2 * (1 - r)).astype(img.dtype)
 
-        max_labels = getattr(self.preproc, "max_labels", 100)
+        max_labels = getattr(self.preproc, "max_labels", 300)
         label_dim = labels.shape[1]
 
         # Drop padding (class == -1) from both, then merge the real objects.

--- a/libreyolo/models/autoconvert.py
+++ b/libreyolo/models/autoconvert.py
@@ -496,6 +496,11 @@ def _wrap_claim(
     if names is None:
         names = cls.default_checkpoint_names(nc)
     extra_metadata: dict[str, Any] = {}
+    if cls.FAMILY == "yolo9":
+        # Official MTL YOLOv9 weights were trained center-padded. Stamp
+        # the converted checkpoint so 1.6 infer/val match that geometry
+        # without flipping unmarked LibreYOLO <=1.5 user checkpoints.
+        extra_metadata["letterbox_pad"] = "center"
     if task == "restore":
         # Restore checkpoints use a single schema placeholder, not a semantic
         # class label. Foreign restoration releases normally carry no names.

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1788,6 +1788,10 @@ class BaseModel(ABC):
             rectangular_metadata = {"imgsz_h": imgsz_h, "imgsz_w": imgsz_w}
         else:
             checkpoint_imgsz = int(native_imgsz)
+        extra_metadata = {}
+        save_extra = getattr(self, "_save_extra_metadata", None)
+        if callable(save_extra):
+            extra_metadata = dict(save_extra() or {})
         checkpoint = wrap_libreyolo_checkpoint(
             state_dict,
             model_family=self._get_model_name(),
@@ -1797,6 +1801,7 @@ class BaseModel(ABC):
             names=self.names,
             imgsz=checkpoint_imgsz,
             **rectangular_metadata,
+            **extra_metadata,
         )
         quant_manifest = getattr(self, "_quant_manifest", None)
         if quant_manifest:

--- a/libreyolo/models/yolo9/convert.py
+++ b/libreyolo/models/yolo9/convert.py
@@ -39,7 +39,7 @@ YOLO9_AUX_LAYER_MAP = {
     23: "aux.spp",  # SPPELAN on B5 → A5
     26: "aux.elan_a4",  # RepNCSPELAN after upsample+concat B4
     29: "aux.elan_a3",  # RepNCSPELAN after upsample+concat B3
-    30: "aux.head",  # MultiheadDetection on [A3, A4, A5]
+    30: "aux_head",  # MultiheadDetection on [A3, A4, A5]
 }
 
 # yolo9-t and yolo9-s: ELAN first block, AConv downsampling

--- a/libreyolo/models/yolo9/convert.py
+++ b/libreyolo/models/yolo9/convert.py
@@ -8,10 +8,11 @@ offline ``weights/convert_yolo9_weights.py`` script and the runtime
 auto-conversion path in :mod:`libreyolo.models.autoconvert` share one
 implementation.
 
-The conversion is structural only — it renames keys and drops the
-auxiliary-detection-head weights (layers >= 23) and the ``anc2vec`` buffers that
-LibreYOLO derives internally. Class count is taken from the upstream detection
-head, so fine-tuned checkpoints with a non-COCO ``nc`` convert correctly.
+The conversion is structural only — it renames keys, keeps the PGI
+auxiliary-branch weights (layers 23/26/29/30 → ``aux.*``) for training, and
+drops the ``anc2vec`` buffers that LibreYOLO derives internally. Class count
+is taken from the upstream detection head, so fine-tuned checkpoints with a
+non-COCO ``nc`` convert correctly.
 """
 
 from __future__ import annotations
@@ -29,6 +30,16 @@ import torch
 COMMON_LAYERS = {
     0: "backbone.conv0",  # Conv 3->X
     1: "backbone.conv1",  # Conv X->Y
+}
+
+# PGI auxiliary branch (MultimediaTechLab v9-*.yaml ``auxiliary``).
+# Training-only; inference never consumes these modules. Old LibreYOLO
+# conversions dropped them; keeping them is additive.
+YOLO9_AUX_LAYER_MAP = {
+    23: "aux.spp",  # SPPELAN on B5 → A5
+    26: "aux.elan_a4",  # RepNCSPELAN after upsample+concat B4
+    29: "aux.elan_a3",  # RepNCSPELAN after upsample+concat B3
+    30: "aux.head",  # MultiheadDetection on [A3, A4, A5]
 }
 
 # yolo9-t and yolo9-s: ELAN first block, AConv downsampling
@@ -51,6 +62,7 @@ YOLO9_TS_LAYER_MAP = {
     21: "neck.elan_down2",  # RepNCSPELAN (P5)
     # Detection head
     22: "head",  # MultiheadDetection
+    **YOLO9_AUX_LAYER_MAP,
 }
 
 # yolo9-m: RepNCSPELAN first block, AConv downsampling
@@ -73,6 +85,7 @@ YOLO9_M_LAYER_MAP = {
     21: "neck.elan_down2",  # RepNCSPELAN (P5)
     # Detection head
     22: "head",  # MultiheadDetection
+    **YOLO9_AUX_LAYER_MAP,
 }
 
 # yolo9-c: RepNCSPELAN first block, ADown downsampling
@@ -95,6 +108,7 @@ YOLO9_C_LAYER_MAP = {
     21: "neck.elan_down2",  # RepNCSPELAN (P5)
     # Detection head
     22: "head",  # MultiheadDetection
+    **YOLO9_AUX_LAYER_MAP,
 }
 
 LAYER_MAPS = {
@@ -185,6 +199,12 @@ def get_layer_type(layer_idx: int, config: str) -> str:
         return "sppelan"
     if layer_idx == 22:
         return "detection"
+    if layer_idx == 23:
+        return "sppelan"
+    if layer_idx in (26, 29):
+        return "repncspelan"
+    if layer_idx == 30:
+        return "detection"
     return "unknown"
 
 
@@ -248,7 +268,8 @@ def convert_state_dict(
 
     Returns:
         ``(converted_state_dict, stats)`` where ``stats`` has ``converted``,
-        ``skipped`` (auxiliary head, layers >= 23) and ``failed`` counts.
+        ``skipped`` (unmapped aux leftovers such as ``anc2vec``, layers >= 23)
+        and ``failed`` counts.
     """
     if config not in LAYER_MAPS:
         raise ValueError(

--- a/libreyolo/models/yolo9/loss.py
+++ b/libreyolo/models/yolo9/loss.py
@@ -489,7 +489,11 @@ class BoxMatcher:
 
 class YOLO9Loss:
     """
-    Combined loss for YOLOv9 training (single head, no auxiliary).
+    Combined loss for one YOLOv9 detection head.
+
+    The optional PGI auxiliary head uses a second ``YOLO9Loss`` instance;
+    ``LibreYOLO9Model`` adds ``aux_weight * aux_loss`` when that branch is
+    attached. Inference never instantiates this class.
 
     Computes:
     - Box loss (CIoU)

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -30,6 +30,11 @@ _TRAIN_DEFAULTS = YOLO9Config()
 logger = logging.getLogger(__name__)
 
 
+def _is_yolo9_aux_key(key: str) -> bool:
+    """True for PGI tensors (``aux.*`` neck or ``aux_head.*``)."""
+    return str(key).startswith("aux.") or str(key).startswith("aux_head.")
+
+
 class LibreYOLO9(BaseModel):
     """YOLOv9 model for object detection.
 
@@ -233,7 +238,11 @@ class LibreYOLO9(BaseModel):
         has_aux = getattr(self.model, "aux", None) is not None
         if has_aux:
             return state_dict
-        return {k: v for k, v in state_dict.items() if not k.startswith("aux.")}
+        return {
+            k: v
+            for k, v in state_dict.items()
+            if not _is_yolo9_aux_key(k)
+        }
 
     def _save_extra_metadata(self) -> dict:
         from ...preprocess.letterbox import normalize_letterbox_pad
@@ -424,6 +433,67 @@ class LibreYOLO9(BaseModel):
         from .trainer import YOLO9Trainer
 
         return YOLO9Trainer
+
+    def _extract_checkpoint_state(self, source: str | Path | dict | None) -> dict:
+        """Return the weight dict from a path or already-loaded checkpoint."""
+        if source is None:
+            return {}
+        if isinstance(source, dict):
+            loaded = source
+        else:
+            path = Path(source)
+            if not path.exists():
+                return {}
+            loaded = load_untrusted_torch_file(
+                str(path),
+                map_location="cpu",
+                context="yolo9 aux probe",
+            )
+        if not isinstance(loaded, dict):
+            return {}
+        if "model" in loaded and isinstance(loaded["model"], dict):
+            state = loaded["model"]
+        elif "state_dict" in loaded and isinstance(loaded["state_dict"], dict):
+            state = loaded["state_dict"]
+        else:
+            state = loaded
+        return self._prepare_state_dict(self._strip_ddp_prefix(state))
+
+    def _maybe_enable_aux_from_path(
+        self, source: str | Path | dict | None, aux_weight: float = 0.25
+    ) -> int:
+        """Attach PGI if *source* carries aux tensors. Returns loaded aux count."""
+        if type(self.model).__name__ != "LibreYOLO9Model":
+            return 0
+        state = self._extract_checkpoint_state(source)
+        if not any(_is_yolo9_aux_key(key) for key in state):
+            return 0
+        self.model.enable_aux(weight=float(aux_weight or 0.25))
+        return self._load_aux_tensors(state)
+
+    def _reload_aux_from_path(self, source: str | Path | dict | None) -> int:
+        """Load aux tensors into an already-attached PGI branch."""
+        if getattr(self.model, "aux", None) is None:
+            return 0
+        return self._load_aux_tensors(self._extract_checkpoint_state(source))
+
+    def _load_aux_tensors(self, state_dict: dict) -> int:
+        if not state_dict:
+            return 0
+        current = self.model.state_dict()
+        matched = {
+            key: value
+            for key, value in state_dict.items()
+            if _is_yolo9_aux_key(key)
+            and key in current
+            and current[key].shape == value.shape
+        }
+        if not matched:
+            return 0
+        current.update(matched)
+        self.model.load_state_dict(current, strict=True)
+        self.model.to(self.device)
+        return len(matched)
 
     # =========================================================================
     # Inference pipeline
@@ -623,16 +693,18 @@ class LibreYOLO9(BaseModel):
         if resume and pretrained:
             raise ValueError("pretrained transfer cannot be combined with resume=True.")
 
-        # PGI aux is training-only. New fine-tunes attach it; resume of a
-        # single-head 1.5 checkpoint stays single-head (trainer.resume).
+        # PGI aux is training-only. Attach before trainer.setup() so the
+        # optimizer / EMA / DDP see the extra parameters. Resume of a
+        # single-head 1.5 checkpoint stays single-head.
         aux_weight = kwargs.get("aux_weight", _TRAIN_DEFAULTS.aux_weight)
-        if (
-            not resume
-            and float(aux_weight or 0) > 0
-            and hasattr(self.model, "enable_aux")
-            and type(self.model).__name__ == "LibreYOLO9Model"
-        ):
-            self.model.enable_aux(weight=float(aux_weight))
+        if type(self.model).__name__ == "LibreYOLO9Model":
+            if resume:
+                self._maybe_enable_aux_from_path(self.model_path, aux_weight)
+            elif float(aux_weight or 0) > 0:
+                self.model.enable_aux(weight=float(aux_weight))
+                # Inference load stripped aux.* from official converts; put
+                # those PGI tensors back now that the branch exists.
+                self._reload_aux_from_path(self.model_path)
 
         if pretrained:
             transfer_weights: str | Path

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -262,23 +262,25 @@ class LibreYOLO9(BaseModel):
             remapped[new_key] = value
         return remapped
 
-    def _rebuild_for_new_classes(self, new_nc: int):
-        """Replace only the final classification layers for different number of classes."""
-        self.nb_classes = new_nc
-        self.model.nc = new_nc
-
-        detect = self.model.head
+    def _rebuild_detect_class_layers(self, detect, new_nc: int) -> None:
         detect.nc = new_nc
         detect.no = new_nc + detect.reg_max * 4
-
         for seq in detect.cv3:
             old_final = seq[-1]
             in_channels = old_final.weight.shape[1]
             seq[-1] = nn.Conv2d(in_channels, new_nc, 1)
-
         detect._init_bias()
         detect._loss_fn = None
         detect.to(next(self.model.parameters()).device)
+
+    def _rebuild_for_new_classes(self, new_nc: int):
+        """Replace only the final classification layers for a new class count."""
+        self.nb_classes = new_nc
+        self.model.nc = new_nc
+        self._rebuild_detect_class_layers(self.model.head, new_nc)
+        aux_head = getattr(self.model, "aux_head", None)
+        if aux_head is not None:
+            self._rebuild_detect_class_layers(aux_head, new_nc)
 
     def _rebuild_for_checkpoint_classes(self, new_nc: int, state_dict: dict):
         """Match YOLO9 checkpoints with either COCO-width or scratch class towers."""

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -35,6 +35,13 @@ def _is_yolo9_aux_key(key: str) -> bool:
     return str(key).startswith("aux.") or str(key).startswith("aux_head.")
 
 
+def resolve_aux_weight(aux_weight) -> float:
+    """Canonical PGI weight. ``None`` is the recipe default; ``0`` stays off."""
+    if aux_weight is None:
+        return 0.25
+    return float(aux_weight)
+
+
 class LibreYOLO9(BaseModel):
     """YOLOv9 model for object detection.
 
@@ -462,15 +469,16 @@ class LibreYOLO9(BaseModel):
         return self._prepare_state_dict(self._strip_ddp_prefix(state))
 
     def _maybe_enable_aux_from_path(
-        self, source: str | Path | dict | None, aux_weight: float = 0.25
+        self, source: str | Path | dict | None, aux_weight: float | None = None
     ) -> int:
         """Attach PGI if *source* carries aux tensors. Returns loaded aux count."""
-        if type(self.model).__name__ != "LibreYOLO9Model":
+        weight = resolve_aux_weight(aux_weight)
+        if weight <= 0 or type(self.model).__name__ != "LibreYOLO9Model":
             return 0
         state = self._extract_checkpoint_state(source)
         if not any(_is_yolo9_aux_key(key) for key in state):
             return 0
-        self.model.enable_aux(weight=float(aux_weight or 0.25))
+        self.model.enable_aux(weight=weight)
         return self._load_aux_tensors(state)
 
     def _reload_aux_from_path(self, source: str | Path | dict | None) -> int:
@@ -698,12 +706,12 @@ class LibreYOLO9(BaseModel):
         # PGI aux is training-only. Attach before trainer.setup() so the
         # optimizer / EMA / DDP see the extra parameters. Resume of a
         # single-head 1.5 checkpoint stays single-head.
-        aux_weight = kwargs.get("aux_weight", _TRAIN_DEFAULTS.aux_weight)
+        aux_weight = resolve_aux_weight(kwargs.get("aux_weight", _TRAIN_DEFAULTS.aux_weight))
         if type(self.model).__name__ == "LibreYOLO9Model":
             if resume:
                 self._maybe_enable_aux_from_path(self.model_path, aux_weight)
-            elif float(aux_weight or 0) > 0:
-                self.model.enable_aux(weight=float(aux_weight))
+            elif aux_weight > 0:
+                self.model.enable_aux(weight=aux_weight)
                 # Inference load stripped aux.* from official converts; put
                 # those PGI tensors back now that the branch exists.
                 self._reload_aux_from_path(self.model_path)

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -160,6 +160,11 @@ class LibreYOLO9(BaseModel):
         **kwargs,
     ):
         self.reg_max = reg_max
+        # Unmarked checkpoints (LibreYOLO <=1.5) used top-left letterbox.
+        # Official MTL conversions stamp ``center``. Never flip unmarked files.
+        from ...preprocess.letterbox import DEFAULT_LETTERBOX_PAD
+
+        self.letterbox_pad = DEFAULT_LETTERBOX_PAD
         super().__init__(
             model_path=model_path,
             size=size,
@@ -208,7 +213,32 @@ class LibreYOLO9(BaseModel):
         state_dict: dict,
         checkpoint: dict | None = None,
     ) -> None:
-        return
+        if isinstance(checkpoint, dict) and "letterbox_pad" in checkpoint:
+            from ...preprocess.letterbox import normalize_letterbox_pad
+
+            self.letterbox_pad = normalize_letterbox_pad(checkpoint.get("letterbox_pad"))
+
+    def _filter_incoming_state_dict(
+        self,
+        state_dict: dict,
+        *,
+        loaded: dict | None = None,
+        checkpoint_task: str | None = None,
+    ) -> dict:
+        """Drop training-only ``aux.*`` keys when the live model is single-head.
+
+        Official conversions keep PGI weights so fine-tunes can load them.
+        Inference and old unmarked checkpoints stay on the main head only.
+        """
+        has_aux = getattr(self.model, "aux", None) is not None
+        if has_aux:
+            return state_dict
+        return {k: v for k, v in state_dict.items() if not k.startswith("aux.")}
+
+    def _save_extra_metadata(self) -> dict:
+        from ...preprocess.letterbox import normalize_letterbox_pad
+
+        return {"letterbox_pad": normalize_letterbox_pad(self.letterbox_pad)}
 
     def _prepare_state_dict(
         self,
@@ -333,6 +363,10 @@ class LibreYOLO9(BaseModel):
                         "Transfer checkpoint metadata is incomplete: "
                         + "; ".join(metadata_errors)
                     )
+            if "letterbox_pad" in loaded:
+                from ...preprocess.letterbox import normalize_letterbox_pad
+
+                self.letterbox_pad = normalize_letterbox_pad(loaded.get("letterbox_pad"))
 
             ckpt_family = loaded.get("model_family", "")
             allowed_families = {
@@ -411,7 +445,10 @@ class LibreYOLO9(BaseModel):
             input_size if input_size is not None else self._get_input_size()
         )
         tensor, img, size = preprocess_image(
-            image, input_size=effective_size, color_format=color_format
+            image,
+            input_size=effective_size,
+            color_format=color_format,
+            letterbox_pad=self.letterbox_pad,
         )
         return tensor, img, size, 1.0
 
@@ -437,6 +474,15 @@ class LibreYOLO9(BaseModel):
             original_size=original_size,
             max_det=max_det,
             letterbox=kwargs.get("letterbox", True),
+            letterbox_pad=self.letterbox_pad,
+        )
+
+    def _get_val_preprocessor(self, img_size: int | None = None):
+        if img_size is None:
+            img_size = self._get_input_size()
+        return self.val_preprocessor_class(
+            img_size=(img_size, img_size),
+            letterbox_pad=self.letterbox_pad,
         )
 
     # =========================================================================
@@ -576,6 +622,17 @@ class LibreYOLO9(BaseModel):
 
         if resume and pretrained:
             raise ValueError("pretrained transfer cannot be combined with resume=True.")
+
+        # PGI aux is training-only. New fine-tunes attach it; resume of a
+        # single-head 1.5 checkpoint stays single-head (trainer.resume).
+        aux_weight = kwargs.get("aux_weight", _TRAIN_DEFAULTS.aux_weight)
+        if (
+            not resume
+            and float(aux_weight or 0) > 0
+            and hasattr(self.model, "enable_aux")
+            and type(self.model).__name__ == "LibreYOLO9Model"
+        ):
+            self.model.enable_aux(weight=float(aux_weight))
 
         if pretrained:
             transfer_weights: str | Path

--- a/libreyolo/models/yolo9/nn.py
+++ b/libreyolo/models/yolo9/nn.py
@@ -909,10 +909,11 @@ class Backbone9(nn.Module):
         x = self.down3(p3)
         p4 = self.elan3(x)
 
-        # Stage 4 - B5/P5
+        # Stage 4 - B5 (pre-SPP) then SPP → P5. Stash B5 for the optional
+        # PGI aux neck without changing this method's 3-tuple return.
         x = self.down4(p4)
-        x = self.elan4(x)
-        p5 = self.spp(x)
+        self.last_b5 = self.elan4(x)
+        p5 = self.spp(self.last_b5)
 
         return p3, p4, p5
 
@@ -998,6 +999,46 @@ class Neck9(nn.Module):
         return out_p3, out_p4, out_p5
 
 
+class AuxNeck(nn.Module):
+    """PGI auxiliary FPN used only during training.
+
+    Mirrors MultimediaTechLab/YOLO ``auxiliary`` in ``v9-*.yaml``: SPPELAN
+    on pre-SPP B5, then top-down concat with B4/B3. Inference never calls
+    this module, so old single-head checkpoints keep their exact graph.
+    """
+
+    def __init__(self, config="c"):
+        super().__init__()
+        cfg = YOLO9_CONFIGS[config]
+        n = cfg["repeat_num"]
+        b3_ch = cfg["stages"][0][1]
+        b4_ch = cfg["stages"][1][1]
+        b5_ch = cfg["stages"][2][1]
+        spp_out = cfg["spp_out"]
+
+        self.spp = SPPELAN(b5_ch, spp_out // 2, spp_out)
+        self.up1 = nn.Upsample(scale_factor=2, mode="nearest")
+        a4_out, a4_part = cfg["neck_elan_up1"]
+        self.elan_a4 = RepNCSPELAN(
+            spp_out + b4_ch, a4_part, a4_part // 2, a4_out, n
+        )
+        self.up2 = nn.Upsample(scale_factor=2, mode="nearest")
+        a3_out, a3_part = cfg["neck_elan_up2"]
+        self.elan_a3 = RepNCSPELAN(
+            a4_out + b3_ch, a3_part, a3_part // 2, a3_out, n
+        )
+
+    def forward(self, p3, p4, b5):
+        a5 = self.spp(b5)
+        x = self.up1(a5)
+        x = torch.cat([x, p4], 1)
+        a4 = self.elan_a4(x)
+        x = self.up2(a4)
+        x = torch.cat([x, p3], 1)
+        a3 = self.elan_a3(x)
+        return a3, a4, a5
+
+
 class LibreYOLO9Model(nn.Module):
     """
     Complete LibreYOLO9 model.
@@ -1046,6 +1087,32 @@ class LibreYOLO9Model(nn.Module):
             reg_max=reg_max,
             stride=(8, 16, 32),
         )
+        # Built only when training with PGI. Inference checkpoints stay
+        # single-head so a 1.6 upgrade does not change the exported graph.
+        self.aux = None
+        self.aux_head = None
+        self.aux_weight = 0.0
+
+    def enable_aux(self, weight: float = 0.25):
+        """Attach the PGI auxiliary neck/head if they are not already present."""
+        self.aux_weight = float(weight)
+        if self.aux is not None:
+            return self
+        cfg = YOLO9_CONFIGS[self.config]
+        self.aux = AuxNeck(self.config)
+        self.aux_head = DDetect(
+            nc=self.nc,
+            ch=cfg["head_channels"],
+            reg_max=self.reg_max,
+            stride=(8, 16, 32),
+        )
+        try:
+            device = next(self.parameters()).device
+        except StopIteration:
+            device = torch.device("cpu")
+        self.aux.to(device)
+        self.aux_head.to(device)
+        return self
 
     def forward(self, x, targets=None):
         """
@@ -1061,7 +1128,8 @@ class LibreYOLO9Model(nn.Module):
             Training without targets: Raw predictions (list of tensors)
             Inference: Dict with decoded predictions and features
         """
-        # Backbone
+        # Backbone. ``last_b5`` is the pre-SPP B5 feature the PGI aux
+        # branch needs; the public 3-tuple return stays (p3, p4, post-SPP p5).
         p3, p4, p5 = self.backbone(x)
 
         # Neck
@@ -1071,7 +1139,20 @@ class LibreYOLO9Model(nn.Module):
         if self.training and targets is not None:
             # Pass image size for anchor generation
             img_size = (x.shape[3], x.shape[2])  # (W, H)
-            return self.head([n3, n4, n5], targets=targets, img_size=img_size)
+            main = self.head([n3, n4, n5], targets=targets, img_size=img_size)
+            if self.aux is None or self.aux_weight <= 0:
+                return main
+            b5 = getattr(self.backbone, "last_b5", None)
+            if b5 is None:
+                return main
+            a3, a4, a5 = self.aux(p3, p4, b5)
+            aux = self.aux_head([a3, a4, a5], targets=targets, img_size=img_size)
+            weight = self.aux_weight
+            combined = dict(main)
+            for key in ("total_loss", "box_loss", "dfl_loss", "cls_loss", "box", "dfl", "cls"):
+                if key in main and key in aux:
+                    combined[key] = main[key] + weight * aux[key]
+            return combined
 
         # Normal forward (training without targets or inference)
         output = self.head([n3, n4, n5])

--- a/libreyolo/models/yolo9/trainer.py
+++ b/libreyolo/models/yolo9/trainer.py
@@ -79,7 +79,7 @@ class YOLO9Trainer(BaseTrainer):
 
         return YOLO9ValidationLoss(
             model,
-            max_labels=int(getattr(self.config, "max_labels", 100)),
+            max_labels=int(getattr(self.config, "max_labels", 300)),
         )
 
     def get_freeze_groups(self) -> List[FreezeGroup]:
@@ -100,17 +100,70 @@ class YOLO9Trainer(BaseTrainer):
                     groups.append((f"neck.{name}", module))
         if head is not None:
             groups.append(("head", head))
+        aux = getattr(model, "aux", None)
+        if aux is not None:
+            groups.append(("aux", aux))
+        aux_head = getattr(model, "aux_head", None)
+        if aux_head is not None:
+            groups.append(("aux_head", aux_head))
         return groups or super().get_freeze_groups()
+
+    def _resolved_letterbox_pad(self) -> str | None:
+        from libreyolo.preprocess.letterbox import normalize_letterbox_pad
+
+        configured = getattr(self.config, "letterbox_pad", None)
+        if configured:
+            pad = normalize_letterbox_pad(configured)
+            if self.wrapper_model is not None:
+                self.wrapper_model.letterbox_pad = pad
+            return pad
+        return getattr(self.wrapper_model, "letterbox_pad", None)
 
     def create_transforms(self):
         preproc = YOLO9TrainTransform(
-            max_labels=getattr(self.config, "max_labels", 100),
+            max_labels=getattr(self.config, "max_labels", 300),
             flip_prob=self.config.flip_prob,
             vertical_flip_prob=getattr(self.config, "flipud", 0.0),
             hsv_prob=self.config.hsv_prob,
             rot90_prob=getattr(self.config, "rot90", 0.0),
+            letterbox_pad=self._resolved_letterbox_pad(),
         )
         return preproc, YOLO9MosaicMixupDataset
+
+    def _checkpoint_extra_metadata(self):
+        extra = super()._checkpoint_extra_metadata()
+        from libreyolo.preprocess.letterbox import normalize_letterbox_pad
+
+        pad = self._resolved_letterbox_pad()
+        extra["letterbox_pad"] = normalize_letterbox_pad(pad)
+        return extra
+
+    def resume(self, checkpoint_path: str):
+        from libreyolo.utils.serialization import load_trusted_torch_file
+        from .nn import LibreYOLO9Model
+
+        checkpoint = load_trusted_torch_file(
+            checkpoint_path,
+            map_location="cpu",
+            context="yolo9 resume aux probe",
+        )
+        state = {}
+        if isinstance(checkpoint, dict):
+            state = checkpoint.get("model") or checkpoint.get("state_dict") or {}
+            if "letterbox_pad" in checkpoint and self.wrapper_model is not None:
+                from libreyolo.preprocess.letterbox import normalize_letterbox_pad
+
+                self.wrapper_model.letterbox_pad = normalize_letterbox_pad(
+                    checkpoint.get("letterbox_pad")
+                )
+        if (
+            type(self.model) is LibreYOLO9Model
+            and any(str(key).startswith("aux.") for key in state)
+        ):
+            self.model.enable_aux(
+                weight=float(getattr(self.config, "aux_weight", 0.25))
+            )
+        return super().resume(checkpoint_path)
 
     def create_scheduler(self, iters_per_epoch: int):
         scheduler_name = self.config.scheduler
@@ -122,6 +175,8 @@ class YOLO9Trainer(BaseTrainer):
                 warmup_epochs=self.config.warmup_epochs,
                 warmup_lr_start=self.config.warmup_lr_start,
                 min_lr_ratio=self.config.min_lr_ratio,
+                warmup_momentum=getattr(self.config, "warmup_momentum", None),
+                momentum=getattr(self.config, "momentum", None),
             )
         elif scheduler_name in ("cos", "warmcos"):
             return CosineAnnealingScheduler(

--- a/libreyolo/models/yolo9/trainer.py
+++ b/libreyolo/models/yolo9/trainer.py
@@ -234,6 +234,10 @@ class YOLO9Trainer(BaseTrainer):
             return None
         if type(self.model.head) is not DDetect:
             return None
+        # Captured forward runs without targets, so the PGI aux branch never
+        # executes and aux params get zero gradients. Fall back to eager.
+        if getattr(self.model, "aux", None) is not None:
+            return None
 
         network = GraphableNetwork(self.model)
 

--- a/libreyolo/models/yolo9/trainer.py
+++ b/libreyolo/models/yolo9/trainer.py
@@ -138,31 +138,34 @@ class YOLO9Trainer(BaseTrainer):
         extra["letterbox_pad"] = normalize_letterbox_pad(pad)
         return extra
 
+    def setup(self):
+        # Attach PGI before optimizer / EMA / DDP when the resume file has it.
+        # ``train(resume=True)`` already did this; this covers setup-first
+        # callers that only pass the path to ``resume()`` later.
+        path = getattr(getattr(self, "wrapper_model", None), "model_path", None)
+        if path and self.wrapper_model is not None:
+            self.wrapper_model._maybe_enable_aux_from_path(
+                path, getattr(self.config, "aux_weight", 0.25)
+            )
+        return super().setup()
+
     def resume(self, checkpoint_path: str):
-        from libreyolo.utils.serialization import load_trusted_torch_file
-        from .nn import LibreYOLO9Model
+        if self.wrapper_model is not None:
+            self.wrapper_model._maybe_enable_aux_from_path(
+                checkpoint_path, getattr(self.config, "aux_weight", 0.25)
+            )
+            from libreyolo.utils.serialization import load_trusted_torch_file
+            from libreyolo.preprocess.letterbox import normalize_letterbox_pad
 
-        checkpoint = load_trusted_torch_file(
-            checkpoint_path,
-            map_location="cpu",
-            context="yolo9 resume aux probe",
-        )
-        state = {}
-        if isinstance(checkpoint, dict):
-            state = checkpoint.get("model") or checkpoint.get("state_dict") or {}
-            if "letterbox_pad" in checkpoint and self.wrapper_model is not None:
-                from libreyolo.preprocess.letterbox import normalize_letterbox_pad
-
+            checkpoint = load_trusted_torch_file(
+                checkpoint_path,
+                map_location="cpu",
+                context="yolo9 resume letterbox probe",
+            )
+            if isinstance(checkpoint, dict) and "letterbox_pad" in checkpoint:
                 self.wrapper_model.letterbox_pad = normalize_letterbox_pad(
                     checkpoint.get("letterbox_pad")
                 )
-        if (
-            type(self.model) is LibreYOLO9Model
-            and any(str(key).startswith("aux.") for key in state)
-        ):
-            self.model.enable_aux(
-                weight=float(getattr(self.config, "aux_weight", 0.25))
-            )
         return super().resume(checkpoint_path)
 
     def create_scheduler(self, iters_per_epoch: int):

--- a/libreyolo/models/yolo9_e2e/model.py
+++ b/libreyolo/models/yolo9_e2e/model.py
@@ -161,6 +161,7 @@ class LibreYOLO9E2E(LibreYOLO9):
             original_size=original_size,
             max_det=max_det,
             letterbox=kwargs.get("letterbox", True),
+            letterbox_pad=getattr(self, "letterbox_pad", None),
         )
 
     # =====================================================================

--- a/libreyolo/models/yolo9_e2e/trainer.py
+++ b/libreyolo/models/yolo9_e2e/trainer.py
@@ -41,7 +41,7 @@ class YOLO9E2ETrainer(YOLO9Trainer):
 
         return YOLO9E2EValidationLoss(
             model,
-            max_labels=int(getattr(self.config, "max_labels", 100)),
+            max_labels=int(getattr(self.config, "max_labels", 300)),
         )
 
     def cuda_graph_train_spec(self):

--- a/libreyolo/postprocess/yolo9.py
+++ b/libreyolo/postprocess/yolo9.py
@@ -115,6 +115,7 @@ def postprocess(
     original_size: Tuple[int, int] | None = None,
     max_det: int = 300,
     letterbox: bool = True,
+    letterbox_pad: str | None = None,
 ) -> Dict:
     """
     Postprocess YOLOv9 model outputs to get final detections.
@@ -182,9 +183,19 @@ def postprocess(
 
         if original_size is not None:
             if letterbox:
+                from ..preprocess.letterbox import letterbox_geometry
+
                 orig_w, orig_h = original_size
-                ratio = min(input_h / orig_h, input_w / orig_w)
-                xywhr[:, :4] = xywhr[:, :4] / ratio
+                # xywhr is cx,cy,w,h,angle. Undo pad on the center only;
+                # scale w/h by ratio. Going through the enclosing AABB would
+                # destroy width/height whenever angle != 0.
+                ratio, _nh, _nw, pad_left, pad_top = letterbox_geometry(
+                    orig_h, orig_w, input_h, input_w, letterbox_pad
+                )
+                xywhr[:, 0] = (xywhr[:, 0] - pad_left) / ratio
+                xywhr[:, 1] = (xywhr[:, 1] - pad_top) / ratio
+                xywhr[:, 2] = xywhr[:, 2] / ratio
+                xywhr[:, 3] = xywhr[:, 3] / ratio
             else:
                 scale_x = original_size[0] / input_w
                 scale_y = original_size[1] / input_h
@@ -272,11 +283,18 @@ def postprocess(
 
     if original_size is not None:
         if letterbox:
+            from ..preprocess.letterbox import letterbox_geometry, unletterbox_xyxy
+
             orig_w, orig_h = original_size
-            ratio = min(input_h / orig_h, input_w / orig_w)
-            boxes[:, :4] = boxes[:, :4] / ratio
+            boxes = unletterbox_xyxy(
+                boxes, orig_w, orig_h, input_h, input_w, pad=letterbox_pad
+            )
             if keypoints is not None:
-                keypoints[..., :2] = keypoints[..., :2] / ratio
+                _ratio, _nh, _nw, pad_left, pad_top = letterbox_geometry(
+                    orig_h, orig_w, input_h, input_w, letterbox_pad
+                )
+                keypoints[..., 0] = (keypoints[..., 0] - pad_left) / _ratio
+                keypoints[..., 1] = (keypoints[..., 1] - pad_top) / _ratio
         else:
             scale_x = original_size[0] / input_w
             scale_y = original_size[1] / input_h

--- a/libreyolo/postprocess/yolo9_e2e.py
+++ b/libreyolo/postprocess/yolo9_e2e.py
@@ -16,6 +16,7 @@ def _scale_and_clip_boxes(
     input_size: Union[int, Tuple[int, int]],
     original_size: Tuple[int, int] | None,
     letterbox: bool,
+    letterbox_pad: str | None = None,
 ) -> torch.Tensor:
     if original_size is None or len(boxes) == 0:
         return boxes
@@ -25,8 +26,11 @@ def _scale_and_clip_boxes(
     input_h, input_w = _input_size_hw(input_size)
 
     if letterbox:
-        ratio = min(input_h / orig_h, input_w / orig_w)
-        boxes[:, :4] = boxes[:, :4] / ratio
+        from ..preprocess.letterbox import unletterbox_xyxy
+
+        boxes = unletterbox_xyxy(
+            boxes, orig_w, orig_h, input_h, input_w, pad=letterbox_pad
+        )
     else:
         scale_x = orig_w / input_w
         scale_y = orig_h / input_h
@@ -46,6 +50,7 @@ def postprocess(
     original_size: Tuple[int, int] | None = None,
     max_det: int = 300,
     letterbox: bool = True,
+    letterbox_pad: str | None = None,
 ) -> Dict:
     """Postprocess YOLOv9 E2E outputs with top-K selection (no NMS).
 
@@ -100,7 +105,9 @@ def postprocess(
     boxes = boxes[keep]
     scores = scores[keep]
     class_ids = class_ids[keep]
-    boxes = _scale_and_clip_boxes(boxes, input_size, original_size, letterbox)
+    boxes = _scale_and_clip_boxes(
+        boxes, input_size, original_size, letterbox, letterbox_pad
+    )
 
     widths = boxes[:, 2] - boxes[:, 0]
     heights = boxes[:, 3] - boxes[:, 1]

--- a/libreyolo/preprocess/letterbox.py
+++ b/libreyolo/preprocess/letterbox.py
@@ -1,0 +1,118 @@
+"""Shared letterbox geometry for families that pad a resized image.
+
+Two pad conventions exist in the wild:
+
+- ``topleft``: resized image in the top-left corner, pad on the right and
+  bottom. This is what LibreYOLO YOLOv9 used through 1.5 (train, val, infer).
+- ``center``: pad split on both sides. MultimediaTechLab/YOLO and WongKinYiu
+  YOLOv9 train this way.
+
+Unmarked YOLOv9 checkpoints must keep ``topleft`` so a 1.6 upgrade does not
+silently move boxes on every user-trained weight. Newly converted official
+MTL checkpoints stamp ``center``.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+LETTERBOX_TOPLEFT = "topleft"
+LETTERBOX_CENTER = "center"
+LETTERBOX_PADS = (LETTERBOX_TOPLEFT, LETTERBOX_CENTER)
+
+# Checkpoints written before letterbox_pad existed used top-left YOLOv9 pad.
+DEFAULT_LETTERBOX_PAD = LETTERBOX_TOPLEFT
+
+
+def normalize_letterbox_pad(value: str | None) -> str:
+    """Return a canonical pad mode. Unknown/empty values become top-left."""
+    if value is None:
+        return DEFAULT_LETTERBOX_PAD
+    pad = str(value).strip().lower().replace("-", "").replace("_", "")
+    if pad in {"center", "centre"}:
+        return LETTERBOX_CENTER
+    if pad in {"topleft", "top-left", "tl"}:
+        return LETTERBOX_TOPLEFT
+    return DEFAULT_LETTERBOX_PAD
+
+
+def letterbox_geometry(
+    orig_h: int,
+    orig_w: int,
+    input_h: int,
+    input_w: int,
+    pad: str | None = None,
+) -> Tuple[float, int, int, int, int]:
+    """Scale and pad offsets for a letterboxed canvas.
+
+    Returns ``(ratio, new_h, new_w, pad_left, pad_top)``. For ``topleft``,
+    both pad offsets are 0 so existing ``coord / ratio`` undo stays exact.
+    """
+    pad = normalize_letterbox_pad(pad)
+    if orig_h <= 0 or orig_w <= 0:
+        raise ValueError(f"original size must be positive, got {(orig_h, orig_w)}")
+    if input_h <= 0 or input_w <= 0:
+        raise ValueError(f"input size must be positive, got {(input_h, input_w)}")
+    ratio = min(input_h / orig_h, input_w / orig_w)
+    new_h = max(int(orig_h * ratio), 1)
+    new_w = max(int(orig_w * ratio), 1)
+    if pad == LETTERBOX_CENTER:
+        pad_left = (input_w - new_w) // 2
+        pad_top = (input_h - new_h) // 2
+    else:
+        pad_left = 0
+        pad_top = 0
+    return float(ratio), new_h, new_w, pad_left, pad_top
+
+
+def apply_letterbox_hwc(
+    image: np.ndarray,
+    input_h: int,
+    input_w: int,
+    *,
+    pad: str | None = None,
+    fill: int = 114,
+) -> Tuple[np.ndarray, float, int, int]:
+    """Letterbox an HWC uint8 image. Returns ``(canvas, ratio, pad_left, pad_top)``."""
+    orig_h, orig_w = image.shape[:2]
+    ratio, new_h, new_w, pad_left, pad_top = letterbox_geometry(
+        orig_h, orig_w, input_h, input_w, pad
+    )
+    import cv2
+
+    resized = cv2.resize(image, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+    if image.ndim == 3:
+        canvas = np.full((input_h, input_w, image.shape[2]), fill, dtype=np.uint8)
+        canvas[pad_top : pad_top + new_h, pad_left : pad_left + new_w] = resized
+    else:
+        canvas = np.full((input_h, input_w), fill, dtype=np.uint8)
+        canvas[pad_top : pad_top + new_h, pad_left : pad_left + new_w] = resized
+    return canvas, ratio, pad_left, pad_top
+
+
+def unletterbox_xyxy(
+    boxes,
+    orig_w: int,
+    orig_h: int,
+    input_h: int,
+    input_w: int,
+    *,
+    pad: str | None = None,
+):
+    """Map boxes from letterboxed canvas pixels back to the original image.
+
+    ``topleft`` is a pure divide-by-ratio, matching historical YOLO9
+    postprocess. ``center`` subtracts the pad first.
+    """
+    ratio, _new_h, _new_w, pad_left, pad_top = letterbox_geometry(
+        orig_h, orig_w, input_h, input_w, pad
+    )
+    # Torch and numpy both support this indexing.
+    boxes = boxes.clone() if hasattr(boxes, "clone") else boxes.copy()
+    boxes[..., 0] = (boxes[..., 0] - pad_left) / ratio
+    boxes[..., 2] = (boxes[..., 2] - pad_left) / ratio
+    boxes[..., 1] = (boxes[..., 1] - pad_top) / ratio
+    boxes[..., 3] = (boxes[..., 3] - pad_top) / ratio
+    return boxes

--- a/libreyolo/preprocess/yolo9.py
+++ b/libreyolo/preprocess/yolo9.py
@@ -20,35 +20,38 @@ from . import as_batched_input
 def preprocess_numpy(
     img_rgb_hwc: np.ndarray,
     input_size: ImageSize = 640,
+    letterbox_pad: str | None = None,
 ) -> Tuple[np.ndarray, float]:
     """
     Preprocess RGB HWC uint8 image for YOLOv9 inference.
 
-    Letterbox resize + normalize to 0-1 range.
+    Letterbox resize + normalize to 0-1 range. Pad defaults to top-left
+    (LibreYOLO <=1.5). Pass ``letterbox_pad="center"`` for official MTL
+    geometry.
 
     Args:
         img_rgb_hwc: Input image as RGB HWC uint8 numpy array.
         input_size: Target size for the model as int or (height, width).
+        letterbox_pad: ``topleft`` (default) or ``center``.
 
     Returns:
         Tuple of (preprocessed CHW float32 array in RGB 0-1, ratio).
     """
-    orig_h, orig_w = img_rgb_hwc.shape[:2]
+    from .letterbox import apply_letterbox_hwc
+
     input_h, input_w = _input_size_hw(input_size)
-    ratio = min(input_h / orig_h, input_w / orig_w)
-    new_h = max(int(orig_h * ratio), 1)
-    new_w = max(int(orig_w * ratio), 1)
-
-    resized = cv2.resize(img_rgb_hwc, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
-    padded = np.full((input_h, input_w, 3), 114, dtype=np.uint8)
-    padded[:new_h, :new_w] = resized
-
+    padded, ratio, _pad_left, _pad_top = apply_letterbox_hwc(
+        img_rgb_hwc, input_h, input_w, pad=letterbox_pad, fill=114
+    )
     arr = np.ascontiguousarray(padded, dtype=np.float32) / 255.0
     return arr.transpose(2, 0, 1), ratio
 
 
 def preprocess_image(
-    image: ImageInput, input_size: ImageSize = 640, color_format: str = "auto"
+    image: ImageInput,
+    input_size: ImageSize = 640,
+    color_format: str = "auto",
+    letterbox_pad: str | None = None,
 ):
     """
     Preprocess image for YOLOv9 inference.
@@ -57,6 +60,7 @@ def preprocess_image(
         image: Input image (path, PIL, numpy, tensor, bytes, etc.)
         input_size: Target size for resizing as int or (height, width).
         color_format: Color format hint ("auto", "rgb", "bgr")
+        letterbox_pad: ``topleft`` (default) or ``center``.
 
     Returns:
         Tuple of (preprocessed_tensor, original_image, original_size)
@@ -65,7 +69,9 @@ def preprocess_image(
     original_size = img.size  # (width, height)
     original_img = img.copy()
 
-    img_chw, _ = preprocess_numpy(np.array(img), input_size)
+    img_chw, _ = preprocess_numpy(
+        np.array(img), input_size, letterbox_pad=letterbox_pad
+    )
     return as_batched_input(img_chw), original_img, original_size
 
 

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -377,8 +377,18 @@ class YOLO9Config(TrainConfig):
     sync_bn: bool = True
     # Per-image ground-truth cap in the train transforms. Dense datasets
     # (e.g. aerial imagery) exceed the historical 100-box default; boxes
-    # beyond the cap are silently dropped, so raise it for such data.
-    max_labels: int = 100
+    # beyond the cap are silently dropped. 300 matches the MTL/YOLO-NAS
+    # recipe and is a training-only change (old checkpoints still load).
+    max_labels: int = 300
+    # PGI auxiliary-head loss weight. 0 disables the branch. Training-only;
+    # inference stays single-head. Resume of a checkpoint without ``aux.*``
+    # weights keeps the single-head graph.
+    aux_weight: float = 0.25
+    # SGD momentum at the start of warmup (MTL LinearL: 0.8 → 0.937).
+    warmup_momentum: float = 0.8
+    # Letterbox pad for new training. ``None`` inherits the loaded
+    # checkpoint stamp, or top-left when the checkpoint is unmarked.
+    letterbox_pad: Optional[str] = None
     # Copy-paste instance augmentation (segmentation task only). ``copy_paste``
     # is the per-sample probability (0 disables it); ``copy_paste_mode`` selects
     # the source: "flip" reuses the same sample mirrored, "mixup" pulls a second

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -87,6 +87,50 @@ def _libreyolo_ddp_worker(
 # ---------------------------------------------------------------------------
 
 
+def _is_training_only_tensor_key(key: str) -> bool:
+    """Keys the inference model drops but workers need for a faithful fine-tune."""
+    return str(key).startswith("aux.") or str(key).startswith("aux_head.")
+
+
+def _training_only_tensors_from_source(path: str | Path) -> dict[str, torch.Tensor]:
+    """Pull PGI aux tensors from the parent's original checkpoint file."""
+    from libreyolo.utils.serialization import load_untrusted_torch_file
+
+    loaded = load_untrusted_torch_file(
+        str(path), map_location="cpu", context="ddp spawn aux merge"
+    )
+    if not isinstance(loaded, dict):
+        return {}
+    if isinstance(loaded.get("model"), dict):
+        state = loaded["model"]
+    elif isinstance(loaded.get("state_dict"), dict):
+        state = loaded["state_dict"]
+    else:
+        state = loaded
+    out: dict[str, torch.Tensor] = {}
+    for key, value in state.items():
+        if _is_training_only_tensor_key(key) and torch.is_tensor(value):
+            out[key] = value.cpu()
+    return out
+
+
+def _bootstrap_state_dict(model_instance: Any) -> dict[str, torch.Tensor]:
+    """Flat tensor dict for DDP workers, plus training-only tensors the live model stripped.
+
+    Must stay a plain ``{name: tensor}`` map (no ``model`` wrapper). RF-DETR
+    and others load this file by passing the dict to ``load_state_dict``.
+    """
+    state = {k: v.cpu() for k, v in model_instance.model.state_dict().items()}
+    source = getattr(model_instance, "model_path", None)
+    if source and Path(str(source)).is_file():
+        try:
+            for key, value in _training_only_tensors_from_source(source).items():
+                state.setdefault(key, value)
+        except Exception:
+            logger.debug("DDP spawn: could not merge training-only tensors from %s", source)
+    return state
+
+
 def _build_init_kw(model_instance: Any) -> dict:
     """Collect __init__ kwargs needed to reconstruct *model_instance* in a worker.
 
@@ -120,6 +164,7 @@ def _build_init_kw(model_instance: Any) -> dict:
         "proto_channels",
         "num_keypoints",
         "weight_variant",
+        "letterbox_pad",
     ):
         if (attr in supported or supports_kwargs) and hasattr(model_instance, attr):
             kw[attr] = getattr(model_instance, attr)
@@ -200,7 +245,7 @@ def spawn_for_model(
         fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
         os.close(fd)
         torch.save(
-            {k: v.cpu() for k, v in model_instance.model.state_dict().items()},
+            _bootstrap_state_dict(model_instance),
             tmp_weights,
         )
         tmp_weights_to_delete = tmp_weights

--- a/libreyolo/training/scheduler.py
+++ b/libreyolo/training/scheduler.py
@@ -78,6 +78,11 @@ class LinearLRScheduler(BaseScheduler):
     LR schedule:
     - Warmup: linear increase from warmup_lr_start to lr over warmup_iters
     - Main: linear decrease from lr to lr * min_lr_ratio over remaining iterations
+
+    Optional SGD momentum warmup (YOLO9 / MTL ``LinearL``): when
+    ``warmup_momentum`` and ``momentum`` are set, ``update_momentum`` lerps
+    between them over the same warmup window. Other callers leave both
+    unset and see no change.
     """
 
     def __init__(
@@ -88,11 +93,26 @@ class LinearLRScheduler(BaseScheduler):
         warmup_epochs: int = 3,
         warmup_lr_start: float = 0.0001,
         min_lr_ratio: float = 0.01,
+        warmup_momentum: float | None = None,
+        momentum: float | None = None,
     ):
         super().__init__(lr, iters_per_epoch, total_epochs)
         self.warmup_iters = iters_per_epoch * warmup_epochs
         self.warmup_lr_start = _clamp_warmup_lr_start(lr, warmup_lr_start)
         self.min_lr = lr * min_lr_ratio
+        self.warmup_momentum = warmup_momentum
+        self.momentum = momentum
+
+    def update_momentum(self, iters: int) -> float | None:
+        """Lerp SGD momentum over warmup. ``None`` when not configured."""
+        if self.warmup_momentum is None or self.momentum is None:
+            return None
+        if self.warmup_iters <= 0 or iters >= self.warmup_iters:
+            return float(self.momentum)
+        t = float(iters) / float(self.warmup_iters)
+        return float(self.warmup_momentum) + (
+            float(self.momentum) - float(self.warmup_momentum)
+        ) * t
 
     def update_lr(self, iters: int) -> float:
         if iters <= self.warmup_iters:

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -2309,11 +2309,24 @@ class BaseTrainer(ABC):
         for param_group in self.optimizer.param_groups:
             param_group["lr"] = self._scale_lr(base_lr, param_group)
 
+    def _apply_scheduler(self, iters: int) -> float:
+        """Step the LR scheduler and optional momentum warmup."""
+        lr = self.lr_scheduler.update_lr(iters)
+        self._set_optimizer_lr(lr)
+        update_momentum = getattr(self.lr_scheduler, "update_momentum", None)
+        if callable(update_momentum):
+            momentum = update_momentum(iters)
+            if momentum is not None:
+                for param_group in self.optimizer.param_groups:
+                    if "momentum" in param_group:
+                        param_group["momentum"] = momentum
+        return lr
+
     def _initialize_scheduler_lr(self) -> None:
         if self.optimizer is None or self.lr_scheduler is None:
             return
         init_iter = getattr(self, "start_epoch", 0) * self._scheduler_steps_per_epoch()
-        self._set_optimizer_lr(self.lr_scheduler.update_lr(init_iter))
+        self._apply_scheduler(init_iter)
 
     def _gradient_clip_parameters(self) -> List[torch.nn.Parameter]:
         if self.optimizer is None:
@@ -2477,8 +2490,7 @@ class BaseTrainer(ABC):
             del outputs, loss, total_loss_raw
 
             # LR update
-            lr = self.lr_scheduler.update_lr(self.current_iter + 1)
-            self._set_optimizer_lr(lr)
+            lr = self._apply_scheduler(self.current_iter + 1)
             num_batches += 1
 
             # Progress bar
@@ -2650,8 +2662,7 @@ class BaseTrainer(ABC):
                 if self.ema_model is not None:
                     self.ema_model.update(self.model)
                 # LR update
-                lr = self.lr_scheduler.update_lr(opt_step + 1)
-                self._set_optimizer_lr(lr)
+                lr = self._apply_scheduler(opt_step + 1)
 
             # Logging uses the raw pre-scale value (single-GPU semantics).
             loss_val = float(total_loss_raw.detach().item())

--- a/libreyolo/validation/preprocessors.py
+++ b/libreyolo/validation/preprocessors.py
@@ -587,7 +587,7 @@ class YOLO9ValPreprocessor(BaseValPreprocessor):
         from libreyolo.preprocess.letterbox import apply_letterbox_hwc
 
         target_h, target_w = input_size
-        padded_img, _ratio, _pad_left, _pad_top = apply_letterbox_hwc(
+        padded_img, _ratio, pad_left, pad_top = apply_letterbox_hwc(
             img, target_h, target_w, pad=self.letterbox_pad, fill=self.pad_value
         )
 
@@ -595,11 +595,17 @@ class YOLO9ValPreprocessor(BaseValPreprocessor):
         padded_img = padded_img.transpose(2, 0, 1)  # HWC → CHW
         padded_img = np.ascontiguousarray(padded_img, dtype=np.float32) / 255.0
 
-        # Targets are already in letterbox coords
+        # Dataset already scaled boxes by the letterbox ratio onto the
+        # unpadded resized frame. Only the pad offset is missing. Top-left
+        # pad is 0 so this is a no-op for unmarked ≤1.5 checkpoints.
         padded_targets = np.zeros((self.max_labels, 5), dtype=np.float32)
         if len(targets) > 0:
             targets = np.array(targets).copy()
             n = min(len(targets), self.max_labels)
+            targets[:n, 0] = targets[:n, 0] + pad_left
+            targets[:n, 1] = targets[:n, 1] + pad_top
+            targets[:n, 2] = targets[:n, 2] + pad_left
+            targets[:n, 3] = targets[:n, 3] + pad_top
             padded_targets[:n] = targets[:n]
 
         return padded_img, padded_targets

--- a/libreyolo/validation/preprocessors.py
+++ b/libreyolo/validation/preprocessors.py
@@ -541,13 +541,23 @@ class CenterNetValPreprocessor(BaseValPreprocessor):
 
 
 class YOLO9ValPreprocessor(BaseValPreprocessor):
-    """YOLOv9 preprocessor: letterbox with gray padding, 0-1 range, RGB format."""
+    """YOLOv9 preprocessor: letterbox with gray padding, 0-1 range, RGB format.
+
+    Pad defaults to top-left (LibreYOLO <=1.5). Official MTL geometry is
+    center-pad and is selected only when the checkpoint stamps
+    ``letterbox_pad="center"``.
+    """
 
     def __init__(
-        self, img_size: Tuple[int, int], max_labels: int = 120, pad_value: int = 114
+        self,
+        img_size: Tuple[int, int],
+        max_labels: int = 120,
+        pad_value: int = 114,
+        letterbox_pad: str | None = None,
     ):
         super().__init__(img_size, max_labels)
         self.pad_value = pad_value
+        self.letterbox_pad = letterbox_pad
 
     @property
     def normalize(self) -> bool:
@@ -557,21 +567,29 @@ class YOLO9ValPreprocessor(BaseValPreprocessor):
     def uses_letterbox(self) -> bool:
         return True
 
+    def letterbox_scale(
+        self, orig_h: int, orig_w: int, imgsz: int
+    ) -> Tuple[float, float, float]:
+        from libreyolo.preprocess.letterbox import letterbox_geometry
+
+        if isinstance(imgsz, (list, tuple)):
+            input_h, input_w = int(imgsz[0]), int(imgsz[1])
+        else:
+            input_h = input_w = int(imgsz)
+        ratio, _nh, _nw, pad_left, pad_top = letterbox_geometry(
+            orig_h, orig_w, input_h, input_w, self.letterbox_pad
+        )
+        return ratio, float(pad_left), float(pad_top)
+
     def __call__(
         self, img: np.ndarray, targets: np.ndarray, input_size: Tuple[int, int]
     ) -> Tuple[np.ndarray, np.ndarray]:
-        orig_h, orig_w = img.shape[:2]
+        from libreyolo.preprocess.letterbox import apply_letterbox_hwc
+
         target_h, target_w = input_size
-
-        # Letterbox resize maintaining aspect ratio
-        ratio = min(target_h / orig_h, target_w / orig_w)
-        new_h = int(orig_h * ratio)
-        new_w = int(orig_w * ratio)
-
-        resized_img = cv2.resize(img, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
-
-        padded_img = np.full((target_h, target_w, 3), self.pad_value, dtype=np.uint8)
-        padded_img[:new_h, :new_w] = resized_img
+        padded_img, _ratio, _pad_left, _pad_top = apply_letterbox_hwc(
+            img, target_h, target_w, pad=self.letterbox_pad, fill=self.pad_value
+        )
 
         padded_img = padded_img[:, :, ::-1]  # BGR → RGB
         padded_img = padded_img.transpose(2, 0, 1)  # HWC → CHW

--- a/tests/unit/test_autoconvert.py
+++ b/tests/unit/test_autoconvert.py
@@ -90,18 +90,22 @@ class TestYolo9Inference:
 
         assert infer_nb_classes(sd) == 3
 
-    def test_convert_state_dict_drops_aux_and_anc2vec(self):
+    def test_convert_state_dict_keeps_aux_and_drops_anc2vec(self):
         sd = {
             "0.conv.weight": torch.zeros(16, 3, 3, 3),
             "22.heads.0.class_conv.2.weight": torch.zeros(5, 16, 1, 1),
             "22.heads.0.anc2vec.anc2vec.weight": torch.zeros(1, 16, 1, 1, 1),
-            "23.heads.0.class_conv.2.weight": torch.zeros(5, 16, 1, 1),
+            "23.conv1.weight": torch.zeros(16, 16, 1, 1),
+            "30.heads.0.class_conv.2.weight": torch.zeros(5, 16, 1, 1),
+            "30.heads.0.anc2vec.anc2vec.weight": torch.zeros(1, 16, 1, 1, 1),
         }
         converted, stats = convert_state_dict(sd, "t")
         assert "backbone.conv0.conv.weight" in converted
         assert "head.cv3.0.2.weight" in converted
-        assert stats["skipped"] == 1  # the aux head (layer 23)
-        assert stats["failed"] == 1  # anc2vec
+        assert "aux.spp.cv1.weight" in converted
+        assert "aux.head.cv3.0.2.weight" in converted
+        assert stats["failed"] == 1  # layer-22 anc2vec
+        assert stats["skipped"] == 1  # layer-30 anc2vec
 
 
 def _synthetic_upstream_yolo9(nc: int) -> dict:

--- a/tests/unit/test_autoconvert.py
+++ b/tests/unit/test_autoconvert.py
@@ -103,7 +103,7 @@ class TestYolo9Inference:
         assert "backbone.conv0.conv.weight" in converted
         assert "head.cv3.0.2.weight" in converted
         assert "aux.spp.cv1.weight" in converted
-        assert "aux.head.cv3.0.2.weight" in converted
+        assert "aux_head.cv3.0.2.weight" in converted
         assert stats["failed"] == 1  # layer-22 anc2vec
         assert stats["skipped"] == 1  # layer-30 anc2vec
 

--- a/tests/unit/test_autoconvert.py
+++ b/tests/unit/test_autoconvert.py
@@ -56,8 +56,14 @@ class TestYolo9ConvertKey:
         out, ok = convert_key("22.heads.0.anc2vec.anc2vec.weight", "t")
         assert ok is False
 
-    def test_auxiliary_head_not_converted(self):
-        out, ok = convert_key("23.heads.0.class_conv.2.weight", "t")
+    def test_auxiliary_spp_and_head_convert(self):
+        out, ok = convert_key("23.conv1.weight", "t")
+        assert ok and out == "aux.spp.cv1.weight"
+        out, ok = convert_key("30.heads.0.class_conv.2.weight", "t")
+        assert ok and out == "aux_head.cv3.0.2.weight"
+
+    def test_unknown_aux_leftover_not_converted(self):
+        out, ok = convert_key("24.heads.0.class_conv.2.weight", "t")
         assert ok is False
 
 

--- a/tests/unit/test_cuda_graph_training.py
+++ b/tests/unit/test_cuda_graph_training.py
@@ -579,6 +579,11 @@ class TestYolo9SpecGating:
         host.model.head = derived
         assert fn(host) is None
 
+    def test_pgi_aux_unsupported(self):
+        fn, host = self._host()
+        host.model.enable_aux(0.25)
+        assert fn(host) is None
+
 
 class TestRFDETRSpecGating:
     def _host(self, task="detect", **model_flags):

--- a/tests/unit/test_yolo9_letterbox.py
+++ b/tests/unit/test_yolo9_letterbox.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 import torch
 
+pytestmark = pytest.mark.unit
+
 from libreyolo.preprocess.letterbox import (
     DEFAULT_LETTERBOX_PAD,
     LETTERBOX_CENTER,
@@ -104,6 +106,44 @@ def test_val_preprocessor_center_moves_content():
     assert off_x == 0.0
     assert off_y == 16.0
     assert r == pytest.approx(0.8)
+
+
+def test_center_val_targets_get_pad_so_gt_undo_recovers_original():
+    """Dataset hands a ratio-scaled, unpadded frame. Center pad must be
+    added to GT or the validator subtracts an offset that was never applied
+    (62.5px on a 500x375 → 640 letterbox)."""
+    orig_w, orig_h, imgsz = 500, 375, 640
+    r, off_x, off_y = YOLO9ValPreprocessor(
+        (imgsz, imgsz), letterbox_pad="center"
+    ).letterbox_scale(orig_h, orig_w, imgsz)
+    assert r == pytest.approx(min(imgsz / orig_h, imgsz / orig_w))
+    assert off_x == 0.0
+    assert off_y == 80.0
+
+    # Dataset contract: image already resized, boxes already * r.
+    resized_box = np.array([[100.0 * r, 50.0 * r, 200.0 * r, 150.0 * r, 0.0]], dtype=np.float32)
+    resized_h = int(orig_h * r)
+    resized_w = int(orig_w * r)
+    frame = np.zeros((resized_h, resized_w, 3), dtype=np.uint8)
+    _img, targets = YOLO9ValPreprocessor(
+        (imgsz, imgsz), max_labels=4, letterbox_pad="center"
+    )(frame, resized_box, (imgsz, imgsz))
+    # Validator undo: subtract pad, divide by r.
+    recovered = targets[0, :4].copy()
+    recovered[[0, 2]] = (recovered[[0, 2]] - off_x) / r
+    recovered[[1, 3]] = (recovered[[1, 3]] - off_y) / r
+    np.testing.assert_allclose(recovered, [100.0, 50.0, 200.0, 150.0], atol=1e-4)
+
+
+def test_topleft_val_targets_stay_unshifted():
+    orig_w, orig_h, imgsz = 500, 375, 640
+    r = min(imgsz / orig_h, imgsz / orig_w)
+    resized_box = np.array([[100.0 * r, 50.0 * r, 200.0 * r, 150.0 * r, 0.0]], dtype=np.float32)
+    frame = np.zeros((int(orig_h * r), int(orig_w * r), 3), dtype=np.uint8)
+    _img, targets = YOLO9ValPreprocessor(
+        (imgsz, imgsz), max_labels=4, letterbox_pad="topleft"
+    )(frame, resized_box, (imgsz, imgsz))
+    np.testing.assert_allclose(targets[0, :4], resized_box[0, :4], atol=1e-5)
 
 
 def test_postprocess_topleft_undo_matches_historical_divide_by_ratio():
@@ -342,3 +382,74 @@ def test_linear_scheduler_momentum_warmup():
 
     plain = LinearLRScheduler(lr=0.01, iters_per_epoch=10, total_epochs=10)
     assert plain.update_momentum(1) is None
+
+
+def test_rebuild_for_new_classes_updates_aux_head():
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    wrapper = LibreYOLO9(None, size="t", nb_classes=80, device="cpu")
+    wrapper.model.enable_aux(0.25)
+    assert wrapper.model.aux_head.nc == 80
+    wrapper._rebuild_for_new_classes(5)
+    assert wrapper.model.head.nc == 5
+    assert wrapper.model.aux_head.nc == 5
+    assert wrapper.model.aux_head.cv3[0][-1].out_channels == 5
+
+
+def test_ddp_bootstrap_merges_aux_and_keeps_flat_dict(tmp_path):
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+    from libreyolo.training.ddp_spawn import (
+        _bootstrap_state_dict,
+        _build_init_kw,
+    )
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    raw = LibreYOLO9Model(config="t", nb_classes=2)
+    raw.enable_aux(0.25)
+    marker = raw.aux.spp.cv1.conv.weight.detach().clone()
+    ckpt = wrap_libreyolo_checkpoint(
+        raw.state_dict(),
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=2,
+        names={0: "a", 1: "b"},
+        imgsz=640,
+        letterbox_pad="center",
+    )
+    path = tmp_path / "official.pt"
+    torch.save(ckpt, path)
+
+    infer = LibreYOLO9Model(config="t", nb_classes=2)
+    class _Wrap:
+        pass
+
+    parent = _Wrap()
+    parent.model = infer
+    parent.model_path = str(path)
+    parent.letterbox_pad = "center"
+    parent.size = "t"
+    parent.nb_classes = 2
+    parent.task = "detect"
+    parent.reg_max = 16
+
+    state = _bootstrap_state_dict(parent)
+    assert all(torch.is_tensor(v) for v in state.values())
+    assert "model" not in state
+    assert "aux.spp.cv1.conv.weight" in state
+    torch.testing.assert_close(state["aux.spp.cv1.conv.weight"], marker.cpu())
+
+    parent.__class__ = type("LibreYOLO9", (), {"__init__": lambda self, *a, **k: None})
+    # _build_init_kw inspects the real class; use a tiny stand-in with **kwargs.
+    class _Fake:
+        def __init__(self, model_path, size="t", **kwargs):
+            pass
+
+    fake = _Fake(None)
+    fake.size = "t"
+    fake.nb_classes = 2
+    fake.task = "detect"
+    fake.reg_max = 16
+    fake.letterbox_pad = "center"
+    init_kw = _build_init_kw(fake)
+    assert init_kw["letterbox_pad"] == "center"

--- a/tests/unit/test_yolo9_letterbox.py
+++ b/tests/unit/test_yolo9_letterbox.py
@@ -233,6 +233,56 @@ def test_aux_keys_are_ignored_at_inference(tmp_path):
     assert all(not k.startswith("aux.") for k in loaded.model.state_dict())
 
 
+def test_aux_head_convert_prefix_loads_into_enabled_branch():
+    from libreyolo.models.yolo9.convert import convert_state_dict
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+
+    sd = {
+        "0.conv.weight": torch.zeros(16, 3, 3, 3),
+        "30.heads.0.class_conv.2.weight": torch.zeros(5, 16, 1, 1),
+    }
+    converted, _stats = convert_state_dict(sd, "t")
+    assert "aux_head.cv3.0.2.weight" in converted
+    model = LibreYOLO9Model(config="t", nb_classes=5)
+    model.enable_aux(0.25)
+    assert "aux_head.cv3.0.2.weight" in model.state_dict()
+
+
+def test_fine_tune_reloads_aux_after_inference_strip(tmp_path):
+    from libreyolo.models.yolo9.model import LibreYOLO9
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    raw = LibreYOLO9Model(config="t", nb_classes=2)
+    raw.enable_aux(0.25)
+    marker = torch.arange(raw.aux_head.cv3[0][2].weight.numel(), dtype=torch.float32)
+    raw.aux_head.cv3[0][2].weight.data.copy_(
+        marker.reshape_as(raw.aux_head.cv3[0][2].weight)
+    )
+    ckpt = wrap_libreyolo_checkpoint(
+        raw.state_dict(),
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=2,
+        names={0: "a", 1: "b"},
+        imgsz=640,
+        letterbox_pad="center",
+    )
+    path = tmp_path / "official_aux.pt"
+    torch.save(ckpt, path)
+
+    loaded = LibreYOLO9(str(path), size="t", nb_classes=2, device="cpu")
+    assert loaded.model.aux is None
+    loaded.model.enable_aux(0.25)
+    n = loaded._reload_aux_from_path(str(path))
+    assert n > 0
+    torch.testing.assert_close(
+        loaded.model.aux_head.cv3[0][2].weight.detach().cpu().flatten(),
+        marker,
+    )
+
+
 def test_enable_aux_is_training_only_and_idempotent():
     from libreyolo.models.yolo9.nn import LibreYOLO9Model
 

--- a/tests/unit/test_yolo9_letterbox.py
+++ b/tests/unit/test_yolo9_letterbox.py
@@ -1,0 +1,294 @@
+"""YOLOv9 letterbox stamp + PGI aux: no silent 1.5 → 1.6 geometry flip."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.preprocess.letterbox import (
+    DEFAULT_LETTERBOX_PAD,
+    LETTERBOX_CENTER,
+    LETTERBOX_TOPLEFT,
+    apply_letterbox_hwc,
+    letterbox_geometry,
+    normalize_letterbox_pad,
+    unletterbox_xyxy,
+)
+from libreyolo.preprocess.yolo9 import preprocess_numpy
+from libreyolo.postprocess.yolo9 import postprocess
+from libreyolo.validation.preprocessors import YOLO9ValPreprocessor
+
+
+def _uint8_gradient(h=40, w=80):
+    img = np.zeros((h, w, 3), dtype=np.uint8)
+    img[:, :, 0] = np.linspace(0, 255, w, dtype=np.uint8)[None, :]
+    img[:, :, 1] = np.linspace(0, 255, h, dtype=np.uint8)[:, None]
+    img[:, :, 2] = 40
+    return img
+
+
+def test_unmarked_letterbox_pad_defaults_to_topleft():
+    assert normalize_letterbox_pad(None) == LETTERBOX_TOPLEFT
+    assert normalize_letterbox_pad("") == LETTERBOX_TOPLEFT
+    assert normalize_letterbox_pad("nope") == LETTERBOX_TOPLEFT
+    assert DEFAULT_LETTERBOX_PAD == LETTERBOX_TOPLEFT
+
+
+def test_topleft_geometry_has_zero_pad_offsets():
+    ratio, new_h, new_w, pad_left, pad_top = letterbox_geometry(40, 80, 64, 64, "topleft")
+    assert pad_left == 0
+    assert pad_top == 0
+    assert new_w == 64
+    assert new_h == 32
+    assert ratio == pytest.approx(0.8)
+
+
+def test_center_geometry_splits_pad():
+    _ratio, _nh, _nw, pad_left, pad_top = letterbox_geometry(40, 80, 64, 64, "center")
+    assert pad_left == 0
+    assert pad_top == 16
+
+
+def test_topleft_preprocess_is_bit_identical_to_historical_placement():
+    img = _uint8_gradient()
+    historical = np.full((64, 64, 3), 114, dtype=np.uint8)
+    import cv2
+
+    resized = cv2.resize(img, (64, 32), interpolation=cv2.INTER_LINEAR)
+    historical[:32, :64] = resized
+
+    canvas, ratio, pad_left, pad_top = apply_letterbox_hwc(img, 64, 64, pad="topleft")
+    assert pad_left == 0
+    assert pad_top == 0
+    np.testing.assert_array_equal(canvas, historical)
+    assert ratio == pytest.approx(0.8)
+
+
+def test_default_preprocess_numpy_matches_topleft():
+    img = _uint8_gradient()
+    default, _ = preprocess_numpy(img, 64)
+    topleft, _ = preprocess_numpy(img, 64, letterbox_pad="topleft")
+    center, _ = preprocess_numpy(img, 64, letterbox_pad="center")
+    np.testing.assert_array_equal(default, topleft)
+    assert not np.array_equal(default, center)
+
+
+def test_val_preprocessor_default_matches_predict_topleft():
+    img = _uint8_gradient()
+    tensor, _ = preprocess_numpy(img, 64, letterbox_pad=None)
+    val, _ = YOLO9ValPreprocessor((64, 64), max_labels=1)(
+        img[:, :, ::-1].copy(),
+        np.zeros((0, 5), dtype=np.float32),
+        (64, 64),
+    )
+    np.testing.assert_allclose(tensor, val, atol=1e-6)
+
+
+def test_val_preprocessor_center_moves_content():
+    img = _uint8_gradient()
+    topleft, _ = YOLO9ValPreprocessor((64, 64), letterbox_pad="topleft")(
+        img[:, :, ::-1].copy(),
+        np.zeros((0, 5), dtype=np.float32),
+        (64, 64),
+    )
+    center, _ = YOLO9ValPreprocessor((64, 64), letterbox_pad="center")(
+        img[:, :, ::-1].copy(),
+        np.zeros((0, 5), dtype=np.float32),
+        (64, 64),
+    )
+    assert not np.array_equal(topleft, center)
+    r, off_x, off_y = YOLO9ValPreprocessor((64, 64), letterbox_pad="center").letterbox_scale(
+        40, 80, 64
+    )
+    assert off_x == 0.0
+    assert off_y == 16.0
+    assert r == pytest.approx(0.8)
+
+
+def test_postprocess_topleft_undo_matches_historical_divide_by_ratio():
+    pred = torch.zeros(1, 6, 1)
+    pred[0, :4, 0] = torch.tensor([0.0, 0.0, 320.0, 320.0])
+    pred[0, 4, 0] = 0.9
+
+    out = postprocess(
+        {"predictions": pred},
+        input_size=640,
+        original_size=(1280, 960),
+    )
+    torch.testing.assert_close(
+        torch.as_tensor(out["boxes"]),
+        torch.tensor([[0.0, 0.0, 640.0, 640.0]]),
+    )
+
+    explicit = postprocess(
+        {"predictions": pred.clone()},
+        input_size=640,
+        original_size=(1280, 960),
+        letterbox_pad="topleft",
+    )
+    torch.testing.assert_close(
+        torch.as_tensor(out["boxes"]),
+        torch.as_tensor(explicit["boxes"]),
+    )
+
+
+def test_postprocess_center_subtracts_pad():
+    pred = torch.zeros(1, 6, 1)
+    # Box sitting in the padded canvas at y=16..336 on a 64-tall content
+    # after center pad of 16 on a 40x80 → 64x64 letterbox (ratio 0.8).
+    pred[0, :4, 0] = torch.tensor([0.0, 16.0, 64.0, 48.0])
+    pred[0, 4, 0] = 0.9
+    out = postprocess(
+        {"predictions": pred},
+        input_size=64,
+        original_size=(80, 40),
+        letterbox_pad="center",
+    )
+    torch.testing.assert_close(
+        torch.as_tensor(out["boxes"]),
+        torch.tensor([[0.0, 0.0, 80.0, 40.0]]),
+    )
+
+
+def test_unletterbox_topleft_is_pure_divide():
+    boxes = torch.tensor([[8.0, 4.0, 16.0, 12.0]])
+    out = unletterbox_xyxy(boxes, orig_w=80, orig_h=40, input_h=64, input_w=64, pad="topleft")
+    torch.testing.assert_close(out, torch.tensor([[10.0, 5.0, 20.0, 15.0]]))
+
+
+def test_unmarked_yolo9_checkpoint_stays_topleft(tmp_path):
+    from libreyolo.models.yolo9.model import LibreYOLO9
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+
+    raw = LibreYOLO9Model(config="t", nb_classes=2)
+    ckpt = wrap_libreyolo_checkpoint(
+        raw.state_dict(),
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=2,
+        names={0: "a", 1: "b"},
+        imgsz=640,
+    )
+    path = tmp_path / "old.pt"
+    torch.save(ckpt, path)
+
+    loaded = LibreYOLO9(str(path), size="t", nb_classes=2, device="cpu")
+    assert loaded.letterbox_pad == LETTERBOX_TOPLEFT
+    assert loaded.model.aux is None
+
+
+def test_stamped_center_checkpoint_is_honored(tmp_path):
+    from libreyolo.models.yolo9.model import LibreYOLO9
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+
+    raw = LibreYOLO9Model(config="t", nb_classes=2)
+    ckpt = wrap_libreyolo_checkpoint(
+        raw.state_dict(),
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=2,
+        names={0: "a", 1: "b"},
+        imgsz=640,
+        letterbox_pad="center",
+    )
+    path = tmp_path / "official.pt"
+    torch.save(ckpt, path)
+
+    loaded = LibreYOLO9(str(path), size="t", nb_classes=2, device="cpu")
+    assert loaded.letterbox_pad == LETTERBOX_CENTER
+    saved = loaded.save(str(tmp_path / "resave.pt"))
+    from libreyolo.utils.serialization import load_untrusted_torch_file
+
+    resaved = load_untrusted_torch_file(saved, map_location="cpu", context="resave")
+    assert resaved["letterbox_pad"] == LETTERBOX_CENTER
+
+
+def test_aux_keys_are_ignored_at_inference(tmp_path):
+    from libreyolo.models.yolo9.model import LibreYOLO9
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+
+    raw = LibreYOLO9Model(config="t", nb_classes=2)
+    raw.enable_aux(0.25)
+    ckpt = wrap_libreyolo_checkpoint(
+        raw.state_dict(),
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=2,
+        names={0: "a", 1: "b"},
+        imgsz=640,
+        letterbox_pad="center",
+    )
+    path = tmp_path / "with_aux.pt"
+    torch.save(ckpt, path)
+
+    loaded = LibreYOLO9(str(path), size="t", nb_classes=2, device="cpu")
+    assert loaded.model.aux is None
+    assert all(not k.startswith("aux.") for k in loaded.model.state_dict())
+
+
+def test_enable_aux_is_training_only_and_idempotent():
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+
+    model = LibreYOLO9Model(config="t", nb_classes=2)
+    assert model.aux is None
+    model.enable_aux(0.25)
+    first = model.aux
+    model.enable_aux(0.25)
+    assert model.aux is first
+    model.eval()
+    with torch.no_grad():
+        out = model(torch.zeros(1, 3, 64, 64))
+    assert "predictions" in out
+
+
+def test_aux_training_forward_combines_losses():
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+
+    model = LibreYOLO9Model(config="t", nb_classes=2)
+    model.enable_aux(0.25)
+    model.train()
+    targets = torch.zeros(1, 4, 5)
+    targets[0, 0] = torch.tensor([0.0, 0.2, 0.2, 0.4, 0.4])
+    out = model(torch.zeros(1, 3, 64, 64), targets=targets)
+    assert torch.isfinite(out["total_loss"])
+    bare = LibreYOLO9Model(config="t", nb_classes=2)
+    bare.train()
+    main_only = bare(torch.zeros(1, 3, 64, 64), targets=targets)
+    # Combined PGI loss is a different tensor than the single-head path.
+    assert out["total_loss"].shape == main_only["total_loss"].shape
+
+
+def test_yolo9_config_recipe_defaults():
+    from libreyolo.training.config import YOLO9Config
+
+    cfg = YOLO9Config()
+    assert cfg.max_labels == 300
+    assert cfg.aux_weight == 0.25
+    assert cfg.warmup_momentum == 0.8
+
+
+def test_linear_scheduler_momentum_warmup():
+    from libreyolo.training.scheduler import LinearLRScheduler
+
+    sched = LinearLRScheduler(
+        lr=0.01,
+        iters_per_epoch=10,
+        total_epochs=10,
+        warmup_epochs=3,
+        warmup_momentum=0.8,
+        momentum=0.937,
+    )
+    assert sched.update_momentum(0) == pytest.approx(0.8)
+    assert sched.update_momentum(30) == pytest.approx(0.937)
+    mid = sched.update_momentum(15)
+    assert 0.8 < mid < 0.937
+
+    plain = LinearLRScheduler(lr=0.01, iters_per_epoch=10, total_epochs=10)
+    assert plain.update_momentum(1) is None

--- a/tests/unit/test_yolo9_letterbox.py
+++ b/tests/unit/test_yolo9_letterbox.py
@@ -453,3 +453,53 @@ def test_ddp_bootstrap_merges_aux_and_keeps_flat_dict(tmp_path):
     fake.letterbox_pad = "center"
     init_kw = _build_init_kw(fake)
     assert init_kw["letterbox_pad"] == "center"
+
+
+def test_resolve_aux_weight_keeps_zero():
+    from libreyolo.models.yolo9.model import resolve_aux_weight
+
+    assert resolve_aux_weight(None) == 0.25
+    assert resolve_aux_weight(0) == 0.0
+    assert resolve_aux_weight(0.0) == 0.0
+    assert resolve_aux_weight(0.25) == 0.25
+
+
+def test_aux_weight_zero_does_not_attach_pgi(tmp_path):
+    from libreyolo.models.yolo9.model import LibreYOLO9
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    raw = LibreYOLO9Model(config="t", nb_classes=2)
+    raw.enable_aux(0.25)
+    ckpt = wrap_libreyolo_checkpoint(
+        raw.state_dict(),
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=2,
+        names={0: "a", 1: "b"},
+        imgsz=640,
+    )
+    path = tmp_path / "with_aux.pt"
+    torch.save(ckpt, path)
+
+    loaded = LibreYOLO9(str(path), size="t", nb_classes=2, device="cpu")
+    assert loaded.model.aux is None
+    n = loaded._maybe_enable_aux_from_path(str(path), aux_weight=0)
+    assert n == 0
+    assert loaded.model.aux is None
+
+
+def test_cuda_graph_spec_disabled_when_pgi_attached():
+    from types import SimpleNamespace
+
+    from libreyolo.models.yolo9.nn import LibreYOLO9Model
+    from libreyolo.models.yolo9.trainer import YOLO9Trainer
+
+    model = LibreYOLO9Model(config="t", nb_classes=2)
+    host = SimpleNamespace(
+        wrapper_model=SimpleNamespace(task="detect"), model=model
+    )
+    assert YOLO9Trainer.cuda_graph_train_spec(host) is not None
+    model.enable_aux(0.25)
+    assert YOLO9Trainer.cuda_graph_train_spec(host) is None

--- a/tests/unit/test_yolo9_p2.py
+++ b/tests/unit/test_yolo9_p2.py
@@ -234,5 +234,5 @@ def test_yolo9_p2_trainer_metadata():
     assert YOLO9P2Trainer._config_class() is YOLO9P2Config
     assert YOLO9P2Trainer.artifact_model_families == ("yolo9_p2",)
     cfg = YOLO9P2Config(size="t")
-    assert cfg.max_labels == 100
+    assert cfg.max_labels == 300
     assert "elan_up3" in YOLO9P2Trainer._NECK_FREEZE_MODULES

--- a/weights/convert_yolo9_weights.py
+++ b/weights/convert_yolo9_weights.py
@@ -97,9 +97,10 @@ def convert_weights(
 
     print("\nConversion summary:")
     print(f"  Converted: {stats['converted']} keys")
-    print(f"  Skipped (auxiliary head): {stats['skipped']} keys")
+    print(f"  Skipped (unmapped aux leftovers): {stats['skipped']} keys")
     print(f"  Failed: {stats['failed']} keys")
     print("  DFL projection is model-derived; no fixed DFL weights added")
+    print("  letterbox_pad: center (MTL training geometry)")
 
     nc = infer_nb_classes(state_dict) or 80
     names = _extract_names(weights, nc)
@@ -107,7 +108,12 @@ def convert_weights(
 
     print(f"\nSaving converted weights to {output_path}")
     wrapped = wrap_libreyolo_checkpoint(
-        converted, model_family="yolo9", size=config, nc=nc, names=names,
+        converted,
+        model_family="yolo9",
+        size=config,
+        nc=nc,
+        names=names,
+        letterbox_pad="center",
     )
     save_checkpoint(wrapped, output_path)
 


### PR DESCRIPTION
What: Stamp YOLOv9 letterbox pad on checkpoints and restore training-only PGI, without flipping ≤1.5 weights.
Why: #795 — a global center-pad switch would fix official MTL converts by silently moving boxes on every user fine-tune.

- Unmarked YOLOv9 checkpoints keep top-left letterbox (bit-identical to 1.5).
- Official convert / autoconvert stamp `letterbox_pad: center` and keep `aux.*` PGI tensors.
- New stock-detect fine-tunes attach PGI (`aux_weight=0.25`); resume of a single-head 1.5 ckpt stays single-head.
- Recipe defaults: `max_labels=300`, SGD momentum warmup 0.8→0.937. Val NMS defaults are unchanged.
- YOLO-NAS preprocess is untouched.

Check: `tests/unit/test_yolo9_letterbox.py` (unmarked→topleft, center stamp survives resave, aux ignored at infer). Also `test_yolo9_layers`, `test_autoconvert.py::TestYolo9Inference`, OBB letterbox undo.
Not verified: COCO val2017 A/B of unmarked top-left vs center-stamped official weights (the geometry gap size).
Opened by an agent. Closes #795.

## Code provenance

Original LibreYOLO code for this PR (checkpoint stamp, letterbox helper, trainer/val wiring, tests). The optional PGI aux neck/head is an architecture port of MultimediaTechLab/YOLO `v9-*.yaml` `auxiliary` (https://github.com/MultimediaTechLab/YOLO, MIT, same upstream as the existing `libreyolo/models/yolo9` port). No GPL/AGPL/LGPL/non-commercial/unknown-license material.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR stamps YOLOv9 letterbox geometry in checkpoints, preserves converted PGI tensors, and restores a training-only auxiliary branch with updated training defaults.
- Routes checkpoint-specific padding through training, validation, inference, postprocessing, and checkpoint resaves.
- Converts and loads the upstream PGI neck and auxiliary detection head while keeping inference single-head.
- Adds PGI-aware loss, trainer, scheduler, DDP-spawn, and regression-test coverage.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because setup-first resume can still attach PGI after optimizer, DDP, and EMA construction when the resume checkpoint differs from `wrapper_model.model_path`.

The early setup probe fixes the normal same-path resume flow, but direct trainer callers can set up against a single-head wrapper path and later resume another PGI checkpoint; that later attachment leaves the auxiliary parameters outside all setup-time training state.

**Files Needing Attention:** libreyolo/models/yolo9/trainer.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/yolo9/trainer.py | Adds checkpoint geometry wiring and pre-setup PGI probing, but setup-first resume remains unsafe when the resume path differs from the wrapper's current model path. |
| libreyolo/models/yolo9/model.py | Adds checkpoint-specific letterbox metadata and training-only PGI attachment/loading while filtering auxiliary tensors during inference. |
| libreyolo/models/yolo9/convert.py | Converts upstream PGI layers into the live `aux.*` and `aux_head.*` namespaces. |
| libreyolo/training/trainer.py | Extends shared checkpoint and scheduling behavior; its setup ordering confirms that modules attached after setup miss optimizer, DDP, and EMA enrollment. |
| libreyolo/preprocess/letterbox.py | Centralizes normalized top-left and center letterbox geometry for the YOLOv9 data paths. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as Resume caller
  participant Y as YOLO9Trainer
  participant W as Wrapper model
  participant B as BaseTrainer
  C->>Y: setup()
  Y->>W: probe wrapper_model.model_path
  Y->>B: setup()
  B->>B: build optimizer, DDP, EMA
  C->>Y: resume(other_checkpoint)
  Y->>W: probe other_checkpoint
  W->>W: attach PGI auxiliary modules
  Note over W,B: Newly attached parameters are absent from setup-time optimizer, DDP, and EMA
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Disable CUDA-graph capture when PGI is o..."](https://github.com/libreyolo/libreyolo/commit/d1af82caad7e2ea4d8bff50f4adcd50081c5388f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53627100)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)

<!-- /greptile_comment -->