### PR TITLE
Host restricted Dome-DETR checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- **Hosted Dome-DETR checkpoints.** The six official AI-TOD-V2 and VisDrone
+  checkpoints now auto-download from LibreYOLO under the upstream card's
+  academic-research-only restriction. Every download warns that the weights
+  are not covered by LibreYOLO's MIT license. Each mirror uses `license: other`
+  and records the complete upstream ambiguity: the card also claims
+  Apache-2.0 but has neither license metadata nor a weight-repository LICENSE
+  file. The learned tensors are unchanged; conversion adds metadata only.
+
 - **Opt-in training helpers (#768).** `class_balanced=True` enables
   repeat-factor sampling for long-tailed detection datasets;
   `average_best=N` writes the uniform mean of the N best validation

--- a/NOTICE
+++ b/NOTICE
@@ -631,11 +631,17 @@ Dome-DETR (Apache License 2.0)
     stack, MS-deformable attention) is imported from libreyolo/models/dfine/
     rather than re-vendored, so the D-FINE entry above continues to cover it.
 
-    Model weights are NOT redistributed by LibreYOLO. The upstream model
-    card at https://huggingface.co/RicePasteM/Dome-DETR states no license in
-    its card metadata, and its prose simultaneously claims Apache-2.0 and
-    restricts use to "academic research purposes only". Users download from
-    upstream and convert locally.
+    The six official AI-TOD-V2 and VisDrone model checkpoints are distributed
+    separately on the LibreYOLO Hugging Face organization under an
+    ACADEMIC-RESEARCH-ONLY restriction. They are not covered by LibreYOLO's
+    MIT license. The upstream weight repository has no license metadata or
+    LICENSE file; its README both calls the project Apache-2.0 and says the
+    weights are "for academic research purposes only". LibreYOLO's maintainer
+    approved mirroring on the explicitly disclosed interpretation that the
+    Apache statement permits redistribution while the stricter academic-use
+    statement remains controlling. Each weight repository uses the Hugging
+    Face `license: other` tag and ships the complete context in its LICENSE
+    and NOTICE. See weights/LICENSE_NOTICE.txt.
 
 TinyFormer (Apache License 2.0)
     Path:    libreyolo/models/tinyformer/,

--- a/libreyolo/models/domedetr/model.py
+++ b/libreyolo/models/domedetr/model.py
@@ -56,8 +56,10 @@ class LibreDOMEDETR(BaseModel):
       attention masks. Convergence against upstream's published 160-epoch
       schedule has not been reproduced here, so treat the paper's AP numbers
       as unverified rather than as a promise this recipe reaches them.
-    - **Weights are not rehosted.** The upstream model card states no license,
-      so they are linked, not mirrored (the YOLO-NAS precedent).
+    - **Official weights are academic-research-only.** LibreYOLO mirrors the
+      six upstream checkpoints under the stricter use restriction stated on
+      the upstream model card. They are not covered by LibreYOLO's MIT license,
+      and every auto-download prints the restriction before fetching them.
     """
 
     FAMILY = "domedetr"
@@ -161,18 +163,7 @@ class LibreDOMEDETR(BaseModel):
 
     @classmethod
     def get_download_url(cls, filename: str) -> Optional[str]:
-        """Refuse to auto-download, with the reason.
-
-        Two separate things would otherwise go wrong here. Nothing is hosted
-        under ``LibreYOLO/`` for this family at all, because the upstream
-        weight license is unresolved. And there is no COCO checkpoint even
-        upstream, so a bare ``LibreDOMEDETRs.pt`` names a file that cannot
-        exist in any world: the canonical names all carry a dataset suffix.
-
-        Left to the base implementation this 404s three times against a
-        never-to-exist repo and ends in a generic "file not found", which
-        sends people looking for a network problem. Raise instead.
-        """
+        """Resolve hosted dataset variants and reject the nonexistent bare name."""
         name = Path(filename).name
         size = cls.detect_size_from_filename(name)
         if size is None:
@@ -184,28 +175,27 @@ class LibreDOMEDETR(BaseModel):
 
         variant = cls.detect_variant_from_filename(name)
         if variant is None:
-            hint = (
+            raise FileNotFoundError(
                 f"{name} has no dataset suffix. Dome-DETR has no COCO checkpoint, "
                 f"so there is no bare {cls.FILENAME_PREFIX}{size}.pt -- the canonical "
                 f"names are {cls.FILENAME_PREFIX}{size}-aitod.pt (AI-TOD-V2, 9 classes) "
                 f"and {cls.FILENAME_PREFIX}{size}-visdrone.pt (VisDrone, 12 classes). "
                 "Pick the one matching your data."
             )
-        else:
-            hint = f"{name} is a valid Dome-DETR name, but LibreYOLO does not host it."
+        return super().get_download_url(name)
 
-        raise FileNotFoundError(
-            f"{hint}\n\n"
-            "Dome-DETR weights are not rehosted under the LibreYOLO org: the "
-            "upstream model card states no license (its prose claims Apache-2.0 "
-            "while also restricting use to academic research), so there is no "
-            "redistribution grant to rely on. Download from upstream and convert:\n\n"
-            "  hf download RicePasteM/Dome-DETR --include 'best_ckpts_dome_2026/*' "
-            "--local-dir dome-ckpts\n"
-            "  python weights/convert_domedetr_weights.py \\\n"
-            f"      dome-ckpts/best_ckpts_dome_2026/aitod-{size}-best.pth \\\n"
-            f"      weights/{cls.FILENAME_PREFIX}{size}-aitod.pt --size {size} --variant aitod\n\n"
-            "See weights/LICENSE_NOTICE.txt."
+    @classmethod
+    def get_download_notice(cls, filename: str, url: str) -> Optional[str]:
+        del url
+        return (
+            f"{Path(filename).name} contains official Dome-DETR pretrained weights. "
+            "The upstream model card restricts these weights to ACADEMIC RESEARCH "
+            "PURPOSES ONLY. They are NOT covered by LibreYOLO's MIT license and "
+            "must not be treated as commercially cleared. The same card also calls "
+            "the project Apache-2.0 but provides no license metadata or weight-repo "
+            "LICENSE file; LibreYOLO mirrors the weights under the stricter academic-"
+            "use reading and documents that unresolved context in each mirror. You "
+            "are responsible for reviewing and complying with the upstream terms."
         )
 
     def _init_model(self) -> nn.Module:

--- a/skills/libreyolo-upload-hf-model/SKILL.md
+++ b/skills/libreyolo-upload-hf-model/SKILL.md
@@ -52,6 +52,7 @@ file = name + ".pt"
 | RFDETR | `LibreRFDETR` | `LibreRFDETRn.pt`, `LibreRFDETRn-seg.pt`, `LibreRFDETRx-pose.pt` |
 | DETR | `LibreDETR` | `LibreDETRr50.pt` (original DETR; Apache-2.0 code + weights; inference-only) |
 | LWDETR | `LibreLWDETR` | `LibreLWDETRt.pt` (LW-DETR, RF-DETR's ancestor; Apache-2.0 code + weights; inference-only) |
+| DOMEDETR | `LibreDOMEDETR` | `LibreDOMEDETRs-aitod.pt`, `LibreDOMEDETRs-visdrone.pt` (dataset-specific tiny-object weights; academic-research-only, see below) |
 | FasterRCNN | `LibreFasterRCNN` | `LibreFasterRCNNn.pt` (modernized torchvision Faster R-CNN; BSD-3-Clause implied for weights, with the pretrained-model caveat on every card; inference-only) |
 | RetinaNet | `LibreRetinaNet` | `LibreRetinaNetr50.pt` (torchvision RetinaNet; BSD-3-Clause implied for weights, with the pretrained-model caveat on every card; inference-only) |
 | SSD | `LibreSSD` | `LibreSSD300.pt` (torchvision SSD300 VGG16; BSD-3-Clause implied for the checkpoint, Oxford VGG feature-weight lineage CC BY 4.0; inference-only) |
@@ -199,6 +200,11 @@ LibreDETRr101.pt, LibreDETRr101dc5.pt,
 LibreLWDETRt.pt, LibreLWDETRs.pt, LibreLWDETRm.pt,
 LibreLWDETRl.pt, LibreLWDETRx.pt,
 
+LibreDOMEDETRs-aitod.pt, LibreDOMEDETRm-aitod.pt,
+LibreDOMEDETRl-aitod.pt,
+LibreDOMEDETRs-visdrone.pt, LibreDOMEDETRm-visdrone.pt,
+LibreDOMEDETRl-visdrone.pt,
+
 LibreFasterRCNNn.pt, LibreFasterRCNNs.pt,
 LibreFasterRCNNm.pt, LibreFasterRCNNl.pt,
 
@@ -344,6 +350,19 @@ Oxford VGG-16 feature-weight lineage under CC BY 4.0, link the Oxford source
 and CC license, and state the torchvision training plus LibreYOLO metadata
 changes. Do not describe CC BY 4.0 as the license for torchvision's SSD code.
 A name being *valid* does not make it *hostable*; run the gate.
+
+**LibreDOMEDETR s/m/l AI-TOD-V2 and VisDrone weights are ACADEMIC-RESEARCH-ONLY.**
+The upstream Hugging Face card has no license metadata or LICENSE file and
+simultaneously says the project is Apache-2.0 and the weights are "for academic
+research purposes only". The maintainer approved rehosting by treating the
+Apache statement as the redistribution basis while preserving the stricter
+academic-use sentence. Cards use `license: other` +
+`license_name: dome-detr-academic-research-only` + a revision-pinned upstream
+`license_link`, lead with an academic-only banner, and disclose that this is a
+LibreYOLO interpretation rather than upstream clarification. Every mirror's
+LICENSE and NOTICE reproduce the complete context. The loader warns before
+every auto-download. Never tag these repos `apache-2.0` or imply commercial
+clearance.
 
 The `-visdrone` suffix is a `WEIGHT_VARIANTS` dataset variant (grammar in
 `docs/nomenclature.md`): only families that declare `WEIGHT_VARIANTS` in

--- a/tests/unit/test_domedetr.py
+++ b/tests/unit/test_domedetr.py
@@ -336,16 +336,24 @@ def test_bare_filename_download_explains_itself():
     assert "no dataset suffix" in message
     assert "LibreDOMEDETRs-aitod.pt" in message
     assert "LibreDOMEDETRs-visdrone.pt" in message
-    assert "convert_domedetr_weights.py" in message
 
 
-def test_suffixed_filename_download_points_upstream():
-    """Even a canonical name is not hosted: say why and how to get it."""
-    with pytest.raises(FileNotFoundError) as excinfo:
-        LibreDOMEDETR.get_download_url("LibreDOMEDETRm-visdrone.pt")
-    message = str(excinfo.value)
-    assert "not rehosted" in message
-    assert "RicePasteM/Dome-DETR" in message
+def test_suffixed_filename_download_uses_libreyolo_mirror():
+    filename = "LibreDOMEDETRm-visdrone.pt"
+    assert LibreDOMEDETR.get_download_url(filename) == (
+        "https://huggingface.co/LibreYOLO/LibreDOMEDETRm-visdrone/"
+        f"resolve/main/{filename}"
+    )
+
+
+def test_download_notice_discloses_restricted_weight_terms():
+    notice = LibreDOMEDETR.get_download_notice(
+        "LibreDOMEDETRs-aitod.pt", "https://example.invalid/checkpoint.pt"
+    )
+    assert "ACADEMIC RESEARCH PURPOSES ONLY" in notice
+    assert "NOT covered by LibreYOLO's MIT license" in notice
+    assert "Apache-2.0" in notice
+    assert "responsible" in notice
 
 
 @pytest.mark.parametrize(

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -35,18 +35,32 @@ project the weights were derived from. Per-family summary:
              recoverable, so LibreYOLO1t ships as code only (bring your own
              tiny-yolov1.weights to convert).
 
-    Dome-DETR (LibreDOMEDETR{s,m,l}-{aitod,visdrone})  NOT REDISTRIBUTED
+    Dome-DETR (LibreDOMEDETR{s,m,l}-{aitod,visdrone})
+                                                        ACADEMIC-RESEARCH-ONLY
              upstream: https://huggingface.co/RicePasteM/Dome-DETR
-             Not mirrored to the LibreYOLO organization. The upstream model
-             card carries no license field in its metadata, and its prose
-             simultaneously states the project is Apache-2.0 and that the
-             material is "for academic research purposes only". Those do not
-             agree, and the stricter reading is not a redistribution grant, so
-             the weight license is implied from the source repository rather
-             than stated. Until upstream sets an explicit license, download the
-             checkpoints from the link above and convert locally with
-             weights/convert_domedetr_weights.py. This follows the YOLO-NAS
-             precedent of linking rather than rehosting.
+             revision: 530230620d1f3261a267d462989cddf204cc6e10
+             Mirrored to the LibreYOLO organization under the upstream model
+             card's stricter statement that the weight files are "for academic
+             research purposes only". These checkpoints are NOT covered by
+             LibreYOLO's MIT license and must not be presented as commercially
+             cleared.
+
+             Full context: the upstream model repo carries no license field in
+             its Hugging Face metadata and no LICENSE file. Its README also
+             says "This project is licensed under the Apache 2.0 license", but
+             that sentence links to a missing LICENSE file. LibreYOLO's
+             maintainer approved rehosting by treating the Apache statement as
+             the redistribution basis and preserving the academic-only sentence
+             as the controlling use restriction. This is a disclosed LibreYOLO
+             interpretation, not an upstream clarification or a claim that the
+             two statements are legally consistent. Every mirror uses
+             `license: other`, leads with the restriction, and ships a LICENSE
+             and NOTICE reproducing this context. Users remain responsible for
+             reviewing the upstream terms.
+
+             Conversion only adds LibreYOLO checkpoint metadata; state-dict
+             keys and learned tensors are unchanged. Source SHA-256 values are
+             recorded in the converted checkpoints and per-repository notices.
              There is no COCO checkpoint for this family: only AI-TOD-V2
              (9 classes) and VisDrone (12), hence the dataset suffix on every
              canonical filename and the absence of a bare LibreDOMEDETRs.pt.

--- a/weights/convert_domedetr_weights.py
+++ b/weights/convert_domedetr_weights.py
@@ -34,6 +34,7 @@ Two pieces of metadata are load-bearing rather than cosmetic:
 from __future__ import annotations
 
 import argparse
+import hashlib
 from pathlib import Path
 
 from _conversion_utils import (
@@ -78,6 +79,21 @@ VISDRONE_NAMES = {
 
 VARIANT_NAMES = {"aitod": AITOD_NAMES, "visdrone": VISDRONE_NAMES}
 
+UPSTREAM_MODEL_REPO = "RicePasteM/Dome-DETR"
+UPSTREAM_MODEL_REVISION = "530230620d1f3261a267d462989cddf204cc6e10"
+WEIGHT_TERMS = (
+    "Academic research purposes only (upstream model card); the same card also "
+    "claims Apache-2.0. See weights/LICENSE_NOTICE.txt."
+)
+
+
+def _sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
 
 def convert(input_path: str, output_path: str, size: str, variant: str) -> None:
     raw = load_checkpoint(input_path)
@@ -111,6 +127,12 @@ def convert(input_path: str, output_path: str, size: str, variant: str) -> None:
         supported_tasks=("detect",),
         default_task="detect",
         weight_variant=variant,
+        source=(
+            f"{UPSTREAM_MODEL_REPO}@{UPSTREAM_MODEL_REVISION}/"
+            f"best_ckpts_dome_2026/{Path(input_path).name}"
+        ),
+        source_sha256=_sha256(input_path),
+        license=WEIGHT_TERMS,
     )
 
     out = Path(output_path)

--- a/weights/upload_domedetr_hf.py
+++ b/weights/upload_domedetr_hf.py
@@ -1,0 +1,463 @@
+"""Build or publish Dome-DETR's five-file Hugging Face weight repos.
+
+The upstream weight card is internally inconsistent: it has no license
+metadata or LICENSE file, calls the project Apache-2.0, and separately says
+the weights are for academic research purposes only. The LibreYOLO maintainer
+approved mirroring on the disclosed interpretation documented here: the
+Apache statement is the redistribution basis and the academic-only sentence
+is preserved as the controlling use restriction.
+
+A real upload requires ``--confirm-academic-license``. ``--dry-run`` only
+builds and validates a local five-file payload.
+
+Example::
+
+    python weights/upload_domedetr_hf.py --size s --variant aitod \
+        --pt LibreDOMEDETRs-aitod.pt --out ./LibreDOMEDETRs-aitod --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+_UPSTREAM_MODEL_REPO = "RicePasteM/Dome-DETR"
+_UPSTREAM_MODEL_REVISION = "530230620d1f3261a267d462989cddf204cc6e10"
+_UPSTREAM_CODE_COMMIT = "2dde3bc1946a3e9fad9abd0612b59fc39bd6b861"
+_COLLECTION = "LibreYOLO/libreyolo-models-698875bf2b5f695708415169"
+_LICENSE_NAME = "dome-detr-academic-research-only"
+_LICENSE_LINK = (
+    f"https://huggingface.co/{_UPSTREAM_MODEL_REPO}/blob/"
+    f"{_UPSTREAM_MODEL_REVISION}/README.md"
+)
+_WEIGHT_TERMS = (
+    "Academic research purposes only (upstream model card); the same card also "
+    "claims Apache-2.0. See weights/LICENSE_NOTICE.txt."
+)
+
+_SPECS = {
+    ("s", "aitod"): {
+        "upstream_file": "aitod-s-best.pth",
+        "source_sha256": "1b10ac2c78a83363b9577ddd74d1001ac8414a479476fea22138fc769a016ba8",
+        "dataset_name": "AI-TOD-V2",
+        "nc": 9,
+    },
+    ("m", "aitod"): {
+        "upstream_file": "aitod-m-best.pth",
+        "source_sha256": "d0242732410ac329a441e2a39b484bbfbb5f7196170cc0379a761ac0cf835d6b",
+        "dataset_name": "AI-TOD-V2",
+        "nc": 9,
+    },
+    ("l", "aitod"): {
+        "upstream_file": "aitod-l-best.pth",
+        "source_sha256": "08525b4bd445e1f193bbc2bb252ddae0f144f542912a95a38111c9a4b9a53cbe",
+        "dataset_name": "AI-TOD-V2",
+        "nc": 9,
+    },
+    ("s", "visdrone"): {
+        "upstream_file": "dome-s-visdrone_converted.pth",
+        "source_sha256": "42874302fd97e17c2a23a46a8ec35d2ea4d2ffe479f0d632c1327fafbf910eb7",
+        "dataset_name": "VisDrone",
+        "nc": 12,
+    },
+    ("m", "visdrone"): {
+        "upstream_file": "dome-m-visdrone_converted.pth",
+        "source_sha256": "3a0d1db3c68fac5239e1b43b4c6f765b1330e6961070113f4ea39dbdbf8846a6",
+        "dataset_name": "VisDrone",
+        "nc": 12,
+    },
+    ("l", "visdrone"): {
+        "upstream_file": "dome-l-visdrone_converted.pth",
+        "source_sha256": "e230db14242f95097efa8f19e9420e17f9fe7a61c4e6d4f7f1881d48f6789039",
+        "dataset_name": "VisDrone",
+        "nc": 12,
+    },
+}
+
+_GITATTRIBUTES = """*.7z filter=lfs diff=lfs merge=lfs -text
+*.arrow filter=lfs diff=lfs merge=lfs -text
+*.bin filter=lfs diff=lfs merge=lfs -text
+*.bz2 filter=lfs diff=lfs merge=lfs -text
+*.ckpt filter=lfs diff=lfs merge=lfs -text
+*.ftz filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.h5 filter=lfs diff=lfs merge=lfs -text
+*.joblib filter=lfs diff=lfs merge=lfs -text
+*.lfs.* filter=lfs diff=lfs merge=lfs -text
+*.mlmodel filter=lfs diff=lfs merge=lfs -text
+*.model filter=lfs diff=lfs merge=lfs -text
+*.msgpack filter=lfs diff=lfs merge=lfs -text
+*.npy filter=lfs diff=lfs merge=lfs -text
+*.npz filter=lfs diff=lfs merge=lfs -text
+*.onnx filter=lfs diff=lfs merge=lfs -text
+*.ot filter=lfs diff=lfs merge=lfs -text
+*.parquet filter=lfs diff=lfs merge=lfs -text
+*.pb filter=lfs diff=lfs merge=lfs -text
+*.pickle filter=lfs diff=lfs merge=lfs -text
+*.pkl filter=lfs diff=lfs merge=lfs -text
+*.pt filter=lfs diff=lfs merge=lfs -text
+*.pth filter=lfs diff=lfs merge=lfs -text
+*.rar filter=lfs diff=lfs merge=lfs -text
+*.safetensors filter=lfs diff=lfs merge=lfs -text
+saved_model/**/* filter=lfs diff=lfs merge=lfs -text
+*.tar.* filter=lfs diff=lfs merge=lfs -text
+*.tar filter=lfs diff=lfs merge=lfs -text
+*.tflite filter=lfs diff=lfs merge=lfs -text
+*.tgz filter=lfs diff=lfs merge=lfs -text
+*.wasm filter=lfs diff=lfs merge=lfs -text
+*.xz filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.zst filter=lfs diff=lfs merge=lfs -text
+*tfevents* filter=lfs diff=lfs merge=lfs -text
+"""
+
+
+def _canonical_name(size: str, variant: str) -> str:
+    return f"LibreDOMEDETR{size}-{variant}"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_path(spec: dict) -> str:
+    return f"best_ckpts_dome_2026/{spec['upstream_file']}"
+
+
+def _license_text() -> str:
+    apache = (_REPO_ROOT / "licenses" / "Apache-2.0.txt").read_text(
+        encoding="utf-8"
+    ).rstrip()
+    return f"""Dome-DETR pretrained checkpoint terms and provenance
+====================================================
+
+Upstream weight repository:
+https://huggingface.co/{_UPSTREAM_MODEL_REPO}
+Revision: {_UPSTREAM_MODEL_REVISION}
+
+The upstream weight repository has no standalone LICENSE file and its Hugging
+Face card metadata has no `license` field. Its README contains both of the
+following statements (reproduced verbatim):
+
+  - The weight files in this repository are for academic research purposes only
+  - This project is licensed under the Apache 2.0 license.
+
+At the pinned revision, the second statement links to a `LICENSE` file that is
+not present in the weight repository. The Dome-DETR source-code repository does
+contain the standard Apache License 2.0 text reproduced below.
+
+LibreYOLO's maintainer approved mirroring these checkpoints by treating the
+upstream Apache statement as the redistribution basis while preserving
+"academic research purposes only" as the controlling use restriction. This is
+a disclosed LibreYOLO interpretation, not an upstream clarification and not a
+claim that the two upstream statements are legally consistent.
+
+THESE PRETRAINED WEIGHTS ARE FOR ACADEMIC RESEARCH PURPOSES ONLY. THEY ARE NOT
+COVERED BY LIBREYOLO'S MIT LICENSE AND MUST NOT BE TREATED AS COMMERCIALLY
+CLEARED. DOWNSTREAM USERS ARE RESPONSIBLE FOR REVIEWING AND COMPLYING WITH THE
+UPSTREAM TERMS.
+
+The complete Apache License 2.0 text from the pinned Dome-DETR source-code
+repository follows for the full context of the upstream Apache statement.
+
+{apache}
+"""
+
+
+def _readme(size: str, variant: str, pt_path: Path) -> str:
+    spec = _SPECS[(size, variant)]
+    name = _canonical_name(size, variant)
+    source_path = _source_path(spec)
+    source_url = (
+        f"https://huggingface.co/{_UPSTREAM_MODEL_REPO}/blob/"
+        f"{_UPSTREAM_MODEL_REVISION}/{source_path}"
+    )
+    return f"""---
+license: other
+license_name: {_LICENSE_NAME}
+license_link: {_LICENSE_LINK}
+library_name: libreyolo
+pipeline_tag: object-detection
+tags:
+  - object-detection
+  - dome-detr
+  - tiny-object-detection
+  - {variant}
+  - academic-research-only
+  - non-commercial
+---
+
+# {name}
+
+Dome-DETR {size.upper()} trained on {spec['dataset_name']} ({spec['nc']} output
+classes), converted for LibreYOLO at 800x800.
+
+> ## ACADEMIC-RESEARCH-ONLY WEIGHTS
+>
+> The upstream model card says these weight files are **for academic research
+> purposes only**. They are **not covered by LibreYOLO's MIT license** and must
+> not be treated as commercially cleared.
+>
+> The same upstream card also says the project is Apache-2.0, but it has no
+> license metadata and links to a LICENSE file that does not exist in the
+> weight repository. LibreYOLO's maintainer approved this mirror by treating
+> the Apache statement as the redistribution basis and preserving the stricter
+> academic-only sentence as the use restriction. This is LibreYOLO's disclosed
+> interpretation, not clarification from the Dome-DETR authors. Review the
+> pinned upstream card and the [`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE)
+> in this repository before use.
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("{name}.pt")
+results = model.predict("image.jpg")
+```
+
+## Source
+
+Official upstream weight file:
+[`{source_path}`]({source_url})
+
+- Upstream model revision: `{_UPSTREAM_MODEL_REVISION}`
+- Source SHA-256: `{spec['source_sha256']}`
+- Converted SHA-256: `{_sha256(pt_path)}`
+
+The Dome-DETR architecture source is Apache-2.0 at commit
+[`{_UPSTREAM_CODE_COMMIT}`](https://github.com/RicePasteM/Dome-DETR/commit/{_UPSTREAM_CODE_COMMIT}).
+Copyright (c) 2025 The Dome-DETR Authors, as stated in its source headers.
+That source-code license and LibreYOLO's MIT code license do not remove the
+academic-only restriction stated for these pretrained weights.
+
+## Modifications
+
+LibreYOLO adds checkpoint-schema metadata, including the dataset variant,
+class names, pinned source revision, and source SHA-256. State-dict keys and
+learned tensors are unchanged. The converted checkpoint loads strictly into
+LibreYOLO's native implementation. See
+[`weights/convert_domedetr_weights.py`](https://github.com/LibreYOLO/libreyolo/blob/dev/weights/convert_domedetr_weights.py).
+
+## License and terms
+
+**Academic research purposes only**, following the stricter statement on the
+upstream weight card. The upstream Apache-2.0 statement and its missing weight
+repository LICENSE file are documented without omission. See
+[`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE).
+"""
+
+
+def _notice(size: str, variant: str, pt_path: Path) -> str:
+    spec = _SPECS[(size, variant)]
+    name = _canonical_name(size, variant)
+    return f"""{name} weights
+{'-' * (len(name) + 8)}
+
+This product contains the official Dome-DETR {size.upper()} checkpoint trained
+on {spec['dataset_name']} and published by the Dome-DETR authors at:
+https://huggingface.co/{_UPSTREAM_MODEL_REPO}
+
+Pinned model revision: {_UPSTREAM_MODEL_REVISION}
+Upstream file: {_source_path(spec)}
+Source SHA-256: {spec['source_sha256']}
+Converted SHA-256: {_sha256(pt_path)}
+
+ACADEMIC-RESEARCH-ONLY WEIGHTS
+
+The upstream weight repository has no license metadata and no LICENSE file.
+Its README says both that the weight files are "for academic research purposes
+only" and that the project is licensed under Apache 2.0; the latter links to a
+missing file. LibreYOLO's maintainer approved mirroring by treating the Apache
+statement as the redistribution basis while preserving the academic-only
+sentence as the controlling use restriction. This is a LibreYOLO
+interpretation, not an upstream clarification or a claim that those statements
+are legally consistent. The complete context and Apache text are included in
+this repository's LICENSE file.
+
+These pretrained weights are NOT covered by LibreYOLO's MIT license and must
+not be treated as commercially cleared. Users are responsible for reviewing
+and complying with the upstream terms.
+
+Architecture source: https://github.com/RicePasteM/Dome-DETR
+Pinned code commit: {_UPSTREAM_CODE_COMMIT}
+Source headers: Copyright (c) 2025 The Dome-DETR Authors.
+Source-code license: Apache License 2.0.
+
+Conversion adds LibreYOLO checkpoint metadata only. State-dict keys and learned
+tensors are unchanged.
+"""
+
+
+def _validate_checkpoint(size: str, variant: str, path: Path) -> None:
+    from libreyolo import LibreYOLO
+    from libreyolo.models.domedetr.model import LibreDOMEDETR
+    from libreyolo.utils.serialization import (
+        load_untrusted_torch_file,
+        validate_checkpoint_metadata,
+    )
+
+    spec = _SPECS[(size, variant)]
+    name = _canonical_name(size, variant)
+    filename = f"{name}.pt"
+    if path.name != filename:
+        raise ValueError(f"Expected canonical filename {filename}, got {path.name}")
+
+    whitelist = (
+        _REPO_ROOT / "skills" / "libreyolo-upload-hf-model" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    if filename not in whitelist:
+        raise ValueError(f"Canonical filename is absent from upload whitelist: {filename}")
+
+    expected_url = (
+        f"https://huggingface.co/LibreYOLO/{name}/resolve/main/{filename}"
+    )
+    actual_url = LibreDOMEDETR.get_download_url(filename)
+    if actual_url != expected_url:
+        raise ValueError(
+            f"Loader URL mismatch for {filename}: {actual_url!r} != {expected_url!r}"
+        )
+
+    checkpoint = load_untrusted_torch_file(path, context="converted checkpoint")
+    errors = validate_checkpoint_metadata(checkpoint, strict=False)
+    if errors:
+        raise ValueError(f"Invalid checkpoint metadata: {'; '.join(errors)}")
+    expected = {
+        "model_family": "domedetr",
+        "size": size,
+        "task": "detect",
+        "nc": spec["nc"],
+        "imgsz": 800,
+        "weight_variant": variant,
+        "source_sha256": spec["source_sha256"],
+        "license": _WEIGHT_TERMS,
+    }
+    mismatches = {
+        key: (checkpoint.get(key), value)
+        for key, value in expected.items()
+        if checkpoint.get(key) != value
+    }
+    expected_source = (
+        f"{_UPSTREAM_MODEL_REPO}@{_UPSTREAM_MODEL_REVISION}/{_source_path(spec)}"
+    )
+    if checkpoint.get("source") != expected_source:
+        mismatches["source"] = (checkpoint.get("source"), expected_source)
+    if mismatches:
+        raise ValueError(f"Checkpoint metadata mismatch: {mismatches}")
+
+    model = LibreYOLO(str(path), device="cpu")
+    loaded = (
+        model.family,
+        model.size,
+        model.nb_classes,
+        model.task,
+        model.weight_variant,
+    )
+    expected_loaded = ("domedetr", size, spec["nc"], "detect", variant)
+    if loaded != expected_loaded:
+        raise ValueError(
+            f"Factory load mismatch: expected {expected_loaded}, got {loaded}"
+        )
+
+
+def build_repo_dir(size: str, variant: str, pt_path: Path, out_dir: Path) -> Path:
+    """Build and validate exactly five files for one weight repository."""
+    if not pt_path.is_file():
+        raise FileNotFoundError(f"Weight file not found: {pt_path}")
+    _validate_checkpoint(size, variant, pt_path)
+    out_dir.mkdir(parents=True, exist_ok=False)
+    (out_dir / ".gitattributes").write_text(
+        _GITATTRIBUTES, encoding="utf-8", newline="\n"
+    )
+    (out_dir / "README.md").write_text(
+        _readme(size, variant, pt_path), encoding="utf-8", newline="\n"
+    )
+    (out_dir / "LICENSE").write_text(
+        _license_text(), encoding="utf-8", newline="\n"
+    )
+    (out_dir / "NOTICE").write_text(
+        _notice(size, variant, pt_path), encoding="utf-8", newline="\n"
+    )
+    name = _canonical_name(size, variant)
+    shutil.copy2(pt_path, out_dir / f"{name}.pt")
+
+    expected = {".gitattributes", "README.md", "LICENSE", "NOTICE", f"{name}.pt"}
+    actual = {path.name for path in out_dir.iterdir()}
+    if actual != expected:
+        raise RuntimeError(
+            f"Five-file contract mismatch: expected {sorted(expected)}, got {sorted(actual)}"
+        )
+    return out_dir
+
+
+def _upload(size: str, variant: str, repo_dir: Path) -> str:
+    from huggingface_hub import HfApi
+
+    name = _canonical_name(size, variant)
+    repo_id = f"LibreYOLO/{name}"
+    api = HfApi()
+    if api.repo_exists(repo_id=repo_id, repo_type="model"):
+        raise FileExistsError(
+            f"Refusing to overwrite existing Hugging Face repository: {repo_id}"
+        )
+    api.create_repo(repo_id=repo_id, repo_type="model", exist_ok=False)
+    api.upload_folder(
+        folder_path=str(repo_dir),
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message=(
+            f"Initial upload: {name} (Dome-DETR, academic-research-only)"
+        ),
+    )
+    api.add_collection_item(
+        collection_slug=_COLLECTION,
+        item_id=repo_id,
+        item_type="model",
+        exists_ok=True,
+    )
+    return f"https://huggingface.co/{repo_id}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--size", required=True, choices=["s", "m", "l"])
+    parser.add_argument("--variant", required=True, choices=["aitod", "visdrone"])
+    parser.add_argument("--pt", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build and validate the five files without changing Hugging Face.",
+    )
+    parser.add_argument(
+        "--confirm-academic-license",
+        action="store_true",
+        help="Confirm the maintainer-approved restricted-use mirroring decision.",
+    )
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.confirm_academic_license:
+        parser.error("a real upload requires --confirm-academic-license")
+
+    if (args.size, args.variant) not in _SPECS:
+        parser.error(f"unsupported Dome-DETR variant: {args.size}/{args.variant}")
+    repo_dir = build_repo_dir(args.size, args.variant, args.pt, args.out)
+    print(f"Built five-file repository: {repo_dir}")
+    if args.dry_run:
+        print("Dry run complete; no external state changed.")
+        return 0
+
+    print(f"Uploaded: {_upload(args.size, args.variant, repo_dir)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- Host the six official Dome-DETR AI-TOD-V2 and VisDrone checkpoints.
- Add canonical autodownload routing with an academic-research-only warning.
- Pin the upstream model revision and source SHA-256 in checkpoint metadata and notices.
- Ship `license: other` cards with the complete Apache/academic-only context.
- Add guarded five-file Hub upload tooling and filename whitelist entries.
- Verified: 51 Dome-DETR unit tests; six-variant inference parity at max abs diff 0; 40 loss terms exact; both live autodownload variants loaded.

## Code provenance

- Implementation and upload tooling are original LibreYOLO code written for this PR.
- Hosted tensors are unchanged from `RicePasteM/Dome-DETR` model revision `530230620d1f3261a267d462989cddf204cc6e10`.
- Architecture reference: `RicePasteM/Dome-DETR` commit `2dde3bc1946a3e9fad9abd0612b59fc39bd6b861`, Apache-2.0. Weight restrictions and ambiguity are reproduced in the notices and model cards.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds canonical LibreYOLO hosting and auto-download routing for six dataset-specific Dome-DETR checkpoints, together with provenance metadata, restricted-use notices, tests, and guarded Hugging Face publication tooling.

- Routes AI-TOD-V2 and VisDrone checkpoint names to LibreYOLO mirrors and emits an academic-use warning before fresh downloads.
- Pins upstream revisions and source digests in converted checkpoint metadata and generated model cards.
- Adds a five-file Hub repository builder and uploader for all six size/dataset variants.
- Updates project notices, upload documentation, tests, and the changelog for the new distribution model.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the licensing-policy conflict and unrecoverable partial-upload workflow are resolved.

The changed download path begins distributing weights without an explicit compatible upstream license, while the new uploader can strand a partial remote repository that its own retry guard refuses to repair; provenance validation also has a non-blocking integrity gap.

**Files Needing Attention:** libreyolo/models/domedetr/model.py and weights/upload_domedetr_hf.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/domedetr/model.py | Enables hosted checkpoint routing and warning text, but the new redistribution path conflicts with the repository's explicit-license policy. |
| weights/upload_domedetr_hf.py | Adds guarded five-file repository generation and publication, but interrupted uploads cannot be resumed and provenance validation trusts self-reported metadata. |
| weights/convert_domedetr_weights.py | Adds pinned source, checksum, and license metadata while preserving the existing conversion behavior. |
| tests/unit/test_domedetr.py | Updates focused tests for mirror URL resolution, bare-name rejection, and restricted-use warning content. |
| weights/LICENSE_NOTICE.txt | Documents the mirrored checkpoints, provenance, conflicting upstream statements, and academic-only interpretation. |
| skills/libreyolo-upload-hf-model/SKILL.md | Adds Dome-DETR filenames and explicit handling guidance to the upload whitelist and licensing documentation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Name[Canonical Dome-DETR filename] --> Resolve[get_download_url]
  Resolve --> Mirror[LibreYOLO Hugging Face mirror]
  Mirror --> Notice[get_download_notice]
  Notice --> Fetch[Download checkpoint]
  Source[Pinned upstream checkpoint] --> Convert[convert_domedetr_weights.py]
  Convert --> Validate[Validate metadata and model load]
  Validate --> Build[Build five-file repository]
  Build --> Create[Create Hub repository]
  Create --> Upload[Upload files]
  Upload --> Collection[Add to model collection]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20libreyolo%2Flibreyolo%20PR%20%23797%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=797&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fdomedetr%2Fmodel.py%3A184%0A**Explicit%20weight%20license%20requirement%20violated**%0A%0ACanonical%20Dome-DETR%20names%20now%20resolve%20to%20LibreYOLO-hosted%20checkpoints%20even%20though%20the%20upstream%20weight%20repository%20has%20neither%20license%20metadata%20nor%20a%20LICENSE%20file%2C%20violating%20the%20repository%20requirement%20that%20redistributed%20third-party%20material%20have%20an%20explicit%20compatible%20license.%0A%0A%23%23%23%20Issue%202%0Aweights%2Fupload_domedetr_hf.py%3A407-413%0A**Interrupted%20uploads%20cannot%20resume**%0A%0AWhen%20%60upload_folder%60%20or%20%60add_collection_item%60%20fails%20after%20%60create_repo%60%20succeeds%2C%20the%20remote%20repository%20remains%20empty%2C%20partial%2C%20or%20unenrolled%2C%20while%20every%20retry%20raises%20%60FileExistsError%60%3B%20publication%20then%20requires%20manual%20remote%20repair%20or%20deletion.%0A%0A%23%23%23%20Issue%203%0Aweights%2Fupload_domedetr_hf.py%3A329-354%0A**Provenance%20trusts%20embedded%20metadata**%0A%0AThe%20upload%20gate%20compares%20%60source_sha256%60%20only%20with%20metadata%20embedded%20in%20the%20checkpoint%20and%20verifies%20loadability%20rather%20than%20tensor%20identity%2C%20so%20a%20checkpoint%20built%20from%20the%20wrong%20source%20can%20still%20generate%20cards%20claiming%20provenance%20from%20the%20pinned%20upstream%20artifact.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=797&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22work%2Fdomedetr-weight-hosting%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22work%2Fdomedetr-weight-hosting%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fdomedetr%2Fmodel.py%3A184%0A**Explicit%20weight%20license%20requirement%20violated**%0A%0ACanonical%20Dome-DETR%20names%20now%20resolve%20to%20LibreYOLO-hosted%20checkpoints%20even%20though%20the%20upstream%20weight%20repository%20has%20neither%20license%20metadata%20nor%20a%20LICENSE%20file%2C%20violating%20the%20repository%20requirement%20that%20redistributed%20third-party%20material%20have%20an%20explicit%20compatible%20license.%0A%0A%23%23%23%20Issue%202%0Aweights%2Fupload_domedetr_hf.py%3A407-413%0A**Interrupted%20uploads%20cannot%20resume**%0A%0AWhen%20%60upload_folder%60%20or%20%60add_collection_item%60%20fails%20after%20%60create_repo%60%20succeeds%2C%20the%20remote%20repository%20remains%20empty%2C%20partial%2C%20or%20unenrolled%2C%20while%20every%20retry%20raises%20%60FileExistsError%60%3B%20publication%20then%20requires%20manual%20remote%20repair%20or%20deletion.%0A%0A%23%23%23%20Issue%203%0Aweights%2Fupload_domedetr_hf.py%3A329-354%0A**Provenance%20trusts%20embedded%20metadata**%0A%0AThe%20upload%20gate%20compares%20%60source_sha256%60%20only%20with%20metadata%20embedded%20in%20the%20checkpoint%20and%20verifies%20loadability%20rather%20than%20tensor%20identity%2C%20so%20a%20checkpoint%20built%20from%20the%20wrong%20source%20can%20still%20generate%20cards%20claiming%20provenance%20from%20the%20pinned%20upstream%20artifact.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=797&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Host Dome-DETR weights"](https://github.com/libreyolo/libreyolo/commit/7762cbc79e1a2bbcf74457cc897ce54306270927) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53628367)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/libreyolo/libreyolo/blob/dev/CLAUDE.md))
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->